### PR TITLE
Implement BVH support and render using light tile grid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ add_subdirectory(src/CanvasFbx)
 add_subdirectory(src/CanvasConsole)
 add_subdirectory(src/CanvasModelViewer)
 add_subdirectory(src/CanvasTerrainViewer)
+add_subdirectory(src/CanvasLightGarden)
 add_subdirectory(src/CanvasUnitTest)
 # Allocators tests - conditionally include based on option
 if(ALLOCATORS_BUILD_TESTS)

--- a/README.md
+++ b/README.md
@@ -245,11 +245,17 @@ The `CanvasUnitTest` target uses GoogleTest and covers:
 - **CanvasTextTest**: font loading and text layout
 - **D3D12ResourceUtilsTest**: graphics-layer resource helpers
 - **GpuTaskGraphTest**: barrier resolution and task-graph correctness
+- **BVHTest**: scene BVH build and frustum/sphere/cone/AABB query equivalence vs. brute force
+- **LightBVHTest**: per-light influence culling and tracked/untracked classification
+
+Tests are discovered automatically via `gtest_discover_tests`, so each `TEST(...)` case shows up as an individual CTest entry:
 
 ```bash
 cd build
 ctest --build-config Release --output-on-failure
 ```
+
+To run a single test or filter by name, invoke the executable directly (it lives under the shared runtime directory, e.g. `build/runtime/Release/CanvasUnitTest.exe`) and use the standard GoogleTest flags, for example `--gtest_filter=BVHTest.*` or `--gtest_list_tests`.
 
 ## Repository Structure
 

--- a/src/CanvasCore/BVH.cpp
+++ b/src/CanvasCore/BVH.cpp
@@ -256,7 +256,7 @@ void BVH::QuerySphere(const BVHPrimitive* primitives,
                       float radius,
                       std::vector<uint32_t>& outVisiblePrimitiveIndices) const
 {
-    if (radius <= 0.0f)
+    if (radius < 0.0f)
         return;
     const Math::Sphere sphere(center, radius);
     Traverse(primitives,
@@ -268,7 +268,7 @@ void BVH::QueryCone(const BVHPrimitive* primitives,
                     const Math::Cone& cone,
                     std::vector<uint32_t>& outVisiblePrimitiveIndices) const
 {
-    if (cone.Range <= 0.0f)
+    if (cone.Range < 0.0f)
         return;
     Traverse(primitives,
              [&](const Math::AABB& b) { return cone.IntersectsAABB(b); },

--- a/src/CanvasCore/BVH.cpp
+++ b/src/CanvasCore/BVH.cpp
@@ -39,9 +39,6 @@ constexpr uint32_t kMaxPrimitivesPerLeaf = 4;    // small-leaf cutoff; below thi
                                                  // rarely beats keeping a leaf node
 constexpr float    kTraversalCost        = 1.0f; // SAH constants in arbitrary units; only
 constexpr float    kIntersectCost        = 1.0f; // ratios matter for split-vs-leaf decisions
-constexpr uint32_t kMaxTraversalStack    = 64;   // BVH depth ~1.44*log2(N); 64 covers any
-                                                 // plausible scene by a wide margin
-
 } // anonymous namespace
 
 void BVH::Build(const BVHPrimitive* primitives, size_t count)
@@ -245,50 +242,48 @@ void BVH::QueryFrustum(const BVHPrimitive* primitives,
                        const Math::Frustum& frustum,
                        std::vector<uint32_t>& outVisiblePrimitiveIndices) const
 {
-    if (m_Nodes.empty())
+    // Per-primitive retest is non-optional: a leaf node's union bounds
+    // can pass the frustum test even when none of its individual
+    // primitives do.  The shared Traverse helper applies `test` at both
+    // node and primitive tiers, so passing the same lambda is correct.
+    Traverse(primitives,
+             [&](const Math::AABB& b) { return frustum.IntersectsAABB(b); },
+             outVisiblePrimitiveIndices);
+}
+
+void BVH::QuerySphere(const BVHPrimitive* primitives,
+                      const Math::FloatVector4& center,
+                      float radius,
+                      std::vector<uint32_t>& outVisiblePrimitiveIndices) const
+{
+    if (radius <= 0.0f)
         return;
+    const Math::Sphere sphere(center, radius);
+    Traverse(primitives,
+             [&](const Math::AABB& b) { return sphere.IntersectsAABB(b); },
+             outVisiblePrimitiveIndices);
+}
 
-    // Fixed-size stack: BVH depth grows like ~1.44*log2(N), so 64 covers
-    // any plausible scene by a wide margin.  Overflow would corrupt
-    // traversal; if it ever becomes possible, add an assert here and
-    // grow the stack.
-    uint32_t stack[kMaxTraversalStack];
-    int top = 0;
-    stack[top++] = 0; // root
+void BVH::QueryCone(const BVHPrimitive* primitives,
+                    const Math::Cone& cone,
+                    std::vector<uint32_t>& outVisiblePrimitiveIndices) const
+{
+    if (cone.Range <= 0.0f)
+        return;
+    Traverse(primitives,
+             [&](const Math::AABB& b) { return cone.IntersectsAABB(b); },
+             outVisiblePrimitiveIndices);
+}
 
-    while (top > 0)
-    {
-        const uint32_t idx = stack[--top];
-        const BVHNode& n = m_Nodes[idx];
-
-        if (!frustum.IntersectsAABB(n.Bounds))
-            continue;
-
-        if (n.IsLeaf())
-        {
-            // Per-primitive retest: a leaf node's union bounds may pass
-            // the frustum test even when individual primitives do not.
-            // Skipping this step produces false-positive visibility.
-            const uint32_t first = n.LeftOrFirst;
-            const uint32_t end   = first + n.PrimitiveCount;
-            for (uint32_t i = first; i < end; ++i)
-            {
-                const uint32_t primIdx = m_PrimitiveIndices[i];
-                if (frustum.IntersectsAABB(primitives[primIdx].WorldBounds))
-                    outVisiblePrimitiveIndices.push_back(primIdx);
-            }
-        }
-        else
-        {
-            // Children are contiguous; push both.  No ordering preference
-            // for frustum cull (unlike ray queries which want front-to-
-            // back) -- the visibility set is unordered.
-            const uint32_t left  = n.LeftOrFirst;
-            const uint32_t right = left + 1;
-            stack[top++] = left;
-            stack[top++] = right;
-        }
-    }
+void BVH::QueryAABB(const BVHPrimitive* primitives,
+                    const Math::AABB& box,
+                    std::vector<uint32_t>& outVisiblePrimitiveIndices) const
+{
+    if (box.IsEmpty())
+        return;
+    Traverse(primitives,
+             [&](const Math::AABB& b) { return box.Intersects(b); },
+             outVisiblePrimitiveIndices);
 }
 
 } // namespace Canvas

--- a/src/CanvasCore/BVH.cpp
+++ b/src/CanvasCore/BVH.cpp
@@ -1,0 +1,294 @@
+//================================================================================================
+// BVH implementation -- SAH binned top-down build + iterative frustum cull.
+//================================================================================================
+
+#include "pch.h"
+#include "BVH.h"
+
+namespace Canvas
+{
+
+namespace
+{
+
+// Surface area of an AABB.  Returns 0 for empty AABBs so the SAH cost
+// model degenerates safely rather than producing negative or NaN costs.
+float SurfaceArea(const Math::AABB& box)
+{
+    if (box.IsEmpty())
+        return 0.0f;
+    const float dx = box.Max.V[0] - box.Min.V[0];
+    const float dy = box.Max.V[1] - box.Min.V[1];
+    const float dz = box.Max.V[2] - box.Min.V[2];
+    // Zero-extent on one or more axes is legitimate (e.g. a quad's
+    // bounds collapsed to a plane) and produces a meaningful surface
+    // area, so no clamping.
+    return 2.0f * (dx * dy + dy * dz + dz * dx);
+}
+
+// Centroid of an AABB; partition key for SAH binning.  Ignores .w.
+void Centroid(const Math::AABB& box, float out[3])
+{
+    out[0] = (box.Min.V[0] + box.Max.V[0]) * 0.5f;
+    out[1] = (box.Min.V[1] + box.Max.V[1]) * 0.5f;
+    out[2] = (box.Min.V[2] + box.Max.V[2]) * 0.5f;
+}
+
+constexpr uint32_t kSAHBinCount          = 16;   // standard balance of quality and cost
+constexpr uint32_t kMaxPrimitivesPerLeaf = 4;    // small-leaf cutoff; below this an SAH split
+                                                 // rarely beats keeping a leaf node
+constexpr float    kTraversalCost        = 1.0f; // SAH constants in arbitrary units; only
+constexpr float    kIntersectCost        = 1.0f; // ratios matter for split-vs-leaf decisions
+constexpr uint32_t kMaxTraversalStack    = 64;   // BVH depth ~1.44*log2(N); 64 covers any
+                                                 // plausible scene by a wide margin
+
+} // anonymous namespace
+
+void BVH::Build(const BVHPrimitive* primitives, size_t count)
+{
+    m_Nodes.clear();
+    m_PrimitiveIndices.clear();
+
+    // Skip empty-sentinel primitives.  Defending here means an upstream
+    // caller that passes empties produces a smaller BVH rather than a
+    // crash or a leaf node with a meaningless AABB.
+    m_PrimitiveIndices.reserve(count);
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        if (!primitives[i].WorldBounds.IsEmpty())
+            m_PrimitiveIndices.push_back(i);
+    }
+
+    if (m_PrimitiveIndices.empty())
+        return;
+
+    // Reserve worst-case node count (2N-1 for N leaf nodes).  Avoids
+    // reallocations during recursion that would invalidate BVHNode
+    // references we operate on.
+    m_Nodes.reserve(2 * m_PrimitiveIndices.size());
+
+    m_Nodes.emplace_back();
+    BuildRecursive(primitives, /*nodeIndex*/ 0, /*first*/ 0,
+                   /*count*/ static_cast<uint32_t>(m_PrimitiveIndices.size()));
+}
+
+void BVH::BuildRecursive(const BVHPrimitive* primitives,
+                         uint32_t nodeIndex,
+                         uint32_t first,
+                         uint32_t count)
+{
+    // Compute this subtree's bounds and the centroid bounds used for
+    // binning.  Centroid bounds are tighter than primitive bounds and
+    // give the binner more separation when primitives overlap heavily.
+    Math::AABB nodeBounds;
+    Math::AABB centroidBounds;
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        const BVHPrimitive& prim = primitives[m_PrimitiveIndices[first + i]];
+        nodeBounds.ExpandToInclude(prim.WorldBounds);
+        float c[3];
+        Centroid(prim.WorldBounds, c);
+        centroidBounds.ExpandToInclude(Math::FloatVector4(c[0], c[1], c[2], 0.0f));
+    }
+    m_Nodes[nodeIndex].Bounds = nodeBounds;
+
+    // Small-leaf early-out: skip binning for tiny subtrees.
+    if (count <= kMaxPrimitivesPerLeaf)
+    {
+        m_Nodes[nodeIndex].LeftOrFirst    = first;
+        m_Nodes[nodeIndex].PrimitiveCount = count;
+        return;
+    }
+
+    // Pick the longest centroid axis to bin along.  Cheap and produces
+    // near-optimal results in practice.
+    const float ex = centroidBounds.Max.V[0] - centroidBounds.Min.V[0];
+    const float ey = centroidBounds.Max.V[1] - centroidBounds.Min.V[1];
+    const float ez = centroidBounds.Max.V[2] - centroidBounds.Min.V[2];
+    int axis = 0;
+    float extent = ex;
+    if (ey > extent) { axis = 1; extent = ey; }
+    if (ez > extent) { axis = 2; extent = ez; }
+
+    // Degenerate: all centroids coincide.  Splitting yields no benefit;
+    // force a leaf node rather than producing two identical children and
+    // recursing forever.
+    if (extent <= 0.0f)
+    {
+        m_Nodes[nodeIndex].LeftOrFirst    = first;
+        m_Nodes[nodeIndex].PrimitiveCount = count;
+        return;
+    }
+
+    // Bin the centroids along the chosen axis.
+    struct Bin { Math::AABB Bounds; uint32_t Count = 0; };
+    Bin bins[kSAHBinCount];
+
+    const float axisMin = centroidBounds.Min.V[axis];
+    const float binScale = static_cast<float>(kSAHBinCount) / extent;
+
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        const BVHPrimitive& prim = primitives[m_PrimitiveIndices[first + i]];
+        float c[3];
+        Centroid(prim.WorldBounds, c);
+        // Clamp guards against floating-point landing exactly at the max
+        // edge (which would produce binIdx == kSAHBinCount).
+        uint32_t binIdx = static_cast<uint32_t>((c[axis] - axisMin) * binScale);
+        if (binIdx >= kSAHBinCount) binIdx = kSAHBinCount - 1;
+        bins[binIdx].Bounds.ExpandToInclude(prim.WorldBounds);
+        bins[binIdx].Count++;
+    }
+
+    // Sweep bins to compute, for each candidate split between bin i and
+    // bin i+1, the SAH cost = traversal + intersectCost *
+    // (leftCount * leftSA + rightCount * rightSA) / parentSA.  We
+    // precompute left/right prefix scans of bounds and counts so each
+    // candidate is O(1).
+    Math::AABB leftBounds [kSAHBinCount - 1];
+    Math::AABB rightBounds[kSAHBinCount - 1];
+    uint32_t   leftCount  [kSAHBinCount - 1] = {};
+    uint32_t   rightCount [kSAHBinCount - 1] = {};
+
+    Math::AABB accum;
+    uint32_t   accumCount = 0;
+    for (uint32_t i = 0; i < kSAHBinCount - 1; ++i)
+    {
+        accum.ExpandToInclude(bins[i].Bounds);
+        accumCount += bins[i].Count;
+        leftBounds[i] = accum;
+        leftCount [i] = accumCount;
+    }
+    accum = Math::AABB{};
+    accumCount = 0;
+    for (int i = static_cast<int>(kSAHBinCount) - 1; i >= 1; --i)
+    {
+        accum.ExpandToInclude(bins[i].Bounds);
+        accumCount += bins[i].Count;
+        rightBounds[i - 1] = accum;
+        rightCount [i - 1] = accumCount;
+    }
+
+    const float parentSA = SurfaceArea(nodeBounds);
+    const float invParentSA = (parentSA > 0.0f) ? (1.0f / parentSA) : 0.0f;
+
+    float bestCost = FLT_MAX;
+    int   bestSplit = -1;
+    for (uint32_t i = 0; i < kSAHBinCount - 1; ++i)
+    {
+        if (leftCount[i] == 0 || rightCount[i] == 0)
+            continue; // an empty side is not a real split
+        const float costL = SurfaceArea(leftBounds [i]) * static_cast<float>(leftCount [i]);
+        const float costR = SurfaceArea(rightBounds[i]) * static_cast<float>(rightCount[i]);
+        const float cost  = kTraversalCost + kIntersectCost * (costL + costR) * invParentSA;
+        if (cost < bestCost)
+        {
+            bestCost  = cost;
+            bestSplit = static_cast<int>(i);
+        }
+    }
+
+    // Emit a leaf node if no split improves over keeping all primitives
+    // here.  This is the SAH stopping criterion; without it the recursion
+    // would happily keep subdividing well past the point of diminishing
+    // returns.
+    const float leafCost = kIntersectCost * static_cast<float>(count);
+    if (bestSplit < 0 || bestCost >= leafCost)
+    {
+        m_Nodes[nodeIndex].LeftOrFirst    = first;
+        m_Nodes[nodeIndex].PrimitiveCount = count;
+        return;
+    }
+
+    // Partition m_PrimitiveIndices[first .. first+count) in place by bin
+    // index <= bestSplit.  std::partition gives an O(count) in-place
+    // reorder.
+    const float splitPos = axisMin + (extent / static_cast<float>(kSAHBinCount))
+                                   * static_cast<float>(bestSplit + 1);
+    uint32_t* begin = m_PrimitiveIndices.data() + first;
+    uint32_t* end   = begin + count;
+    uint32_t* mid   = std::partition(begin, end, [&](uint32_t idx) {
+        float c[3];
+        Centroid(primitives[idx].WorldBounds, c);
+        return c[axis] < splitPos;
+    });
+    const uint32_t leftCountFinal  = static_cast<uint32_t>(mid - begin);
+    const uint32_t rightCountFinal = count - leftCountFinal;
+
+    // Floating-point at the bin boundary can collapse one side to zero
+    // even when the binner picked a valid split.  Fall back to a leaf
+    // node in that case rather than infinite-recursing on a one-sided
+    // partition.
+    if (leftCountFinal == 0 || rightCountFinal == 0)
+    {
+        m_Nodes[nodeIndex].LeftOrFirst    = first;
+        m_Nodes[nodeIndex].PrimitiveCount = count;
+        return;
+    }
+
+    // Reserve two contiguous child slots and recurse.  Capture the left
+    // child index BEFORE the emplace_backs because recursion may grow
+    // m_Nodes further; LeftOrFirst stores only the left index since the
+    // right child is always left+1.
+    const uint32_t leftChildIndex = static_cast<uint32_t>(m_Nodes.size());
+    m_Nodes.emplace_back();
+    m_Nodes.emplace_back();
+
+    m_Nodes[nodeIndex].LeftOrFirst    = leftChildIndex;
+    m_Nodes[nodeIndex].PrimitiveCount = 0;
+
+    BuildRecursive(primitives, leftChildIndex,     first,                  leftCountFinal);
+    BuildRecursive(primitives, leftChildIndex + 1, first + leftCountFinal, rightCountFinal);
+}
+
+void BVH::QueryFrustum(const BVHPrimitive* primitives,
+                       const Math::Frustum& frustum,
+                       std::vector<uint32_t>& outVisiblePrimitiveIndices) const
+{
+    if (m_Nodes.empty())
+        return;
+
+    // Fixed-size stack: BVH depth grows like ~1.44*log2(N), so 64 covers
+    // any plausible scene by a wide margin.  Overflow would corrupt
+    // traversal; if it ever becomes possible, add an assert here and
+    // grow the stack.
+    uint32_t stack[kMaxTraversalStack];
+    int top = 0;
+    stack[top++] = 0; // root
+
+    while (top > 0)
+    {
+        const uint32_t idx = stack[--top];
+        const BVHNode& n = m_Nodes[idx];
+
+        if (!frustum.IntersectsAABB(n.Bounds))
+            continue;
+
+        if (n.IsLeaf())
+        {
+            // Per-primitive retest: a leaf node's union bounds may pass
+            // the frustum test even when individual primitives do not.
+            // Skipping this step produces false-positive visibility.
+            const uint32_t first = n.LeftOrFirst;
+            const uint32_t end   = first + n.PrimitiveCount;
+            for (uint32_t i = first; i < end; ++i)
+            {
+                const uint32_t primIdx = m_PrimitiveIndices[i];
+                if (frustum.IntersectsAABB(primitives[primIdx].WorldBounds))
+                    outVisiblePrimitiveIndices.push_back(primIdx);
+            }
+        }
+        else
+        {
+            // Children are contiguous; push both.  No ordering preference
+            // for frustum cull (unlike ray queries which want front-to-
+            // back) -- the visibility set is unordered.
+            const uint32_t left  = n.LeftOrFirst;
+            const uint32_t right = left + 1;
+            stack[top++] = left;
+            stack[top++] = right;
+        }
+    }
+}
+
+} // namespace Canvas

--- a/src/CanvasCore/BVH.h
+++ b/src/CanvasCore/BVH.h
@@ -9,8 +9,10 @@
 // BVH's internal index array is permuted, so caller-held
 // BVHPrimitiveIds remain valid across rebuilds.
 //
-// Traversal: iterative depth-first with a fixed-size node stack.
-// Frustum culling is the only supported query today.
+// Traversal: iterative depth-first with a fixed-size node stack,
+// shared by every Query* via a templated shape predicate.  Supported
+// queries: frustum (view culling), sphere (point-light influence),
+// bounded cone (spot-light influence), and AABB (tile / world-box).
 //================================================================================================
 
 #pragma once
@@ -81,7 +83,7 @@ public:
     // (Re)build the BVH from the supplied primitive array.  The
     // primitive array is read-only here; only the BVH's internal index
     // permutation is modified.  Empty input produces an empty BVH;
-    // calling QueryFrustum on an empty BVH yields no results.
+    // calling any Query* on an empty BVH yields no results.
     // Primitives whose WorldBounds.IsEmpty() are silently skipped to
     // honor the AABB sentinel contract documented on AABB::IsEmpty().
     CANVAS_API void Build(const BVHPrimitive* primitives, size_t count);
@@ -104,6 +106,35 @@ public:
                                  const Math::Frustum& frustum,
                                  std::vector<uint32_t>& outVisiblePrimitiveIndices) const;
 
+    // Iterative sphere overlap query.  Exact at the per-primitive
+    // tier: a primitive is returned iff its WorldBounds is within
+    // `radius` of `center` (closest-point AABB test).  Same output /
+    // aliasing contract as QueryFrustum.  Intended for point-light
+    // influence culling.
+    //
+    // radius <= 0 yields no results.
+    CANVAS_API void QuerySphere(const BVHPrimitive* primitives,
+                                const Math::FloatVector4& center,
+                                float radius,
+                                std::vector<uint32_t>& outVisiblePrimitiveIndices) const;
+
+    // Iterative bounded-cone overlap query.  Conservative: each AABB
+    // (node or primitive) is bounded by its outer sphere and tested
+    // against the cone via Math::Cone::IntersectsAABB.  False positives
+    // are possible at the BVH culling tier but never false negatives.
+    // Intended for spot-light influence culling.
+    CANVAS_API void QueryCone(const BVHPrimitive* primitives,
+                              const Math::Cone& cone,
+                              std::vector<uint32_t>& outVisiblePrimitiveIndices) const;
+
+    // Iterative AABB overlap query.  Exact axis-aligned overlap test
+    // at both the node and primitive tier (no looseness introduced).
+    // Empty query box yields no results.  Intended for tile-frustum
+    // pre-binning and any caller that already has a world-space box.
+    CANVAS_API void QueryAABB(const BVHPrimitive* primitives,
+                              const Math::AABB& box,
+                              std::vector<uint32_t>& outVisiblePrimitiveIndices) const;
+
     bool Empty() const { return m_Nodes.empty(); }
     size_t NodeCount() const { return m_Nodes.size(); }
     size_t PrimitiveCount() const { return m_PrimitiveIndices.size(); }
@@ -111,6 +142,54 @@ public:
     const std::vector<uint32_t>& GetPrimitiveIndices() const { return m_PrimitiveIndices; }
 
 private:
+    // BVH depth grows like ~1.44*log2(N); 64 covers any plausible scene
+    // by a wide margin.
+    static constexpr uint32_t kMaxTraversalStack = 64;
+
+    // Shared iterative traversal.  `test(aabb) -> bool` is invoked both
+    // for node bounds (to prune subtrees) and for per-primitive bounds
+    // (to filter false positives within accepted leaves).  Inline so
+    // each query specializes the test at the call site without an
+    // indirect call.
+    template <typename ShapeTest>
+    void Traverse(const BVHPrimitive* primitives,
+                  ShapeTest&& test,
+                  std::vector<uint32_t>& out) const
+    {
+        if (m_Nodes.empty())
+            return;
+
+        uint32_t stack[kMaxTraversalStack];
+        int top = 0;
+        stack[top++] = 0; // root
+
+        while (top > 0)
+        {
+            const uint32_t idx = stack[--top];
+            const BVHNode& n = m_Nodes[idx];
+
+            if (!test(n.Bounds))
+                continue;
+
+            if (n.IsLeaf())
+            {
+                const uint32_t first = n.LeftOrFirst;
+                const uint32_t end   = first + n.PrimitiveCount;
+                for (uint32_t i = first; i < end; ++i)
+                {
+                    const uint32_t primIdx = m_PrimitiveIndices[i];
+                    if (test(primitives[primIdx].WorldBounds))
+                        out.push_back(primIdx);
+                }
+            }
+            else
+            {
+                stack[top++] = n.LeftOrFirst;
+                stack[top++] = n.LeftOrFirst + 1;
+            }
+        }
+    }
+
     // Recursive SAH binned split.  Operates on m_PrimitiveIndices in
     // place over [first, first+count); produces m_Nodes[nodeIndex] and
     // (when split) two child nodes appended at the back of m_Nodes.

--- a/src/CanvasCore/BVH.h
+++ b/src/CanvasCore/BVH.h
@@ -129,8 +129,8 @@ public:
 
     // Iterative AABB overlap query.  Exact axis-aligned overlap test
     // at both the node and primitive tier (no looseness introduced).
-    // Empty query box yields no results.  Intended for tile-frustum
-    // pre-binning and any caller that already has a world-space box.
+    // Empty query box yields no results.  Intended for callers that
+    // already have a world-space box (e.g. spatial-region selections).
     CANVAS_API void QueryAABB(const BVHPrimitive* primitives,
                               const Math::AABB& box,
                               std::vector<uint32_t>& outVisiblePrimitiveIndices) const;

--- a/src/CanvasCore/BVH.h
+++ b/src/CanvasCore/BVH.h
@@ -1,0 +1,126 @@
+//================================================================================================
+// BVH
+//
+// CPU-side, single-threaded, static-only, SAH-binned top-down build over
+// an array of BVHPrimitive entries.  Produces a binary tree of AABB
+// nodes whose leaf nodes reference contiguous ranges of a reordered
+// primitive-index array.  The BVHPrimitive array itself is owned
+// externally (SceneBVH) and is NOT reordered by the BVH; only the
+// BVH's internal index array is permuted, so caller-held
+// BVHPrimitiveIds remain valid across rebuilds.
+//
+// Traversal: iterative depth-first with a fixed-size node stack.
+// Frustum culling is the only supported query today.
+//================================================================================================
+
+#pragma once
+
+#include "pch.h"
+
+namespace Canvas
+{
+
+struct XSceneGraphNode;
+
+// Reserved for future use.  The current build produces and consumes
+// only None / Static.
+enum BVHPrimitiveFlags : uint32_t
+{
+    BVHPrimitiveFlag_None         = 0,
+    BVHPrimitiveFlag_Static       = 1u << 0,
+    BVHPrimitiveFlag_Dynamic      = 1u << 1,
+    BVHPrimitiveFlag_CastsShadow  = 1u << 2,
+};
+
+// Stable index into the SceneBVH-owned primitive table.
+using BVHPrimitiveId = uint32_t;
+
+constexpr BVHPrimitiveId kInvalidBVHPrimitiveId = UINT32_MAX;
+
+// A BVHPrimitive is the BVH's user-level payload: pairs a world-space
+// AABB with a back-pointer to the XSceneGraphNode that produced it.
+// Primitives live in a flat array owned by SceneBVH.
+struct BVHPrimitive
+{
+    // World-space AABB.  Currently set once at Build() time as
+    // localBounds.Transform(node->GetGlobalMatrix())
+    // and never updated.
+    Math::AABB WorldBounds;
+
+    // Weak back-pointer to the producing node.  Lifetime is guaranteed
+    // by the scene graph holding a Gem reference to the node.
+    XSceneGraphNode* Node = nullptr;
+
+    BVHPrimitiveId Id = kInvalidBVHPrimitiveId;
+    uint32_t Flags = BVHPrimitiveFlag_None;
+};
+
+struct BVHNode
+{
+    // Tight bounds over all primitives in this subtree.
+    Math::AABB Bounds;
+
+    // Inner node:  LeftOrFirst    = index of left child node; right = left + 1
+    //                               (children are always stored contiguously,
+    //                               so one index addresses both).
+    //              PrimitiveCount = 0.
+    // Leaf node:   LeftOrFirst    = index into BVH::GetPrimitiveIndices() of
+    //                               the first primitive belonging to this node.
+    //              PrimitiveCount > 0 = number of contiguous primitive entries.
+    uint32_t LeftOrFirst    = 0;
+    uint32_t PrimitiveCount = 0;
+
+    bool IsLeaf() const { return PrimitiveCount > 0; }
+};
+
+class BVH
+{
+public:
+    BVH() = default;
+
+    // (Re)build the BVH from the supplied primitive array.  The
+    // primitive array is read-only here; only the BVH's internal index
+    // permutation is modified.  Empty input produces an empty BVH;
+    // calling QueryFrustum on an empty BVH yields no results.
+    // Primitives whose WorldBounds.IsEmpty() are silently skipped to
+    // honor the AABB sentinel contract documented on AABB::IsEmpty().
+    CANVAS_API void Build(const BVHPrimitive* primitives, size_t count);
+
+    // Iterative frustum cull.  Appends to outVisiblePrimitiveIndices
+    // the index (into the primitive array passed to Build) of every
+    // primitive whose WorldBounds passes Frustum::IntersectsAABB.  The
+    // output vector is NOT cleared first - callers typically reuse a
+    // scratch vector across frames.  Result order is depth-first
+    // traversal; stable per build but otherwise unspecified.
+    //
+    // `primitives` MUST point at the same array (or one with identical
+    // bounds at the same indices) that was passed to Build; the BVH
+    // stores only indices and needs the bounds back to perform
+    // per-primitive retest at leaf nodes.  The retest is non-optional:
+    // a leaf node's union bounds can pass the frustum even when none
+    // of its individual primitives do, so skipping it produces
+    // false-positive visibility.
+    CANVAS_API void QueryFrustum(const BVHPrimitive* primitives,
+                                 const Math::Frustum& frustum,
+                                 std::vector<uint32_t>& outVisiblePrimitiveIndices) const;
+
+    bool Empty() const { return m_Nodes.empty(); }
+    size_t NodeCount() const { return m_Nodes.size(); }
+    size_t PrimitiveCount() const { return m_PrimitiveIndices.size(); }
+    const std::vector<BVHNode>& GetNodes() const { return m_Nodes; }
+    const std::vector<uint32_t>& GetPrimitiveIndices() const { return m_PrimitiveIndices; }
+
+private:
+    // Recursive SAH binned split.  Operates on m_PrimitiveIndices in
+    // place over [first, first+count); produces m_Nodes[nodeIndex] and
+    // (when split) two child nodes appended at the back of m_Nodes.
+    void BuildRecursive(const BVHPrimitive* primitives,
+                        uint32_t nodeIndex,
+                        uint32_t first,
+                        uint32_t count);
+
+    std::vector<BVHNode> m_Nodes;             // node 0 is root when non-empty
+    std::vector<uint32_t> m_PrimitiveIndices; // permutation of [0, primitiveCount)
+};
+
+} // namespace Canvas

--- a/src/CanvasCore/CMakeLists.txt
+++ b/src/CanvasCore/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(CanvasCore SHARED
     UIGraph.cpp
     BVH.cpp
     SceneBVH.cpp
+    LightBVH.cpp
     
     # Header files (for IDE organization)
     ../Inc/CanvasCore.h
@@ -39,6 +40,7 @@ add_library(CanvasCore SHARED
     Timer.h
     BVH.h
     SceneBVH.h
+    LightBVH.h
     pch.h
     targetver.h
 )

--- a/src/CanvasCore/CMakeLists.txt
+++ b/src/CanvasCore/CMakeLists.txt
@@ -15,6 +15,8 @@ add_library(CanvasCore SHARED
     FontImpl.cpp
     TextLayout.cpp
     UIGraph.cpp
+    BVH.cpp
+    SceneBVH.cpp
     
     # Header files (for IDE organization)
     ../Inc/CanvasCore.h
@@ -35,6 +37,8 @@ add_library(CanvasCore SHARED
     ScopedUtils.h
     Timeline.h
     Timer.h
+    BVH.h
+    SceneBVH.h
     pch.h
     targetver.h
 )

--- a/src/CanvasCore/LightBVH.cpp
+++ b/src/CanvasCore/LightBVH.cpp
@@ -1,0 +1,285 @@
+//================================================================================================
+// LightBVH implementation.
+//================================================================================================
+
+#include "pch.h"
+#include "LightBVH.h"
+#include "Canvas.h"
+
+namespace Canvas
+{
+
+namespace
+{
+
+// Conservative AABB enclosing the cone defined by apex / unit axis /
+// range / outer half-angle.  We don't need a tight oriented bound for
+// BVH-tier culling, so we sample the cone's apex and four rim points
+// (axial endpoint and four cardinal directions around the rim) and
+// take their AABB.  Looser than the analytical extremes but cheap and
+// always conservative.
+Math::AABB ComputeSpotInfluenceAABB(const Math::FloatVector4& apex,
+                                    const Math::FloatVector4& axis,
+                                    float range,
+                                    float outerHalfAngleRadians)
+{
+    Math::AABB box;
+    box.ExpandToInclude(apex);
+
+    if (range <= 0.0f)
+        return box;
+
+    // Pick any vector not parallel to the axis to derive an
+    // orthonormal basis (axis, right, up) for the rim sampling.
+    const float ax = axis.V[0], ay = axis.V[1], az = axis.V[2];
+    Math::FloatVector4 helper = (std::abs(ax) < 0.9f)
+        ? Math::FloatVector4(1.0f, 0.0f, 0.0f, 0.0f)
+        : Math::FloatVector4(0.0f, 1.0f, 0.0f, 0.0f);
+
+    // right = normalize(axis x helper)
+    Math::FloatVector4 right(
+        ay * helper.V[2] - az * helper.V[1],
+        az * helper.V[0] - ax * helper.V[2],
+        ax * helper.V[1] - ay * helper.V[0],
+        0.0f);
+    {
+        const float rlen = std::sqrt(right.V[0] * right.V[0]
+                                   + right.V[1] * right.V[1]
+                                   + right.V[2] * right.V[2]);
+        if (rlen > 1e-6f)
+        {
+            right.V[0] /= rlen; right.V[1] /= rlen; right.V[2] /= rlen;
+        }
+    }
+    // up = axis x right
+    const Math::FloatVector4 up(
+        ay * right.V[2] - az * right.V[1],
+        az * right.V[0] - ax * right.V[2],
+        ax * right.V[1] - ay * right.V[0],
+        0.0f);
+
+    const float rimDist = range * std::tan(outerHalfAngleRadians);
+    const Math::FloatVector4 axialEnd(
+        apex.V[0] + ax * range,
+        apex.V[1] + ay * range,
+        apex.V[2] + az * range,
+        0.0f);
+
+    box.ExpandToInclude(axialEnd);
+    for (int sign : { -1, +1 })
+    {
+        const float s = static_cast<float>(sign);
+        box.ExpandToInclude(Math::FloatVector4(
+            axialEnd.V[0] + s * rimDist * right.V[0],
+            axialEnd.V[1] + s * rimDist * right.V[1],
+            axialEnd.V[2] + s * rimDist * right.V[2],
+            0.0f));
+        box.ExpandToInclude(Math::FloatVector4(
+            axialEnd.V[0] + s * rimDist * up.V[0],
+            axialEnd.V[1] + s * rimDist * up.V[1],
+            axialEnd.V[2] + s * rimDist * up.V[2],
+            0.0f));
+    }
+    return box;
+}
+
+// AABB of the point-light influence sphere: simply the bbox of the
+// sphere of radius `range` centered at `position`.
+Math::AABB ComputePointInfluenceAABB(const Math::FloatVector4& position, float range)
+{
+    if (range <= 0.0f)
+        return Math::AABB{};
+    return Math::AABB(
+        Math::FloatVector4(position.V[0] - range, position.V[1] - range, position.V[2] - range, 0.0f),
+        Math::FloatVector4(position.V[0] + range, position.V[1] + range, position.V[2] + range, 0.0f));
+}
+
+// Derive (worldPosition, axisForward) from a light's attached node's
+// global matrix.  Position is row 3; the spot/directional "forward"
+// is row 0 (matches the row-vector basis convention used throughout
+// Canvas).  Returns false when no node is attached.
+bool GetLightWorldPose(XLight* light,
+                       Math::FloatVector4& outPosition,
+                       Math::FloatVector4& outForward)
+{
+    XSceneGraphNode* node = light->GetAttachedNode();
+    if (!node)
+        return false;
+    const Math::FloatMatrix4x4 world = node->GetGlobalMatrix();
+    outPosition = Math::FloatVector4(world[3][0], world[3][1], world[3][2], 1.0f);
+    outForward  = Math::FloatVector4(world[0][0], world[0][1], world[0][2], 0.0f);
+    return true;
+}
+
+} // anonymous namespace
+
+void LightBVH::Clear()
+{
+    m_Primitives.clear();
+    m_LightForPrimitive.clear();
+    m_UntrackedLights.clear();
+    m_TrackedLightSet.clear();
+    m_BVH = BVH{};
+    m_VisiblePrimitiveScratch.clear();
+    m_Built = false;
+}
+
+void LightBVH::Build(XSceneGraphNode* root)
+{
+    Clear();
+
+    if (!root)
+        return;
+
+    // Iterative DFS to match SceneBVH (and to defend against the
+    // deep instanced subtrees that can occur in imported scenes).
+    std::vector<XSceneGraphNode*> stack;
+    stack.reserve(64);
+    stack.push_back(root);
+
+    BVHPrimitiveId nextId = 0;
+    while (!stack.empty())
+    {
+        XSceneGraphNode* node = stack.back();
+        stack.pop_back();
+        if (!node)
+            continue;
+
+        const UINT elementCount = node->GetBoundElementCount();
+        for (UINT i = 0; i < elementCount; ++i)
+        {
+            XSceneGraphElement* element = node->GetBoundElement(i);
+            if (!element)
+                continue;
+
+            Gem::TGemPtr<XLight> pLight;
+            if (FAILED(element->QueryInterface(&pLight)))
+                continue;
+
+            XLight* lightRaw = pLight.Get();
+            const LightType type = lightRaw->GetType();
+
+            // Directional / Ambient / Area / disabled-attached light:
+            // no spatial bound, route to the untracked list so the
+            // consumer can include it unconditionally.
+            if (type != LightType::Point && type != LightType::Spot)
+            {
+                m_UntrackedLights.push_back(lightRaw);
+                continue;
+            }
+
+            Math::FloatVector4 worldPos, forward;
+            if (!GetLightWorldPose(lightRaw, worldPos, forward))
+            {
+                // A point/spot light with no attached node has no
+                // meaningful world position; treat as untracked so it
+                // still reaches the renderer (which will handle the
+                // missing-node fallback) rather than silently
+                // dropping it.
+                m_UntrackedLights.push_back(lightRaw);
+                continue;
+            }
+
+            const float range = lightRaw->GetRange();
+            Math::AABB influence;
+
+            if (type == LightType::Point)
+            {
+                influence = ComputePointInfluenceAABB(worldPos, range);
+            }
+            else // LightType::Spot
+            {
+                float innerHalf = 0.785398f;
+                float outerHalf = 1.047198f;
+                lightRaw->GetSpotAngles(&innerHalf, &outerHalf);
+                // SetSpotAngles takes the full angle pair; the cone
+                // half-angle for influence bounding is outer / 2.
+                // (Mirrors the cosine used by the renderer's spot
+                // attenuation.)
+                const float outerHalfAngle = 0.5f * outerHalf;
+
+                // Defensive normalize: imported / animated transforms
+                // can drift basis rows slightly off unit length.
+                const float flen = std::sqrt(forward.V[0] * forward.V[0]
+                                           + forward.V[1] * forward.V[1]
+                                           + forward.V[2] * forward.V[2]);
+                if (flen > 1e-6f)
+                {
+                    forward.V[0] /= flen;
+                    forward.V[1] /= flen;
+                    forward.V[2] /= flen;
+                }
+                influence = ComputeSpotInfluenceAABB(worldPos, forward, range, outerHalfAngle);
+            }
+
+            if (influence.IsEmpty())
+            {
+                // Zero-range or otherwise degenerate; classify as
+                // untracked so the renderer still sees it (it will
+                // produce zero contribution at runtime anyway, but
+                // we shouldn't silently drop authored lights).
+                m_UntrackedLights.push_back(lightRaw);
+                continue;
+            }
+
+            BVHPrimitive prim;
+            prim.WorldBounds = influence;
+            prim.Node        = node;
+            prim.Id          = nextId++;
+            prim.Flags       = BVHPrimitiveFlag_Static;
+            m_Primitives.push_back(prim);
+            m_LightForPrimitive.push_back(lightRaw);
+            m_TrackedLightSet.insert(lightRaw);
+        }
+
+        for (XSceneGraphNode* child = node->GetFirstChild();
+             child;
+             child = node->GetNextChild(child))
+        {
+            stack.push_back(child);
+        }
+    }
+
+    if (!m_Primitives.empty())
+        m_BVH.Build(m_Primitives.data(), m_Primitives.size());
+
+    m_Built = true;
+}
+
+bool LightBVH::IsTrackedLight(XLight* light) const
+{
+    if (!light)
+        return false;
+    return m_TrackedLightSet.find(light) != m_TrackedLightSet.end();
+}
+
+void LightBVH::QueryFrustum(XCamera* camera, std::vector<XLight*>& outVisibleLights) const
+{
+    outVisibleLights.clear();
+    if (!camera || !m_Built || m_Primitives.empty())
+        return;
+
+    const Math::FloatMatrix4x4 vp = camera->GetViewProjectionMatrix();
+    const Math::Frustum f = Math::Frustum::FromViewProjection(vp, /*reverseZ*/ true);
+    QueryFrustum(f, outVisibleLights);
+}
+
+void LightBVH::QueryFrustum(const Math::Frustum& frustum,
+                            std::vector<XLight*>& outVisibleLights) const
+{
+    outVisibleLights.clear();
+    if (!m_Built || m_Primitives.empty())
+        return;
+
+    m_VisiblePrimitiveScratch.clear();
+    m_BVH.QueryFrustum(m_Primitives.data(), frustum, m_VisiblePrimitiveScratch);
+
+    // Each tracked light contributes exactly one primitive, so a
+    // primitive-index -> light mapping is sufficient and no dedup
+    // pass is required here.
+    outVisibleLights.reserve(m_VisiblePrimitiveScratch.size());
+    for (uint32_t primIdx : m_VisiblePrimitiveScratch)
+        outVisibleLights.push_back(m_LightForPrimitive[primIdx]);
+}
+
+} // namespace Canvas

--- a/src/CanvasCore/LightBVH.h
+++ b/src/CanvasCore/LightBVH.h
@@ -1,0 +1,113 @@
+//================================================================================================
+// LightBVH
+//
+// Owns the per-light primitive table for a CScene and the BVH built
+// over it.  Parallel structure to SceneBVH, but the primitive AABBs
+// describe each light's spatial *influence* (the volume within which
+// the light can contribute >= cutoff radiance) rather than its mesh
+// bounds.  This lets the renderer cull lights against the camera
+// frustum so the per-frame HlslLight upload contains only lights
+// that can affect visible pixels.
+//
+// Per-light influence AABB derivation:
+//   - LightType::Point         bbox of Sphere(worldPos, Range)
+//   - LightType::Spot          bbox of bounded Cone(apex, axisDir,
+//                              Range, outerHalfAngle).  Computed from
+//                              the cone's apex + four rim samples,
+//                              which is loose but correct.
+//   - LightType::Directional   not tracked (infinite extent).  Always
+//                              passes the visibility filter.
+//   - LightType::Ambient       not tracked (scene-global).  Always
+//                              passes.
+//   - LightType::Area          not tracked.  Always passes.
+//
+// This class does NOT:
+//   - track dirty light transforms (no refit, no per-frame update)
+//   - cull shadow casters (the shadow pass consumes the full caster
+//     list)
+//================================================================================================
+
+#pragma once
+
+#include "pch.h"
+#include "BVH.h"
+
+namespace Canvas
+{
+
+struct XCamera;
+struct XLight;
+struct XSceneGraphNode;
+
+class LightBVH
+{
+public:
+    LightBVH() = default;
+
+    // Walks the subtree rooted at `root`, discovers every XLight bound
+    // to any node via QueryInterface, computes a per-light influence
+    // AABB, and builds the BVH.  Lights with no spatial bound
+    // (directional / ambient / area) are recorded as "untracked" so
+    // QueryFrustum-style consumers can mix them back in as always-pass
+    // (see IsTrackedLight).  Discards prior state first; safe to call
+    // repeatedly when scene topology changes.  Null root is a no-op
+    // (leaves IsBuilt() == false).
+    CANVAS_API void Build(XSceneGraphNode* root);
+
+    // Reset to the pre-Build state.  Frees BVH / primitive memory.
+    CANVAS_API void Clear();
+
+    bool IsBuilt() const { return m_Built; }
+    size_t TrackedLightCount() const { return m_LightForPrimitive.size(); }
+    size_t UntrackedLightCount() const { return m_UntrackedLights.size(); }
+
+    // True when `light` was seen at the last successful Build AND
+    // contributes a spatial primitive (i.e. is subject to frustum
+    // culling).  Lights of untracked type return false; consumers
+    // wanting to include them must check via the UntrackedLights view
+    // below or treat "not tracked" as "always visible".
+    CANVAS_API bool IsTrackedLight(XLight* light) const;
+
+    // Read-only view over the untracked-light table, populated at
+    // Build time.  Renderer-side visibility consumers typically union
+    // this with the QueryFrustum result before pushing to the GPU.
+    const std::vector<XLight*>& GetUntrackedLights() const { return m_UntrackedLights; }
+
+    // Compute the visible-light set for the given camera's frustum.
+    // The output vector is cleared first.  Only TRACKED lights are
+    // returned; untracked lights are out-of-scope here and must be
+    // handled by the caller.  Duplicate primitives (a single light
+    // contributes one primitive but the contract permits multiple)
+    // are collapsed via the unordered_set scratch.
+    // Empty / unbuilt BVH produces an empty vector without error.
+    CANVAS_API void QueryFrustum(XCamera* camera, std::vector<XLight*>& outVisibleLights) const;
+
+    // Direct frustum query (no camera dereference) for callers that
+    // already have a Frustum in hand (e.g. unit tests).
+    CANVAS_API void QueryFrustum(const Math::Frustum& frustum,
+                                 std::vector<XLight*>& outVisibleLights) const;
+
+private:
+    // Per-tracked-light primitive table.  Index parallel to
+    // m_LightForPrimitive: m_Primitives[i].Id == i, and that primitive
+    // corresponds to m_LightForPrimitive[i].
+    std::vector<BVHPrimitive> m_Primitives;
+    std::vector<XLight*>      m_LightForPrimitive;
+
+    // Untracked lights (directional / ambient / area / disabled),
+    // captured so the caller can fold them back into the visible set.
+    std::vector<XLight*>      m_UntrackedLights;
+
+    // Lookup for IsTrackedLight.  Populated alongside m_Primitives so
+    // O(1) membership without rescanning the primitive vector.
+    std::unordered_set<XLight*> m_TrackedLightSet;
+
+    BVH m_BVH;
+
+    // Scratch reused across query calls to dedup primitive ids.
+    mutable std::vector<uint32_t> m_VisiblePrimitiveScratch;
+
+    bool m_Built = false;
+};
+
+} // namespace Canvas

--- a/src/CanvasCore/Scene.cpp
+++ b/src/CanvasCore/Scene.cpp
@@ -50,6 +50,19 @@ GEMMETHODIMP CScene::SubmitRenderables(XGfxRenderQueue *pRenderQueue)
 
         pRenderQueue->SetBackground(&m_Background);
 
+        // Auto-build if the caller didn't invoke BuildBVH() at load
+        // time.  Eats the first-frame cost rather than failing.
+        if (!m_SceneBVH.IsBuilt())
+            m_SceneBVH.Build(m_pRoot.Get());
+
+        // Visibility filter: renderable nodes are gated by frustum
+        // visibility; non-renderable nodes (lights, cameras) always
+        // pass through.  No active camera => empty visible set =>
+        // nothing renderable is submitted.
+        m_VisibleNodeScratch.clear();
+        if (m_pActiveCamera)
+            m_SceneBVH.QueryFrustum(m_pActiveCamera.Get(), m_VisibleNodeScratch);
+
         // Iterative depth-first traversal using persistent stack (no per-frame allocation)
         m_TraversalStack.clear();
         m_TraversalStack.push_back(m_pRoot.Get());
@@ -59,9 +72,17 @@ GEMMETHODIMP CScene::SubmitRenderables(XGfxRenderQueue *pRenderQueue)
             XSceneGraphNode *pNode = m_TraversalStack.back();
             m_TraversalStack.pop_back();
 
-            // Submit this node for rendering (render queue handles its elements)
+            // Skip only when the node is renderable AND not in the
+            // visible set.  Non-renderable nodes pass through; so do
+            // renderable nodes the BVH has never seen (e.g. added
+            // after Build), so a stale BVH never hides geometry.
             if (pNode->GetBoundElementCount() > 0)
-                Gem::ThrowGemError(pRenderQueue->SubmitForRender(pNode));
+            {
+                const bool renderable = m_SceneBVH.IsRenderableNode(pNode);
+                const bool visible    = !renderable || m_VisibleNodeScratch.count(pNode) > 0;
+                if (visible)
+                    Gem::ThrowGemError(pRenderQueue->SubmitForRender(pNode));
+            }
 
             // Push children onto stack for traversal
             for (XSceneGraphNode *pChild = pNode->GetFirstChild(); pChild; pChild = pNode->GetNextChild(pChild))

--- a/src/CanvasCore/Scene.cpp
+++ b/src/CanvasCore/Scene.cpp
@@ -54,6 +54,8 @@ GEMMETHODIMP CScene::SubmitRenderables(XGfxRenderQueue *pRenderQueue)
         // time.  Eats the first-frame cost rather than failing.
         if (!m_SceneBVH.IsBuilt())
             m_SceneBVH.Build(m_pRoot.Get());
+        if (!m_LightBVH.IsBuilt())
+            m_LightBVH.Build(m_pRoot.Get());
 
         // Visibility filter: renderable nodes are gated by frustum
         // visibility; non-renderable nodes (lights, cameras) always
@@ -62,6 +64,33 @@ GEMMETHODIMP CScene::SubmitRenderables(XGfxRenderQueue *pRenderQueue)
         m_VisibleNodeScratch.clear();
         if (m_pActiveCamera)
             m_SceneBVH.QueryFrustum(m_pActiveCamera.Get(), m_VisibleNodeScratch);
+
+        // Light visibility: union of untracked lights (ambient /
+        // directional / area -- always relevant) and frustum-culled
+        // tracked lights.  Order within the list is unspecified; the
+        // renderer's filter is set-membership, not rank-keyed.
+        m_VisibleLightsScratch.clear();
+        const std::vector<XLight*>& untracked = m_LightBVH.GetUntrackedLights();
+        m_VisibleLightsScratch.insert(m_VisibleLightsScratch.end(),
+                                      untracked.begin(), untracked.end());
+
+        m_VisibleTrackedLightsScratch.clear();
+        if (m_pActiveCamera)
+            m_LightBVH.QueryFrustum(m_pActiveCamera.Get(), m_VisibleTrackedLightsScratch);
+
+        m_VisibleLightsScratch.insert(m_VisibleLightsScratch.end(),
+                                      m_VisibleTrackedLightsScratch.begin(),
+                                      m_VisibleTrackedLightsScratch.end());
+
+        // Always install the filter, even when the visible-lights
+        // list is empty -- the renderer's contract treats an empty
+        // filter as "drop every light this frame," which is the right
+        // behavior when culling finds nothing visible (preventing
+        // out-of-frustum lights from leaking through SubmitForRender's
+        // natural traversal order).
+        pRenderQueue->SetVisibleLights(
+            m_VisibleLightsScratch.empty() ? nullptr : m_VisibleLightsScratch.data(),
+            m_VisibleLightsScratch.size());
 
         // Iterative depth-first traversal using persistent stack (no per-frame allocation)
         m_TraversalStack.clear();

--- a/src/CanvasCore/Scene.h
+++ b/src/CanvasCore/Scene.h
@@ -7,6 +7,7 @@
 #include "Canvas.h"
 #include "SceneGraph.h"
 #include "SceneBVH.h"
+#include "LightBVH.h"
 
 namespace Canvas
 {
@@ -32,6 +33,16 @@ private:
     // current scope and capabilities.
     SceneBVH m_SceneBVH;
     mutable std::unordered_set<XSceneGraphNode*> m_VisibleNodeScratch; // reused per frame
+
+    // BVH over per-light influence volumes.  Built alongside the
+    // SceneBVH (same lifecycle rules); consumed by SubmitRenderables
+    // to compute a frustum-culled visible-light list that gets pushed
+    // to the render queue via SetVisibleLights.  See LightBVH for
+    // tracked vs untracked light handling and the per-light
+    // influence-AABB derivation.
+    LightBVH m_LightBVH;
+    mutable std::vector<XLight*> m_VisibleTrackedLightsScratch;
+    mutable std::vector<XLight*> m_VisibleLightsScratch;
 
     // Background storage.  Every scene has a background; default-constructed
     // GfxBackgroundDesc is opaque black with no cubemap.  pSkyboxCubemapA/B
@@ -102,6 +113,7 @@ public: // XScene methods
     GEMMETHOD_(void, BuildBVH)() final
     {
         m_SceneBVH.Build(m_pRoot.Get());
+        m_LightBVH.Build(m_pRoot.Get());
     }
 };
 

--- a/src/CanvasCore/Scene.h
+++ b/src/CanvasCore/Scene.h
@@ -6,6 +6,7 @@
 
 #include "Canvas.h"
 #include "SceneGraph.h"
+#include "SceneBVH.h"
 
 namespace Canvas
 {
@@ -19,6 +20,18 @@ private:
     Gem::TGemPtr<XSceneGraphNode> m_pRoot;
     Gem::TGemPtr<XCamera> m_pActiveCamera;
     std::vector<XSceneGraphNode*> m_TraversalStack;  // Reused across frames to avoid allocation
+
+    // BVH over the world-space AABB of every renderable scene element
+    // bound to a node in the scene graph (one primitive per
+    // [node, element] pair whose element returns a non-empty
+    // GetLocalBounds()).  Non-renderable elements (lights, cameras)
+    // honor the empty-AABB contract and contribute no primitives; they
+    // continue to flow through SubmitRenderables unfiltered.  Built
+    // explicitly via BuildBVH(), or lazily on the first
+    // SubmitRenderables when not yet built.  See SceneBVH for the
+    // current scope and capabilities.
+    SceneBVH m_SceneBVH;
+    mutable std::unordered_set<XSceneGraphNode*> m_VisibleNodeScratch; // reused per frame
 
     // Background storage.  Every scene has a background; default-constructed
     // GfxBackgroundDesc is opaque black with no cubemap.  pSkyboxCubemapA/B
@@ -85,6 +98,11 @@ public: // XScene methods
     }
 
     GEMMETHOD(SubmitRenderables)(XGfxRenderQueue *pRenderQueue) final;
+
+    GEMMETHOD_(void, BuildBVH)() final
+    {
+        m_SceneBVH.Build(m_pRoot.Get());
+    }
 };
 
 }

--- a/src/CanvasCore/SceneBVH.cpp
+++ b/src/CanvasCore/SceneBVH.cpp
@@ -1,0 +1,129 @@
+//================================================================================================
+// SceneBVH implementation.
+//================================================================================================
+
+#include "pch.h"
+#include "SceneBVH.h"
+
+namespace Canvas
+{
+
+void SceneBVH::Clear()
+{
+    m_Primitives.clear();
+    m_RenderableNodes.clear();
+    m_BVH = BVH{};
+    m_VisiblePrimitiveScratch.clear();
+    m_Built = false;
+}
+
+void SceneBVH::Build(XSceneGraphNode* root)
+{
+    Clear();
+
+    if (!root)
+        return;
+
+    // Iterative DFS rather than recursion: scene graphs can be very deep
+    // (instanced model subtrees, hierarchical rigs) and Canvas already
+    // uses this pattern in CScene::SubmitRenderables for the same reason.
+    std::vector<XSceneGraphNode*> stack;
+    stack.reserve(64);
+    stack.push_back(root);
+
+    BVHPrimitiveId nextId = 0;
+    while (!stack.empty())
+    {
+        XSceneGraphNode* node = stack.back();
+        stack.pop_back();
+        if (!node)
+            continue;
+
+        // Compute the global matrix ONCE per node and reuse across all of
+        // its elements.  GetGlobalMatrix may cascade through dirty-flag
+        // propagation; not paying that cost per element matters for nodes
+        // carrying multiple bound elements.
+        const Math::FloatMatrix4x4 worldMtx = node->GetGlobalMatrix();
+
+        const UINT elementCount = node->GetBoundElementCount();
+        bool nodeContributed = false;
+        for (UINT i = 0; i < elementCount; ++i)
+        {
+            XSceneGraphElement* element = node->GetBoundElement(i);
+            if (!element)
+                continue;
+
+            const Math::AABB localBounds = element->GetLocalBounds();
+            if (localBounds.IsEmpty())
+                continue; // non-renderable (lights, cameras) or genuinely empty
+
+            const Math::AABB worldBounds = localBounds.Transform(worldMtx);
+            if (worldBounds.IsEmpty())
+                continue; // transform of empty stays empty; defensive double-check
+
+            BVHPrimitive prim;
+            prim.WorldBounds = worldBounds;
+            prim.Node        = node;
+            prim.Id          = nextId++;
+            prim.Flags       = BVHPrimitiveFlag_Static;
+            m_Primitives.push_back(prim);
+            nodeContributed = true;
+        }
+
+        if (nodeContributed)
+            m_RenderableNodes.insert(node);
+
+        for (XSceneGraphNode* child = node->GetFirstChild();
+             child;
+             child = node->GetNextChild(child))
+        {
+            stack.push_back(child);
+        }
+    }
+
+    if (!m_Primitives.empty())
+        m_BVH.Build(m_Primitives.data(), m_Primitives.size());
+
+    // Mark built even when the scene has no renderable elements;
+    // otherwise we'd re-walk the graph every frame.
+    m_Built = true;
+}
+
+bool SceneBVH::IsRenderableNode(XSceneGraphNode* node) const
+{
+    if (!node)
+        return false;
+    return m_RenderableNodes.find(node) != m_RenderableNodes.end();
+}
+
+void SceneBVH::QueryFrustum(XCamera* camera,
+                            std::unordered_set<XSceneGraphNode*>& outVisibleNodes) const
+{
+    outVisibleNodes.clear();
+    if (!camera || !m_Built || m_Primitives.empty())
+        return;
+
+    const Math::FloatMatrix4x4 vp = camera->GetViewProjectionMatrix();
+    const Math::Frustum f = Math::Frustum::FromViewProjection(vp, /*reverseZ*/ true);
+    QueryFrustum(f, outVisibleNodes);
+}
+
+void SceneBVH::QueryFrustum(const Math::Frustum& frustum,
+                            std::unordered_set<XSceneGraphNode*>& outVisibleNodes) const
+{
+    outVisibleNodes.clear();
+    if (!m_Built || m_Primitives.empty())
+        return;
+
+    m_VisiblePrimitiveScratch.clear();
+    m_BVH.QueryFrustum(m_Primitives.data(), frustum, m_VisiblePrimitiveScratch);
+
+    // Dedup primitives back to nodes.  Reserving against the primitive
+    // count is a safe over-estimate that avoids rehashing for typical
+    // scenes where most nodes carry a single renderable element.
+    outVisibleNodes.reserve(m_VisiblePrimitiveScratch.size());
+    for (uint32_t primIdx : m_VisiblePrimitiveScratch)
+        outVisibleNodes.insert(m_Primitives[primIdx].Node);
+}
+
+} // namespace Canvas

--- a/src/CanvasCore/SceneBVH.h
+++ b/src/CanvasCore/SceneBVH.h
@@ -1,0 +1,88 @@
+//================================================================================================
+// SceneBVH
+//
+// Owns the primitive table for a CScene and the BVH built over it.
+//
+//   1. Walk a scene-graph subtree on demand (Build) to extract a flat
+//      list of BVHPrimitive from every (node, element) pair whose
+//      element reports a non-empty GetLocalBounds().
+//   2. Hand that primitive list to BVH for SAH-binned construction.
+//   3. Service per-frame frustum queries, deduplicating primitives back
+//      to their owning XSceneGraphNode* so the caller can filter
+//      SubmitForRender at node granularity.
+//
+// Today this class does NOT:
+//   - track dirty transforms (no refit, no per-frame update)
+//   - distinguish static from dynamic (all primitives treated as static)
+//   - hold an influence-BVH for light culling
+//   - own ray-query state for hybrid RT
+//================================================================================================
+
+#pragma once
+
+#include "pch.h"
+#include "BVH.h"
+
+namespace Canvas
+{
+
+struct XCamera;
+struct XSceneGraphNode;
+
+class SceneBVH
+{
+public:
+    SceneBVH() = default;
+
+    // Walks the subtree rooted at `root`, extracts renderable
+    // primitives, and builds the BVH.  Discards any prior state first;
+    // safe to call repeatedly when scene topology changes.  Null root
+    // is a no-op (leaves IsBuilt() == false).
+    //
+    // Primitive criterion: an element contributes a primitive iff
+    // element->GetLocalBounds() is non-empty.  Lights, cameras, and
+    // other non-renderable elements honor this contract by returning
+    // the empty sentinel (see XSceneGraphElement::GetLocalBounds), so
+    // they are skipped automatically with no per-type branching here.
+    void Build(XSceneGraphNode* root);
+
+    // Reset to the pre-Build state.  Frees BVH/primitive memory.
+    void Clear();
+
+    bool IsBuilt() const { return m_Built; }
+    size_t PrimitiveCount() const { return m_Primitives.size(); }
+    size_t RenderableNodeCount() const { return m_RenderableNodes.size(); }
+
+    // True iff `node` had at least one renderable element at the last
+    // successful Build.  Nodes added to the graph after Build return
+    // false -- they will (correctly) bypass the visibility filter until
+    // the next Build.  This is the right behavior for a static BVH:
+    // a stale BVH never *hides* geometry, it only fails to cull it.
+    bool IsRenderableNode(XSceneGraphNode* node) const;
+
+    // Compute the visible-node set for the given camera's view frustum.
+    // The output set is cleared first.  Multiple primitives belonging
+    // to the same node collapse to a single entry, matching the
+    // granularity at which RenderQueue::SubmitForRender consumes.
+    // Empty / unbuilt BVH produces an empty set without error.
+    void QueryFrustum(XCamera* camera,
+                      std::unordered_set<XSceneGraphNode*>& outVisibleNodes) const;
+
+    // Direct frustum query (no camera dereference) for callers that
+    // already have a Frustum in hand (tests, future shadow passes).
+    void QueryFrustum(const Math::Frustum& frustum,
+                      std::unordered_set<XSceneGraphNode*>& outVisibleNodes) const;
+
+private:
+    std::vector<BVHPrimitive> m_Primitives;
+    std::unordered_set<XSceneGraphNode*> m_RenderableNodes;
+    BVH m_BVH;
+
+    // Scratch space reused across QueryFrustum calls to avoid per-frame
+    // allocation; mutable so const queries can populate it.
+    mutable std::vector<uint32_t> m_VisiblePrimitiveScratch;
+
+    bool m_Built = false;
+};
+
+} // namespace Canvas

--- a/src/CanvasCore/SceneGraph.h
+++ b/src/CanvasCore/SceneGraph.h
@@ -35,10 +35,10 @@ public:
         return Gem::Result::Success;
     }
 
-    // Default returns an empty AABB.  Geometric elements (CMeshInstance,
+    // Default returns an empty AABB.  Renderable elements (CMeshInstance,
     // CModel, ...) override with their node-local vertex envelope.
-    // Non-geometric elements -- lights, cameras, ambient -- inherit
-    // this default so they contribute nothing to geometric aggregates.
+    // Non-renderable elements -- lights, cameras, ambient -- inherit
+    // this default so they contribute nothing to renderable aggregates.
     GEMMETHOD_(Math::AABB, GetLocalBounds)() const
     {
         return Math::AABB{};
@@ -47,7 +47,7 @@ public:
     // Default returns an empty AABB.  Elements that affect a bounded
     // region of space (finite-range XLight, XCamera) override with
     // their node-local influence volume.  Infinite-influence elements
-    // (directional / ambient lights) and pure-geometry elements
+    // (directional / ambient lights) and pure-renderable elements
     // (XMeshInstance, XModel) inherit this default.
     GEMMETHOD_(Math::AABB, GetLocalInfluenceBounds)() const
     {

--- a/src/CanvasGfx12/Lib/RenderQueue12.cpp
+++ b/src/CanvasGfx12/Lib/RenderQueue12.cpp
@@ -1450,7 +1450,7 @@ void CRenderQueue12::EnsureCompositePSO(DXGI_FORMAT rtvFormat)
     ID3D12Device* pD3DDevice = m_pDevice->GetD3DDevice();
 
     // Composite root signature:
-    //   Slot 0: Root CBV (b0) -- per-frame constants (camera, lights, sky params)
+    //   Slot 0: Root CBV (b0) -- per-frame constants (camera, sky params, light count)
     //   Slot 1: Descriptor table with SRV[8] at t0-t7:
     //             t0-t2 = G-buffer (normals, diffuse, world pos) [Texture2D]
     //             t3-t4 = optional skybox cubes A / B            [TextureCube]
@@ -1461,6 +1461,10 @@ void CRenderQueue12::EnsureCompositePSO(DXGI_FORMAT rtvFormat)
     //           SkyHasCubemap / HasStars / HasMoon / per-light ShadowFlags
     //           flags select active branches.  The sun has no texture
     //           (procedural disc).
+    //   Slot 2: Root SRV (t8) -- StructuredBuffer<HlslLight> for the
+    //           per-frame light table.  Sized to PerFrame.LightCount;
+    //           always bound (a single dummy element when no lights
+    //           are visible so the SRV slot is never null).
     //   Static sampler s0: point/clamp  (exact G-buffer texel fetch)
     //   Static sampler s1: linear/wrap  (cube sampling for skybox + stars)
     //   Static sampler s2: linear/clamp (moon billboard quad)
@@ -1504,10 +1508,16 @@ void CRenderQueue12::EnsureCompositePSO(DXGI_FORMAT rtvFormat)
     srvRange.Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 8, 0, 0,  // SRV[8] at t0-t7, space0
                   D3D12_DESCRIPTOR_RANGE_FLAG_DESCRIPTORS_VOLATILE, 0);
 
-    std::vector<CD3DX12_ROOT_PARAMETER1> compositeRootParams(2);
+    std::vector<CD3DX12_ROOT_PARAMETER1> compositeRootParams(3);
     compositeRootParams[0].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE,
                                                     D3D12_SHADER_VISIBILITY_PIXEL);
     compositeRootParams[1].InitAsDescriptorTable(1, &srvRange, D3D12_SHADER_VISIBILITY_PIXEL);
+    // Lights structured buffer as a root SRV at t8.  Root SRVs are
+    // untyped; the shader's `StructuredBuffer<HlslLight>` declaration
+    // supplies the element shape.  DATA_VOLATILE matches the upload
+    // ring's per-frame lifecycle (contents change every submit).
+    compositeRootParams[2].InitAsShaderResourceView(8, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE,
+                                                    D3D12_SHADER_VISIBILITY_PIXEL);
 
     CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC compositeRootSigDesc(
         static_cast<UINT>(compositeRootParams.size()),
@@ -2506,7 +2516,14 @@ Gem::Result CRenderQueue12::SubmitLight(Canvas::XLight *pLight)
     if (m_HasVisibleLightFilter && m_VisibleLightFilter.find(pLight) == m_VisibleLightFilter.end())
         return Gem::Result::Success;
 
-    HlslTypes::HlslLight& gpu = m_Lights[m_LightCount++];
+    // Reserve to a reasonable capacity on first push so typical scenes
+    // hit at most one allocation per process lifetime.
+    if (m_Lights.empty())
+        m_Lights.reserve(64);
+
+    m_Lights.emplace_back();
+    HlslTypes::HlslLight& gpu = m_Lights.back();
+    ++m_LightCount;
     gpu = {};
     gpu.Type = static_cast<uint32_t>(pLight->GetType());
 
@@ -2770,8 +2787,24 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
             ? (1.0f / static_cast<float>(m_ShadowAtlasSize))
             : 0.0f;
 
+        // Per-frame light table -- uploaded into the ring as a
+        // structured buffer and bound to the composite root SRV at
+        // slot 2 (t8).  Always allocate at least one element so the
+        // root SRV is never bound to a null address (D3D12 validation
+        // tolerates it but it's a sharper contract to keep the buffer
+        // always valid; the shader's loop is gated by LightCount so
+        // the dummy element is never read).
+        const uint32_t lightUploadCount = (m_LightCount > 0) ? m_LightCount : 1u;
+        const uint64_t lightUploadBytes =
+            static_cast<uint64_t>(lightUploadCount) * sizeof(HlslTypes::HlslLight);
+        HostWriteAllocation lightsHw;
+        Gem::ThrowGemError(m_UploadRing.AllocateFromRing(lightUploadBytes, lightsHw));
         if (m_LightCount > 0)
-            memcpy(frameConstants.Lights, m_Lights, m_LightCount * sizeof(HlslTypes::HlslLight));
+            memcpy(lightsHw.pMapped, m_Lights.data(),
+                   static_cast<size_t>(m_LightCount) * sizeof(HlslTypes::HlslLight));
+        else
+            memset(lightsHw.pMapped, 0, sizeof(HlslTypes::HlslLight));
+        const D3D12_GPU_VIRTUAL_ADDRESS lightsSRVAddress = lightsHw.GpuAddress;
 
         // Upload per-frame constants and bind to root CBV (slot 0, register b0)
         constexpr uint64_t cbAlignment = D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT;
@@ -3353,7 +3386,7 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
                 D3D12_BARRIER_LAYOUT_RENDER_TARGET,
                 D3D12_BARRIER_SYNC_RENDER_TARGET,
                 D3D12_BARRIER_ACCESS_RENDER_TARGET);
-            compositeTask.RecordFunc = [frameCBVAddress, baseGpuHandle, this](ID3D12GraphicsCommandList* pCL)
+            compositeTask.RecordFunc = [frameCBVAddress, lightsSRVAddress, baseGpuHandle, this](ID3D12GraphicsCommandList* pCL)
             {
                 // No clear: every back-buffer pixel is written by the composite PS
                 // (background fills empty G-buffer pixels).
@@ -3366,6 +3399,7 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
                 pCL->SetDescriptorHeaps(2, m_DescriptorHeapsArray);
                 pCL->SetGraphicsRootConstantBufferView(0, frameCBVAddress);
                 pCL->SetGraphicsRootDescriptorTable(1, baseGpuHandle);
+                pCL->SetGraphicsRootShaderResourceView(2, lightsSRVAddress);
                 pCL->DrawInstanced(3, 1, 0, 0);
             };
             m_GpuTaskGraph.InsertTask(compositeTask);
@@ -3436,6 +3470,8 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
         m_FrameWorldBounds.Reset();
         m_VisibleLightFilter.clear();
         m_HasVisibleLightFilter = false;
+        m_Lights.clear();
+        m_LightCount = 0;
         m_pCurrentSwapChain = nullptr;
         m_pActiveCamera = nullptr;
         return e.Result();
@@ -3444,6 +3480,7 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
     m_pCurrentSwapChain = nullptr;
     m_pActiveCamera = nullptr;
     m_LightCount = 0;
+    m_Lights.clear();
     m_NextShadowTileIndex = 0;
     m_PendingShadowCasters.clear();
     m_FrameWorldBounds.Reset();

--- a/src/CanvasGfx12/Lib/RenderQueue12.cpp
+++ b/src/CanvasGfx12/Lib/RenderQueue12.cpp
@@ -2348,6 +2348,30 @@ GEMMETHODIMP_(void) CRenderQueue12::SetActiveCamera(Canvas::XCamera *pCamera)
 }
 
 //------------------------------------------------------------------------------------------------
+GEMMETHODIMP_(void) CRenderQueue12::SetVisibleLights(Canvas::XLight* const* ppLights, size_t count)
+{
+    // The filter is ALWAYS installed by this call -- including when
+    // count == 0, which expresses "no light is visible this frame,
+    // drop every SubmitLight."  Callers that never invoke
+    // SetVisibleLights leave the filter inactive (the default), in
+    // which case SubmitLight accepts every enabled light in
+    // submission order up to the cap.  EndFrame restores the
+    // inactive state so each frame starts clean.
+    m_VisibleLightFilter.clear();
+    m_HasVisibleLightFilter = true;
+
+    if (ppLights == nullptr || count == 0)
+        return;
+
+    m_VisibleLightFilter.reserve(count);
+    for (size_t i = 0; i < count; ++i)
+    {
+        if (ppLights[i])
+            m_VisibleLightFilter.insert(ppLights[i]);
+    }
+}
+
+//------------------------------------------------------------------------------------------------
 GEMMETHODIMP_(void) CRenderQueue12::SetBackground(const Canvas::GfxBackgroundDesc *pDesc)
 {
     if (pDesc)
@@ -2472,6 +2496,14 @@ Gem::Result CRenderQueue12::SubmitLight(Canvas::XLight *pLight)
 
     // Skip disabled lights
     if (!(pLight->GetFlags() & Canvas::LightFlags::Enabled))
+        return Gem::Result::Success;
+
+    // Per-frame visibility filter (installed by Scene from the
+    // LightBVH frustum cull).  When active, only lights present in
+    // the allowlist consume a slot; the rest are silently dropped
+    // just like the cap above.  Inactive filter -> every enabled
+    // light passes through in submission order.
+    if (m_HasVisibleLightFilter && m_VisibleLightFilter.find(pLight) == m_VisibleLightFilter.end())
         return Gem::Result::Success;
 
     HlslTypes::HlslLight& gpu = m_Lights[m_LightCount++];
@@ -3402,6 +3434,8 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
         m_DisplacedDraws.clear();
         m_PendingShadowCasters.clear();
         m_FrameWorldBounds.Reset();
+        m_VisibleLightFilter.clear();
+        m_HasVisibleLightFilter = false;
         m_pCurrentSwapChain = nullptr;
         m_pActiveCamera = nullptr;
         return e.Result();
@@ -3413,5 +3447,10 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
     m_NextShadowTileIndex = 0;
     m_PendingShadowCasters.clear();
     m_FrameWorldBounds.Reset();
+    // Light visibility filter is per-frame: clear here so the next
+    // frame starts in "no filter" mode unless Scene installs one
+    // again.  Matches the contract documented on SetVisibleLights.
+    m_VisibleLightFilter.clear();
+    m_HasVisibleLightFilter = false;
     return Gem::Result::Success;
 }

--- a/src/CanvasGfx12/Lib/RenderQueue12.cpp
+++ b/src/CanvasGfx12/Lib/RenderQueue12.cpp
@@ -2553,28 +2553,37 @@ Gem::Result CRenderQueue12::SubmitLight(Canvas::XLight *pLight)
     if (pNode)
     {
         auto world = pNode->GetGlobalMatrix();
-        if (pLight->GetType() == Canvas::LightType::Directional || pLight->GetType() == Canvas::LightType::Spot)
+        if (pLight->GetType() == Canvas::LightType::Directional)
         {
             Canvas::Math::FloatVector4 dir(world[0][0], world[0][1], world[0][2], 0.0f);
             dir = dir.Normalize();
             gpu.DirectionOrPosition = { dir[0], dir[1], dir[2], 0.0f };
+        }
+        else if (pLight->GetType() == Canvas::LightType::Spot)
+        {
+            // Spot lights need both the world-space apex (consumed as
+            // DirectionOrPosition by the shader's `toLight = pos - P`
+            // computation) and a unit forward axis for the cone test.
+            // The axis goes into DirectionAndSpot below; the position
+            // belongs here.
+            gpu.DirectionOrPosition = { world[3][0], world[3][1], world[3][2], 1.0f };
 
-            if (pLight->GetType() == Canvas::LightType::Spot)
-            {
-                float innerAngle = 0.785398f;
-                float outerAngle = 1.047198f;
-                pLight->GetSpotAngles(&innerAngle, &outerAngle);
-                if (innerAngle > outerAngle)
-                    std::swap(innerAngle, outerAngle);
+            Canvas::Math::FloatVector4 dir(world[0][0], world[0][1], world[0][2], 0.0f);
+            dir = dir.Normalize();
 
-                gpu.DirectionAndSpot = {
-                    dir[0],
-                    dir[1],
-                    dir[2],
-                    std::cos(outerAngle * 0.5f)
-                };
-                gpu.Color.w = std::cos(innerAngle * 0.5f);
-            }
+            float innerAngle = 0.785398f;
+            float outerAngle = 1.047198f;
+            pLight->GetSpotAngles(&innerAngle, &outerAngle);
+            if (innerAngle > outerAngle)
+                std::swap(innerAngle, outerAngle);
+
+            gpu.DirectionAndSpot = {
+                dir[0],
+                dir[1],
+                dir[2],
+                std::cos(outerAngle * 0.5f)
+            };
+            gpu.Color.w = std::cos(innerAngle * 0.5f);
         }
         else
         {
@@ -2583,8 +2592,10 @@ Gem::Result CRenderQueue12::SubmitLight(Canvas::XLight *pLight)
     }
     else
     {
-        if (pLight->GetType() == Canvas::LightType::Directional || pLight->GetType() == Canvas::LightType::Spot)
+        if (pLight->GetType() == Canvas::LightType::Directional)
             gpu.DirectionOrPosition = { 0.0f, 1.0f, 0.0f, 0.0f };
+        else if (pLight->GetType() == Canvas::LightType::Spot)
+            gpu.DirectionOrPosition = { 0.0f, 0.0f, 0.0f, 1.0f };
     }
 
     if (pLight->GetType() == Canvas::LightType::Directional)

--- a/src/CanvasGfx12/Lib/RenderQueue12.cpp
+++ b/src/CanvasGfx12/Lib/RenderQueue12.cpp
@@ -1450,7 +1450,8 @@ void CRenderQueue12::EnsureCompositePSO(DXGI_FORMAT rtvFormat)
     ID3D12Device* pD3DDevice = m_pDevice->GetD3DDevice();
 
     // Composite root signature:
-    //   Slot 0: Root CBV (b0) -- per-frame constants (camera, sky params, light count)
+    //   Slot 0: Root CBV (b0) -- per-frame constants (camera, sky params, light count,
+    //           tile grid dimensions).
     //   Slot 1: Descriptor table with SRV[8] at t0-t7:
     //             t0-t2 = G-buffer (normals, diffuse, world pos) [Texture2D]
     //             t3-t4 = optional skybox cubes A / B            [TextureCube]
@@ -1465,6 +1466,13 @@ void CRenderQueue12::EnsureCompositePSO(DXGI_FORMAT rtvFormat)
     //           per-frame light table.  Sized to PerFrame.LightCount;
     //           always bound (a single dummy element when no lights
     //           are visible so the SRV slot is never null).
+    //   Slot 3: Root SRV (t9) -- StructuredBuffer<uint> per-tile light
+    //           count for Forward+ tile binning.  One uint per tile in
+    //           row-major order (tile (x, y) at index y * TileCountX + x).
+    //   Slot 4: Root SRV (t10) -- StructuredBuffer<uint> per-tile
+    //           packed light-index lists, MAX_LIGHTS_PER_TILE uints per
+    //           tile (fixed stride).  Indexed by tile-base + i, with
+    //           i < TileLightCounts[tile].
     //   Static sampler s0: point/clamp  (exact G-buffer texel fetch)
     //   Static sampler s1: linear/wrap  (cube sampling for skybox + stars)
     //   Static sampler s2: linear/clamp (moon billboard quad)
@@ -1508,7 +1516,7 @@ void CRenderQueue12::EnsureCompositePSO(DXGI_FORMAT rtvFormat)
     srvRange.Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 8, 0, 0,  // SRV[8] at t0-t7, space0
                   D3D12_DESCRIPTOR_RANGE_FLAG_DESCRIPTORS_VOLATILE, 0);
 
-    std::vector<CD3DX12_ROOT_PARAMETER1> compositeRootParams(3);
+    std::vector<CD3DX12_ROOT_PARAMETER1> compositeRootParams(5);
     compositeRootParams[0].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE,
                                                     D3D12_SHADER_VISIBILITY_PIXEL);
     compositeRootParams[1].InitAsDescriptorTable(1, &srvRange, D3D12_SHADER_VISIBILITY_PIXEL);
@@ -1517,6 +1525,12 @@ void CRenderQueue12::EnsureCompositePSO(DXGI_FORMAT rtvFormat)
     // supplies the element shape.  DATA_VOLATILE matches the upload
     // ring's per-frame lifecycle (contents change every submit).
     compositeRootParams[2].InitAsShaderResourceView(8, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE,
+                                                    D3D12_SHADER_VISIBILITY_PIXEL);
+    // Per-tile light counts (t9) and packed indices (t10) for the
+    // Forward+ binner.  Both rebuilt and re-uploaded each frame.
+    compositeRootParams[3].InitAsShaderResourceView(9, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE,
+                                                    D3D12_SHADER_VISIBILITY_PIXEL);
+    compositeRootParams[4].InitAsShaderResourceView(10, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE,
                                                     D3D12_SHADER_VISIBILITY_PIXEL);
 
     CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC compositeRootSigDesc(
@@ -2501,7 +2515,7 @@ Canvas::Math::FloatMatrix4x4 CRenderQueue12::BuildDirectionalShadowMatrixFromBou
 //------------------------------------------------------------------------------------------------
 Gem::Result CRenderQueue12::SubmitLight(Canvas::XLight *pLight)
 {
-    if (!pLight || m_LightCount >= MAX_LIGHTS_PER_REGION)
+    if (!pLight)
         return Gem::Result::Success;
 
     // Skip disabled lights
@@ -2510,9 +2524,9 @@ Gem::Result CRenderQueue12::SubmitLight(Canvas::XLight *pLight)
 
     // Per-frame visibility filter (installed by Scene from the
     // LightBVH frustum cull).  When active, only lights present in
-    // the allowlist consume a slot; the rest are silently dropped
-    // just like the cap above.  Inactive filter -> every enabled
-    // light passes through in submission order.
+    // the allowlist consume a slot; the rest are silently dropped.
+    // Inactive filter -> every enabled light passes through in
+    // submission order.
     if (m_HasVisibleLightFilter && m_VisibleLightFilter.find(pLight) == m_VisibleLightFilter.end())
         return Gem::Result::Success;
 
@@ -2646,6 +2660,155 @@ Gem::Result CRenderQueue12::SubmitLight(Canvas::XLight *pLight)
 }
 
 //------------------------------------------------------------------------------------------------
+void CRenderQueue12::BuildTileLightLists(uint32_t framebufferWidth,
+                                         uint32_t framebufferHeight,
+                                         const Canvas::Math::FloatMatrix4x4& viewProj)
+{
+    using Canvas::Math::AABB;
+    using Canvas::Math::Frustum;
+    using Canvas::Math::FloatVector4;
+    using Canvas::Math::FloatMatrix4x4;
+
+    if (framebufferWidth == 0 || framebufferHeight == 0)
+    {
+        m_LightTileCountX = 0;
+        m_LightTileCountY = 0;
+        m_TileLightCounts.clear();
+        m_TileLightIndices.clear();
+        return;
+    }
+
+    constexpr uint32_t kTileSize = LIGHT_TILE_SIZE_PIXELS;
+    constexpr uint32_t kPerTile  = MAX_LIGHTS_PER_TILE;
+    m_LightTileCountX = (framebufferWidth  + kTileSize - 1) / kTileSize;
+    m_LightTileCountY = (framebufferHeight + kTileSize - 1) / kTileSize;
+    const uint32_t totalTiles = m_LightTileCountX * m_LightTileCountY;
+
+    m_TileLightCounts.assign(totalTiles, 0);
+    m_TileLightIndices.assign(static_cast<size_t>(totalTiles) * kPerTile, 0);
+
+    if (m_LightCount == 0)
+        return;
+
+    // Split the per-frame light table into:
+    //   alwaysIndices   -- ambient / directional / area (no spatial
+    //                      bound; copied into every tile),
+    //   spatialIndices  -- point / spot (gated by per-tile frustum).
+    // Influence AABBs for spatial lights are derived from HlslLight
+    // fields (DirectionOrPosition.xyz as the apex/center,
+    // AttenuationAndRange.w as the cutoff distance, which is already
+    // the precomputed range CPU-side).  For spot lights this uses the
+    // bounding sphere of the cone -- conservative at the tile tier,
+    // tightened later if profiling shows it matters.
+    std::vector<uint32_t> alwaysIndices;
+    std::vector<uint32_t> spatialIndices;
+    std::vector<AABB>     spatialBoxes;
+    alwaysIndices.reserve(m_LightCount);
+    spatialIndices.reserve(m_LightCount);
+    spatialBoxes.reserve(m_LightCount);
+
+    for (uint32_t i = 0; i < m_LightCount; ++i)
+    {
+        const HlslTypes::HlslLight& L = m_Lights[i];
+        const bool spatial =
+            (L.Type == LIGHT_POINT) || (L.Type == LIGHT_SPOT);
+
+        if (!spatial)
+        {
+            alwaysIndices.push_back(i);
+            continue;
+        }
+
+        const float r = L.AttenuationAndRange.w;
+        if (r <= 0.0f)
+            continue; // zero-cutoff light -- contributes nothing anywhere
+
+        const float cx = L.DirectionOrPosition.x;
+        const float cy = L.DirectionOrPosition.y;
+        const float cz = L.DirectionOrPosition.z;
+        spatialIndices.push_back(i);
+        spatialBoxes.emplace_back(
+            FloatVector4(cx - r, cy - r, cz - r, 0.0f),
+            FloatVector4(cx + r, cy + r, cz + r, 0.0f));
+    }
+
+    // Seed every tile with the always-on lights (capped at kPerTile;
+    // in practice a scene has at most a handful, so the cap is never
+    // a real constraint here -- the loop just defends against
+    // pathological inputs).
+    const uint32_t alwaysToCopy = std::min<uint32_t>(
+        static_cast<uint32_t>(alwaysIndices.size()), kPerTile);
+    for (uint32_t t = 0; t < totalTiles; ++t)
+    {
+        uint32_t* dst = &m_TileLightIndices[static_cast<size_t>(t) * kPerTile];
+        for (uint32_t a = 0; a < alwaysToCopy; ++a)
+            dst[a] = alwaysIndices[a];
+        m_TileLightCounts[t] = alwaysToCopy;
+    }
+
+    if (spatialIndices.empty())
+        return;
+
+    // Per-tile binning.  Build a sub-frustum from the camera's view-
+    // projection scaled to each tile's NDC sub-rect and test each
+    // spatial light's influence AABB against it.  The sub-rect remap
+    // matrix R rescales clip-space xy from [xMin,xMax] x [yMin,yMax]
+    // to [-1,+1]^2 so the existing Frustum::FromViewProjection plane
+    // extraction works unchanged.  Reverse-Z near/far are inherited
+    // from the camera projection.
+    const float fbW = static_cast<float>(framebufferWidth);
+    const float fbH = static_cast<float>(framebufferHeight);
+
+    for (uint32_t ty = 0; ty < m_LightTileCountY; ++ty)
+    {
+        for (uint32_t tx = 0; tx < m_LightTileCountX; ++tx)
+        {
+            const float xPxMin = static_cast<float>(tx * kTileSize);
+            const float xPxMax = std::min<float>(static_cast<float>((tx + 1) * kTileSize), fbW);
+            const float yPxMin = static_cast<float>(ty * kTileSize);
+            const float yPxMax = std::min<float>(static_cast<float>((ty + 1) * kTileSize), fbH);
+
+            // Screen-pixel origin is top-left; NDC y is bottom-up, so
+            // flip the y mapping.
+            const float xNdcMin = (xPxMin / fbW) * 2.0f - 1.0f;
+            const float xNdcMax = (xPxMax / fbW) * 2.0f - 1.0f;
+            const float yNdcMax = 1.0f - (yPxMin / fbH) * 2.0f;
+            const float yNdcMin = 1.0f - (yPxMax / fbH) * 2.0f;
+
+            const float cx = (xNdcMin + xNdcMax) * 0.5f;
+            const float cy = (yNdcMin + yNdcMax) * 0.5f;
+            const float sx = (xNdcMax - xNdcMin);
+            const float sy = (yNdcMax - yNdcMin);
+            // Guard against zero-size tiles at the framebuffer edge.
+            if (sx <= 0.0f || sy <= 0.0f)
+                continue;
+
+            FloatMatrix4x4 R = Canvas::Math::IdentityMatrix<float, 4, 4>();
+            R[0][0] =  2.0f / sx;
+            R[1][1] =  2.0f / sy;
+            R[3][0] = -2.0f * cx / sx;
+            R[3][1] = -2.0f * cy / sy;
+
+            const FloatMatrix4x4 tileVP = viewProj * R;
+            const Frustum tileFrustum = Frustum::FromViewProjection(tileVP, /*reverseZ*/ true);
+
+            const uint32_t tileIdx = ty * m_LightTileCountX + tx;
+            uint32_t*      dst     = &m_TileLightIndices[static_cast<size_t>(tileIdx) * kPerTile];
+            uint32_t       cnt     = m_TileLightCounts[tileIdx];
+
+            for (size_t si = 0; si < spatialIndices.size(); ++si)
+            {
+                if (cnt >= kPerTile)
+                    break;
+                if (tileFrustum.IntersectsAABB(spatialBoxes[si]))
+                    dst[cnt++] = spatialIndices[si];
+            }
+            m_TileLightCounts[tileIdx] = cnt;
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------
 void CRenderQueue12::ResolveShadowCasters()
 {
     // No geometry bounds -> no shadow region this frame.  Casters
@@ -2750,6 +2913,23 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
         frameConstants.LightCount = m_LightCount;
         frameConstants.LightCullThreshold = kDefaultLightCullThreshold;
 
+        // Forward+ tile binning.  Must run after SubmitLight has
+        // finished populating m_Lights (so spatial lights have valid
+        // positions) and after ResolveShadowCasters has written its
+        // bookkeeping back into m_Lights[].  The resulting tile grid
+        // is uploaded below alongside the per-frame light table.
+        {
+            Canvas::Math::FloatMatrix4x4 vp{};
+            if (m_pActiveCamera)
+                vp = m_pActiveCamera->GetViewProjectionMatrix();
+            const uint32_t fbW = static_cast<uint32_t>(m_BackBufferViewport.Width);
+            const uint32_t fbH = static_cast<uint32_t>(m_BackBufferViewport.Height);
+            BuildTileLightLists(fbW, fbH, vp);
+        }
+        frameConstants.LightTileCountX     = m_LightTileCountX;
+        frameConstants.LightTileCountY     = m_LightTileCountY;
+        frameConstants.LightTileSizePixels = LIGHT_TILE_SIZE_PIXELS;
+
         // Scene background -> per-frame constants.  The cube SRVs themselves
         // are bound below as part of the composite descriptor table.
         {
@@ -2816,6 +2996,38 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
         else
             memset(lightsHw.pMapped, 0, sizeof(HlslTypes::HlslLight));
         const D3D12_GPU_VIRTUAL_ADDRESS lightsSRVAddress = lightsHw.GpuAddress;
+
+        // Per-tile light counts and packed indices for Forward+ tile
+        // binning -- both rebuilt each frame by BuildTileLightLists
+        // above.  Always allocate at least one element each so the
+        // root SRVs are never bound to a null GPU address (the shader
+        // gates reads by LightTileCountX/Y, so unused tail entries
+        // are never sampled).
+        const uint32_t totalTiles = m_LightTileCountX * m_LightTileCountY;
+        const uint32_t tileCountElems = (totalTiles > 0) ? totalTiles : 1u;
+        const uint64_t tileCountsBytes =
+            static_cast<uint64_t>(tileCountElems) * sizeof(uint32_t);
+        HostWriteAllocation tileCountsHw;
+        Gem::ThrowGemError(m_UploadRing.AllocateFromRing(tileCountsBytes, tileCountsHw));
+        if (totalTiles > 0)
+            memcpy(tileCountsHw.pMapped, m_TileLightCounts.data(),
+                   static_cast<size_t>(totalTiles) * sizeof(uint32_t));
+        else
+            memset(tileCountsHw.pMapped, 0, sizeof(uint32_t));
+        const D3D12_GPU_VIRTUAL_ADDRESS tileCountsSRVAddress = tileCountsHw.GpuAddress;
+
+        const uint32_t tileIndicesElems =
+            (totalTiles > 0) ? (totalTiles * MAX_LIGHTS_PER_TILE) : 1u;
+        const uint64_t tileIndicesBytes =
+            static_cast<uint64_t>(tileIndicesElems) * sizeof(uint32_t);
+        HostWriteAllocation tileIndicesHw;
+        Gem::ThrowGemError(m_UploadRing.AllocateFromRing(tileIndicesBytes, tileIndicesHw));
+        if (totalTiles > 0)
+            memcpy(tileIndicesHw.pMapped, m_TileLightIndices.data(),
+                   static_cast<size_t>(totalTiles) * MAX_LIGHTS_PER_TILE * sizeof(uint32_t));
+        else
+            memset(tileIndicesHw.pMapped, 0, sizeof(uint32_t));
+        const D3D12_GPU_VIRTUAL_ADDRESS tileIndicesSRVAddress = tileIndicesHw.GpuAddress;
 
         // Upload per-frame constants and bind to root CBV (slot 0, register b0)
         constexpr uint64_t cbAlignment = D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT;
@@ -3397,7 +3609,7 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
                 D3D12_BARRIER_LAYOUT_RENDER_TARGET,
                 D3D12_BARRIER_SYNC_RENDER_TARGET,
                 D3D12_BARRIER_ACCESS_RENDER_TARGET);
-            compositeTask.RecordFunc = [frameCBVAddress, lightsSRVAddress, baseGpuHandle, this](ID3D12GraphicsCommandList* pCL)
+            compositeTask.RecordFunc = [frameCBVAddress, lightsSRVAddress, tileCountsSRVAddress, tileIndicesSRVAddress, baseGpuHandle, this](ID3D12GraphicsCommandList* pCL)
             {
                 // No clear: every back-buffer pixel is written by the composite PS
                 // (background fills empty G-buffer pixels).
@@ -3411,6 +3623,8 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
                 pCL->SetGraphicsRootConstantBufferView(0, frameCBVAddress);
                 pCL->SetGraphicsRootDescriptorTable(1, baseGpuHandle);
                 pCL->SetGraphicsRootShaderResourceView(2, lightsSRVAddress);
+                pCL->SetGraphicsRootShaderResourceView(3, tileCountsSRVAddress);
+                pCL->SetGraphicsRootShaderResourceView(4, tileIndicesSRVAddress);
                 pCL->DrawInstanced(3, 1, 0, 0);
             };
             m_GpuTaskGraph.InsertTask(compositeTask);
@@ -3483,6 +3697,10 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
         m_HasVisibleLightFilter = false;
         m_Lights.clear();
         m_LightCount = 0;
+        m_TileLightCounts.clear();
+        m_TileLightIndices.clear();
+        m_LightTileCountX = 0;
+        m_LightTileCountY = 0;
         m_pCurrentSwapChain = nullptr;
         m_pActiveCamera = nullptr;
         return e.Result();
@@ -3492,6 +3710,10 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
     m_pActiveCamera = nullptr;
     m_LightCount = 0;
     m_Lights.clear();
+    m_TileLightCounts.clear();
+    m_TileLightIndices.clear();
+    m_LightTileCountX = 0;
+    m_LightTileCountY = 0;
     m_NextShadowTileIndex = 0;
     m_PendingShadowCasters.clear();
     m_FrameWorldBounds.Reset();

--- a/src/CanvasGfx12/Lib/RenderQueue12.h
+++ b/src/CanvasGfx12/Lib/RenderQueue12.h
@@ -599,6 +599,18 @@ public:
     HlslTypes::HlslLight m_Lights[MAX_LIGHTS_PER_REGION] = {};
     uint32_t m_LightCount = 0;
 
+    // Optional per-frame light visibility filter installed via
+    // XGfxRenderQueue::SetVisibleLights and consulted by SubmitLight.
+    // When m_HasVisibleLightFilter is true, only XLight pointers
+    // present in m_VisibleLightFilter are accepted (an empty set with
+    // the flag true means "drop all"); when false (the default and
+    // post-EndFrame state) SubmitLight accepts every call up to the
+    // light cap.  The Scene installs this with the frustum-culled
+    // visible-light set so the GPU only sees lights that can affect
+    // visible pixels.
+    std::unordered_set<Canvas::XLight*> m_VisibleLightFilter;
+    bool                                m_HasVisibleLightFilter = false;
+
     // Shadow-caster intents recorded by SubmitLight (one per enabled
     // directional light with LightFlags::CastsShadows).  Resolved at
     // EndFrame, after scene traversal is complete and m_FrameWorldBounds
@@ -691,6 +703,7 @@ public:
     GEMMETHOD(SubmitForRender)(Canvas::XSceneGraphNode *pNode) final;
     GEMMETHOD(SubmitForUIRender)(Canvas::XUIGraphNode *pNode) final;
     GEMMETHOD_(void, SetActiveCamera)(Canvas::XCamera *pCamera) final;
+    GEMMETHOD_(void, SetVisibleLights)(Canvas::XLight* const* ppLights, size_t count) final;
     GEMMETHOD_(void, SetBackground)(const Canvas::GfxBackgroundDesc *pDesc) final;
     GEMMETHOD_(void, SetGeometryWireframe)(bool wireframe) final;
     GEMMETHOD_(bool, GetGeometryWireframe)() const final;

--- a/src/CanvasGfx12/Lib/RenderQueue12.h
+++ b/src/CanvasGfx12/Lib/RenderQueue12.h
@@ -596,7 +596,13 @@ public:
     Gem::TGemPtr<Canvas::XGfxSurface> m_pSkyCubeB;
     Gem::TGemPtr<Canvas::XGfxSurface> m_pStarsCube;
     Gem::TGemPtr<Canvas::XGfxSurface> m_pMoonTexture;
-    HlslTypes::HlslLight m_Lights[MAX_LIGHTS_PER_REGION] = {};
+    // Per-frame light table accumulated by SubmitLight and uploaded as
+    // a StructuredBuffer<HlslLight> at the composite root SRV slot.
+    // Reserved up-front so SubmitLight is push_back-only without
+    // routinely reallocating; reused (not freed) across frames via
+    // clear() in EndFrame.
+    std::vector<HlslTypes::HlslLight> m_Lights;
+    // Mirrors m_Lights.size() and indexes PendingShadowCaster::LightSlotIndex.
     uint32_t m_LightCount = 0;
 
     // Optional per-frame light visibility filter installed via

--- a/src/CanvasGfx12/Lib/RenderQueue12.h
+++ b/src/CanvasGfx12/Lib/RenderQueue12.h
@@ -617,6 +617,19 @@ public:
     std::unordered_set<Canvas::XLight*> m_VisibleLightFilter;
     bool                                m_HasVisibleLightFilter = false;
 
+    // Forward+ tile binning state.  Built each frame by
+    // BuildTileLightLists() after SubmitLight has finished
+    // accumulating m_Lights; uploaded as two structured buffers
+    // (counts at t9, indices at t10) consumed by the composite PS.
+    // Sizes scale with framebuffer dimensions: m_LightTileCountX/Y =
+    // ceil(W/H over LIGHT_TILE_SIZE_PIXELS), m_TileLightCounts has
+    // one uint per tile, m_TileLightIndices has MAX_LIGHTS_PER_TILE
+    // uints per tile (fixed-stride layout).
+    std::vector<uint32_t> m_TileLightCounts;
+    std::vector<uint32_t> m_TileLightIndices;
+    uint32_t              m_LightTileCountX = 0;
+    uint32_t              m_LightTileCountY = 0;
+
     // Shadow-caster intents recorded by SubmitLight (one per enabled
     // directional light with LightFlags::CastsShadows).  Resolved at
     // EndFrame, after scene traversal is complete and m_FrameWorldBounds
@@ -936,6 +949,18 @@ private:
     // from EndFrame after scene traversal has completed and before
     // per-frame constants are uploaded.
     void ResolveShadowCasters();
+
+    // Build the per-frame Forward+ tile light-index lists from the
+    // accumulated m_Lights and the current framebuffer dimensions.
+    // Constructs an off-center sub-frustum per screen tile (computed
+    // from the active camera's view-projection), intersects each
+    // light's influence AABB against it, and packs the resulting
+    // indices into m_TileLightCounts / m_TileLightIndices.  Always-on
+    // lights (ambient / directional) are pre-baked into every tile's
+    // list so the composite PS only runs one loop per pixel.
+    void BuildTileLightLists(uint32_t framebufferWidth,
+                             uint32_t framebufferHeight,
+                             const Canvas::Math::FloatMatrix4x4& viewProj);
 
     // Build a texel-snapped world-to-shadow-clip matrix for a directional
     // light, fitting the ortho box to a world-space scene AABB.  Projects

--- a/src/CanvasGfx12/Lib/UploadRing.cpp
+++ b/src/CanvasGfx12/Lib/UploadRing.cpp
@@ -13,6 +13,8 @@ void CUploadRing::Initialize(CDevice12* pDevice, uint64_t initialSize)
     m_Size = initialSize;
     m_WriteOffset = 0;
     m_ReadOffset = 0;
+    m_InFlightBytes = 0;
+    m_BytesAllocatedThisFrame = 0;
     m_LastCompletedFenceValue = 0;
     m_FrameMarkers.clear();
     // Resource creation is lazy — EnsureResource() on first allocate.
@@ -31,6 +33,8 @@ void CUploadRing::Shutdown()
     m_Size = 0;
     m_WriteOffset = 0;
     m_ReadOffset = 0;
+    m_InFlightBytes = 0;
+    m_BytesAllocatedThisFrame = 0;
     m_FrameMarkers.clear();
     m_pDevice = nullptr;
 }
@@ -82,10 +86,10 @@ Gem::Result CUploadRing::AllocateFromRing(uint64_t sizeInBytes, HostWriteAllocat
 
         EnsureResource();
 
+        // Single source of truth.  No head==tail ambiguity: full <=>
+        // m_InFlightBytes == m_Size; empty <=> m_InFlightBytes == 0.
         auto availableBytes = [&]() -> uint64_t {
-            if (m_WriteOffset >= m_ReadOffset)
-                return m_Size - m_WriteOffset + m_ReadOffset;
-            return m_ReadOffset - m_WriteOffset;
+            return m_Size - m_InFlightBytes;
         };
 
         // Pad m_WriteOffset up to the requested alignment before measuring fit.
@@ -96,17 +100,15 @@ Gem::Result CUploadRing::AllocateFromRing(uint64_t sizeInBytes, HostWriteAllocat
         uint64_t writeOffset = alignedWrite();
         uint64_t padHead     = writeOffset - m_WriteOffset;
         uint64_t needed      = padHead + alignedSize;
-        uint64_t available   = availableBytes();
 
         // Try reclaiming completed submissions first.
-        if (needed > available)
+        if (needed > availableBytes())
         {
             Reclaim(m_LastCompletedFenceValue);
-            available = availableBytes();
         }
 
         // Grow if still insufficient.
-        if (needed > available)
+        if (needed > availableBytes())
         {
             uint64_t target = m_Size ? m_Size : (alignedSize + alignment);
             while (target < alignedSize + alignment)
@@ -116,7 +118,13 @@ Gem::Result CUploadRing::AllocateFromRing(uint64_t sizeInBytes, HostWriteAllocat
             padHead     = writeOffset - m_WriteOffset;
         }
 
-        // Handle wrap-around (the aligned start + payload doesn't fit before m_Size).
+        // Handle wrap-around (the aligned start + payload doesn't fit
+        // before m_Size).  The slack from m_WriteOffset to m_Size is
+        // abandoned by the wrap; charge it to in-flight bytes so it is
+        // reclaimed alongside this frame's data (one MarkSubmissionEnd
+        // later) rather than appearing as free space that doesn't
+        // exist.
+        uint64_t wrapSlack = 0;
         if (writeOffset + alignedSize > m_Size)
         {
             if (alignedSize + alignment > m_ReadOffset)
@@ -126,8 +134,9 @@ Gem::Result CUploadRing::AllocateFromRing(uint64_t sizeInBytes, HostWriteAllocat
             }
             else
             {
+                wrapSlack    = m_Size - m_WriteOffset;
                 m_WriteOffset = 0;
-                writeOffset = 0;  // already a multiple of alignment
+                writeOffset   = 0;  // already a multiple of alignment
             }
             padHead = writeOffset - m_WriteOffset;
         }
@@ -139,6 +148,9 @@ Gem::Result CUploadRing::AllocateFromRing(uint64_t sizeInBytes, HostWriteAllocat
         out.ResourceOffset = writeOffset;
 
         m_WriteOffset = writeOffset + alignedSize;
+        const uint64_t bytesConsumed = padHead + alignedSize + wrapSlack;
+        m_InFlightBytes           += bytesConsumed;
+        m_BytesAllocatedThisFrame += bytesConsumed;
         return Gem::Result::Success;
     }
     catch (const Gem::GemError& e) { return e.Result(); }
@@ -148,7 +160,8 @@ Gem::Result CUploadRing::AllocateFromRing(uint64_t sizeInBytes, HostWriteAllocat
 //------------------------------------------------------------------------------------------------
 void CUploadRing::MarkSubmissionEnd(UINT64 fenceValue)
 {
-    m_FrameMarkers.push_back({ fenceValue, m_WriteOffset });
+    m_FrameMarkers.push_back({ fenceValue, m_WriteOffset, m_BytesAllocatedThisFrame });
+    m_BytesAllocatedThisFrame = 0;
 
     // Tag any retired resources whose retiring submission is the one we're
     // about to signal. A retired resource may have been referenced by commands
@@ -165,12 +178,21 @@ void CUploadRing::MarkSubmissionEnd(UINT64 fenceValue)
 void CUploadRing::Reclaim(UINT64 completedFenceValue)
 {
     m_LastCompletedFenceValue = completedFenceValue;
+    // Advance the read pointer (and shrink the in-flight count) by the
+    // size of each fully-retired frame's footprint.  Using BytesInFrame
+    // instead of jumping m_ReadOffset to the marker's recorded
+    // WriteOffset keeps the read pointer monotonically advancing through
+    // the ring (modulo wrap), which prevents the post-wrap regression
+    // that the WriteOffset-jump approach suffered from when a wrap'd
+    // frame's offset was numerically smaller than the previous
+    // frame's.
     while (!m_FrameMarkers.empty())
     {
         auto& oldest = m_FrameMarkers.front();
         if (oldest.FenceValue > completedFenceValue)
             break;
-        m_ReadOffset = oldest.WriteOffset;
+        m_InFlightBytes -= oldest.BytesInFrame;
+        m_ReadOffset     = (m_ReadOffset + oldest.BytesInFrame) % m_Size;
         m_FrameMarkers.pop_front();
     }
 
@@ -206,6 +228,12 @@ void CUploadRing::GrowTo(uint64_t newSize)
     m_Size = newSize;
     m_WriteOffset = 0;
     m_ReadOffset = 0;
+    // New ring starts fully empty.  Any in-flight bytes from the old
+    // ring are tracked separately via m_RetiredResources -- the new
+    // ring has no relation to that memory and accounts only for its
+    // own allocations from here on.
+    m_InFlightBytes = 0;
+    m_BytesAllocatedThisFrame = 0;
     m_FrameMarkers.clear();
     EnsureResource();
 }

--- a/src/CanvasGfx12/Lib/UploadRing.h
+++ b/src/CanvasGfx12/Lib/UploadRing.h
@@ -83,12 +83,22 @@ private:
     uint64_t m_Size        = 0;
     uint64_t m_WriteOffset = 0;
     uint64_t m_ReadOffset  = 0;
+    // Authoritative fill level.  Removes the head==tail full-vs-empty
+    // ambiguity that the head/tail-only model suffered from: the head
+    // (m_WriteOffset) and tail (m_ReadOffset) are cached convenience
+    // positions, but every free-space query reads m_InFlightBytes.
+    // Invariant: m_WriteOffset == (m_ReadOffset + m_InFlightBytes) % m_Size.
+    uint64_t m_InFlightBytes           = 0;
+    // Bytes consumed since the most recent MarkSubmissionEnd, recorded
+    // into the next FrameMarker so Reclaim can decrement the right amount.
+    uint64_t m_BytesAllocatedThisFrame = 0;
     UINT64   m_LastCompletedFenceValue = 0;
 
     struct FrameMarker
     {
-        UINT64 FenceValue;
-        uint64_t WriteOffset;
+        UINT64   FenceValue;
+        uint64_t WriteOffset;     // m_WriteOffset at the time of MarkSubmissionEnd (kept for debugging)
+        uint64_t BytesInFrame;    // amount to decrement m_InFlightBytes by when this marker is reclaimed
     };
     std::deque<FrameMarker> m_FrameMarkers;
 

--- a/src/CanvasGfx12/README.md
+++ b/src/CanvasGfx12/README.md
@@ -377,8 +377,9 @@ All PSOs are created lazily on first use and cached for the lifetime of the rend
 - 5 render targets matching the G-buffer formats. D32_Float depth with reverse-Z.
 
 **Composition pass**:
-- Slot 0: root CBV at b0 for per-frame constants (camera, lights, shadow atlas parameters, sky/background parameters).
+- Slot 0: root CBV at b0 for per-frame constants (camera, light count, shadow atlas parameters, sky/background parameters).
 - Slot 1: descriptor table with SRV[8] at t0-t7: G-buffer (normals t0, diffuse t1, world position t2), optional skybox cube A (t3), optional skybox cube B (t4), optional stars cube (t5), optional moon billboard texture (t6), optional shadow atlas (t7). Unbound slots hold null SRVs; shader flags select active branches.
+- Slot 2: root SRV at t8 for `StructuredBuffer<HlslLight>` (the per-frame light table, sized to `PerFrame.LightCount`). Always bound; a one-element dummy is uploaded when no lights are visible so the slot is never null.
 - Static samplers: s0 = point/clamp (G-buffer texel fetch), s1 = linear/wrap (cubemap / stars sampling), s2 = linear/clamp (moon billboard), s3 = hardware PCF comparison sampler (GREATER_EQUAL reverse-Z, OPAQUE_WHITE border for shadow atlas).
 - Single render target at back-buffer format. No depth.
 
@@ -444,7 +445,7 @@ The displaced shadow PSO shares the VS and HS bytecode (ensuring shadow tessella
 
 ### Light Submission
 
-Lights are accumulated during scene graph traversal. Each light's attenuation and cull distance are pre-computed on the CPU and packed into an `HlslLight` struct. Up to `MAX_LIGHTS_PER_REGION` (16) lights are uploaded as part of the per-frame constant buffer.
+Lights are accumulated during scene graph traversal (gated by the LightBVH-driven visibility filter that `XScene::SubmitRenderables` installs via `XGfxRenderQueue::SetVisibleLights`). Each light's attenuation and cull distance are pre-computed on the CPU and packed into an `HlslLight` struct. The packed lights are uploaded each frame as a `StructuredBuffer<HlslLight>` (bound at root slot 2 / shader register `t8`), sized to the actual visible-light count up to a defensive engine cap of `MAX_LIGHTS_PER_REGION` (1024). The composite shader iterates the buffer in a single loop bounded by `PerFrame.LightCount`.
 
 For directional lights with `LightFlags::CastsShadows`, `SubmitLight` additionally:
 
@@ -634,7 +635,7 @@ Shaders are compiled offline from HLSL source to CSO files using DXC. CMake cust
 
 `HlslTypes.h` is included by both C++ and HLSL code. It defines the constant buffer layouts that cross the CPU/GPU boundary:
 
-**HlslPerFrameConstants** (register b0): view-projection matrix, camera world position and basis vectors (for fullscreen view-ray reconstruction), light count, exposure multiplier, shadow atlas global parameters (`ShadowAtlasSize`, `ShadowPcfTexelStep`), scene background parameters (solid color, skybox cubemap flags and blend factor, orientation quaternion, intensity, stars parameters, procedural sun disc parameters, moon billboard parameters), and an array of `HlslLight` structs.
+**HlslPerFrameConstants** (register b0): view-projection matrix, camera world position and basis vectors (for fullscreen view-ray reconstruction), light count, exposure multiplier, shadow atlas global parameters (`ShadowAtlasSize`, `ShadowPcfTexelStep`), and scene background parameters (solid color, skybox cubemap flags and blend factor, orientation quaternion, intensity, stars parameters, procedural sun disc parameters, moon billboard parameters). The per-frame light table itself is **not** in this CB; it lives in a separate `StructuredBuffer<HlslLight>` bound at `t8` and sized to `LightCount`.
 
 **HlslPerObjectConstants** (register b1): world transform, inverse-transpose for normals, base color / emissive / roughness-metallic-AO factors, and material flag bits.
 

--- a/src/CanvasGfx12/README.md
+++ b/src/CanvasGfx12/README.md
@@ -377,9 +377,11 @@ All PSOs are created lazily on first use and cached for the lifetime of the rend
 - 5 render targets matching the G-buffer formats. D32_Float depth with reverse-Z.
 
 **Composition pass**:
-- Slot 0: root CBV at b0 for per-frame constants (camera, light count, shadow atlas parameters, sky/background parameters).
+- Slot 0: root CBV at b0 for per-frame constants (camera, light count, tile-grid dimensions, shadow atlas parameters, sky/background parameters).
 - Slot 1: descriptor table with SRV[8] at t0-t7: G-buffer (normals t0, diffuse t1, world position t2), optional skybox cube A (t3), optional skybox cube B (t4), optional stars cube (t5), optional moon billboard texture (t6), optional shadow atlas (t7). Unbound slots hold null SRVs; shader flags select active branches.
 - Slot 2: root SRV at t8 for `StructuredBuffer<HlslLight>` (the per-frame light table, sized to `PerFrame.LightCount`). Always bound; a one-element dummy is uploaded when no lights are visible so the slot is never null.
+- Slot 3: root SRV at t9 for `StructuredBuffer<uint>` — per-tile active light count (one uint per screen tile in row-major order).
+- Slot 4: root SRV at t10 for `StructuredBuffer<uint>` — packed per-tile light indices, `MAX_LIGHTS_PER_TILE` uints per tile (fixed stride). Indexed as `tile * MAX_LIGHTS_PER_TILE + i` for `i < TileLightCounts[tile]`. Both tile buffers are rebuilt by `BuildTileLightLists` each frame and uploaded into the ring; a one-element dummy is bound when the framebuffer has no tiles.
 - Static samplers: s0 = point/clamp (G-buffer texel fetch), s1 = linear/wrap (cubemap / stars sampling), s2 = linear/clamp (moon billboard), s3 = hardware PCF comparison sampler (GREATER_EQUAL reverse-Z, OPAQUE_WHITE border for shadow atlas).
 - Single render target at back-buffer format. No depth.
 
@@ -445,7 +447,9 @@ The displaced shadow PSO shares the VS and HS bytecode (ensuring shadow tessella
 
 ### Light Submission
 
-Lights are accumulated during scene graph traversal (gated by the LightBVH-driven visibility filter that `XScene::SubmitRenderables` installs via `XGfxRenderQueue::SetVisibleLights`). Each light's attenuation and cull distance are pre-computed on the CPU and packed into an `HlslLight` struct. The packed lights are uploaded each frame as a `StructuredBuffer<HlslLight>` (bound at root slot 2 / shader register `t8`), sized to the actual visible-light count up to a defensive engine cap of `MAX_LIGHTS_PER_REGION` (1024). The composite shader iterates the buffer in a single loop bounded by `PerFrame.LightCount`.
+Lights are accumulated during scene graph traversal (gated by the LightBVH-driven visibility filter that `XScene::SubmitRenderables` installs via `XGfxRenderQueue::SetVisibleLights`). Each light's attenuation and cull distance are pre-computed on the CPU and packed into an `HlslLight` struct. The packed lights are uploaded each frame as a `StructuredBuffer<HlslLight>` (bound at root slot 2 / shader register `t8`), sized to the actual visible-light count — no fixed cap; the count scales with scene complexity the same way mesh-instance count does.
+
+After SubmitLight aggregation and `ResolveShadowCasters`, `BuildTileLightLists` divides the framebuffer into `LIGHT_TILE_SIZE_PIXELS` × `LIGHT_TILE_SIZE_PIXELS` (32×32) screen tiles, constructs each tile's sub-frustum by remapping the camera view-projection to the tile's NDC sub-rect, and bins each spatial light's influence AABB against it. Always-on lights (ambient / directional) are pre-baked into every tile's list. The resulting per-tile counts and packed indices are uploaded as two `StructuredBuffer<uint>`s (root slots 3 / 4 at `t9` / `t10`) capped at `MAX_LIGHTS_PER_TILE` (32) per tile. The composite shader picks the owning tile from `SV_Position`, reads its count, and iterates only those light indices — turning the per-pixel cost from O(visible lights) into O(tile lights).
 
 For directional lights with `LightFlags::CastsShadows`, `SubmitLight` additionally:
 
@@ -635,7 +639,7 @@ Shaders are compiled offline from HLSL source to CSO files using DXC. CMake cust
 
 `HlslTypes.h` is included by both C++ and HLSL code. It defines the constant buffer layouts that cross the CPU/GPU boundary:
 
-**HlslPerFrameConstants** (register b0): view-projection matrix, camera world position and basis vectors (for fullscreen view-ray reconstruction), light count, exposure multiplier, shadow atlas global parameters (`ShadowAtlasSize`, `ShadowPcfTexelStep`), and scene background parameters (solid color, skybox cubemap flags and blend factor, orientation quaternion, intensity, stars parameters, procedural sun disc parameters, moon billboard parameters). The per-frame light table itself is **not** in this CB; it lives in a separate `StructuredBuffer<HlslLight>` bound at `t8` and sized to `LightCount`.
+**HlslPerFrameConstants** (register b0): view-projection matrix, camera world position and basis vectors (for fullscreen view-ray reconstruction), light count, exposure multiplier, shadow atlas global parameters (`ShadowAtlasSize`, `ShadowPcfTexelStep`), Forward+ tile-grid parameters (`LightTileCountX`, `LightTileCountY`, `LightTileSizePixels`), and scene background parameters (solid color, skybox cubemap flags and blend factor, orientation quaternion, intensity, stars parameters, procedural sun disc parameters, moon billboard parameters). The per-frame light table itself is **not** in this CB; it lives in a separate `StructuredBuffer<HlslLight>` bound at `t8` and sized to `LightCount`. The tile-binning indirection lives in two more `StructuredBuffer<uint>`s at `t9` / `t10`.
 
 **HlslPerObjectConstants** (register b1): world transform, inverse-transpose for normals, base color / emissive / roughness-metallic-AO factors, and material flag bits.
 

--- a/src/CanvasLightGarden/CMakeLists.txt
+++ b/src/CanvasLightGarden/CMakeLists.txt
@@ -1,0 +1,71 @@
+# CanvasLightGarden - procedural deterministic many-light sample for Canvas
+cmake_minimum_required(VERSION 3.24)
+
+include(${CMAKE_SOURCE_DIR}/cmake/FetchFonts.cmake)
+
+add_executable(CanvasLightGarden WIN32
+    CanvasLightGarden.cpp
+    pch.h
+    targetver.h
+    QLogAdapter.h
+)
+
+set_target_properties(CanvasLightGarden PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+    OUTPUT_NAME "CanvasLightGarden"
+)
+
+target_include_directories(CanvasLightGarden PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../Inc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../Common
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../deps/InCommand/inc
+)
+
+target_compile_definitions(CanvasLightGarden PRIVATE
+    $<$<CONFIG:Debug>:_DEBUG>
+    $<$<CONFIG:Release>:NDEBUG>
+    NOMINMAX
+)
+
+if(WIN32)
+    target_compile_definitions(CanvasLightGarden PRIVATE WIN32 _WINDOWS)
+
+    target_link_libraries(CanvasLightGarden PRIVATE
+        kernel32 user32 gdi32 winspool comdlg32 advapi32
+        shell32 ole32 oleaut32 uuid odbc32 odbccp32 comctl32
+    )
+
+    set_target_properties(CanvasLightGarden PROPERTIES
+        LINK_FLAGS "/SUBSYSTEM:WINDOWS"
+    )
+endif()
+
+target_link_libraries(CanvasLightGarden PRIVATE
+    CanvasCore
+    CanvasPlatformWin32
+    InCommandLib
+    InCommandHeaders
+)
+
+target_precompile_headers(CanvasLightGarden PRIVATE pch.h)
+
+install(TARGETS CanvasLightGarden
+    RUNTIME DESTINATION ${CANVAS_INSTALL_DEST}/bin
+)
+install(FILES $<TARGET_PDB_FILE:CanvasLightGarden> DESTINATION ${CANVAS_INSTALL_DEST}/bin OPTIONAL)
+
+install(FILES
+    "${CANVAS_FONT_INTER}"
+    "${CANVAS_FONT_JETBRAINSMONO}"
+    DESTINATION ${CANVAS_INSTALL_DEST}/bin/fonts
+)
+
+add_custom_command(TARGET CanvasLightGarden POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${CANVAS_RUNTIME_DIR}/fonts"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CANVAS_FONT_INTER}"         "${CANVAS_RUNTIME_DIR}/fonts/"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CANVAS_FONT_JETBRAINSMONO}" "${CANVAS_RUNTIME_DIR}/fonts/"
+    COMMENT "Staging fonts to runtime directory (CanvasLightGarden)"
+    VERBATIM
+)

--- a/src/CanvasLightGarden/CanvasLightGarden.cpp
+++ b/src/CanvasLightGarden/CanvasLightGarden.cpp
@@ -8,13 +8,10 @@
 // cells) one spot light, both seeded from a fixed PRNG so the layout
 // is bit-identical across runs.
 //
-// The sample exists to give the BVH + tiled-lighting work a target
-// scene that is heavy on light count and instance count but trivial
-// on art-asset dependencies.  Today it renders with the engine's
-// existing per-frame light list (directional sun gets shadows; point
-// and spot lights run shadow-free pending engine support).  As the
-// engine grows a light-influence BVH and view-space tiling, this app
-// is the first place those features will pay off visibly.
+// The sample exists as a stress test for light culling, view-space
+// tiling, and shadow culling: heavy on light count and instance count
+// but trivial on art-asset dependencies.  Directional sun gets
+// shadows; point and spot lights run shadow-free.
 //
 // Controls:
 //   WASD / Space-Ctrl : move
@@ -224,7 +221,7 @@ struct GardenConfig
     uint32_t Seed         = 0xC0FFEEu;
     float    SpotChance   = 0.30f;   // P(spot light per cell)
     uint32_t MaxPropsCell = 3;
-    bool     ShadowsAll   = false;   // future: enable per-light shadows
+    bool     ShadowsAll   = false;   // request shadows on every light (no-op for point/spot)
 };
 
 class GardenBuilder

--- a/src/CanvasLightGarden/CanvasLightGarden.cpp
+++ b/src/CanvasLightGarden/CanvasLightGarden.cpp
@@ -330,7 +330,7 @@ public:
             const float py = cy + propOffset(rng) * 0.3f;
             const float px = cx + propOffset(rng) * 0.3f;
             AddPointLight(FloatVector4(px, py, h * 0.85f, 1),
-                          color, 6.0f, cfg.CellMeters * 0.9f,
+                          color, 8.0f, cfg.CellMeters * 0.9f,
                           cfg.ShadowsAll);
 
             // ~30% of cells: a spot light angled at a prop.
@@ -342,10 +342,22 @@ public:
                     std::cos(yaw) * std::cos(pitch),
                     std::sin(yaw) * std::cos(pitch),
                     std::sin(pitch), 0.0f);
+                // Spot palette mirrors the point palette but stays
+                // closer to white -- spots read as accent fixtures,
+                // not the cell's primary ambience.
+                const float spotWarmness = u01(rng);
+                const FloatVector4 spotColor = Lerp(
+                    FloatVector4(0.70f, 0.85f, 1.00f, 1.0f),   // cool
+                    FloatVector4(1.00f, 0.85f, 0.55f, 1.0f),   // warm
+                    spotWarmness);
                 AddSpotLight(FloatVector4(cx, cy, h * 1.1f, 1),
                              dir.Normalize(),
-                             FloatVector4(1.0f, 1.0f, 0.9f, 1.0f),
-                             8.0f,
+                             spotColor,
+                             // Authored as cone-flux: the shader divides by the
+                             // outer-cone solid angle, so 0.5 here lands at a
+                             // peak radiance on the same order as the point
+                             // lights above (which divide by 4*pi instead).
+                             0.5f,
                              cfg.CellMeters * 1.2f,
                              /*innerDeg*/ 18.0f,
                              /*outerDeg*/ 28.0f,

--- a/src/CanvasLightGarden/CanvasLightGarden.cpp
+++ b/src/CanvasLightGarden/CanvasLightGarden.cpp
@@ -1,0 +1,986 @@
+// CanvasLightGarden.cpp
+//
+// Procedural, deterministic many-light sample for the Canvas engine.
+//
+// Builds an N x N grid of open-topped "courtyard" cells from a small
+// palette of mesh-instanced primitives (floor plane, wall cube,
+// column, prop cube).  Each cell hosts one point light and (~30% of
+// cells) one spot light, both seeded from a fixed PRNG so the layout
+// is bit-identical across runs.
+//
+// The sample exists to give the BVH + tiled-lighting work a target
+// scene that is heavy on light count and instance count but trivial
+// on art-asset dependencies.  Today it renders with the engine's
+// existing per-frame light list (directional sun gets shadows; point
+// and spot lights run shadow-free pending engine support).  As the
+// engine grows a light-influence BVH and view-space tiling, this app
+// is the first place those features will pay off visibly.
+//
+// Controls:
+//   WASD / Space-Ctrl : move
+//   Mouse             : look
+//   Tab               : toggle camera capture
+//   Alt+Enter         : toggle borderless fullscreen
+//   Esc               : exit
+
+#include "pch.h"
+#include "QLogAdapter.h"
+#include "CanvasCore.h"
+#include "CanvasGfx.h"
+#include "TokenParser.h"
+#include "InCommand.h"
+
+#include <conio.h>
+
+// D3D12 Agility SDK version exports - same as the other Canvas apps.
+extern "C" { __declspec(dllexport) extern const UINT D3D12SDKVersion = 616; }
+extern "C" { __declspec(dllexport) extern const char* D3D12SDKPath = ".\\D3D12\\"; }
+
+namespace
+{
+
+using Canvas::Math::FloatVector2;
+using Canvas::Math::FloatVector4;
+using Canvas::Math::FloatMatrix4x4;
+using Canvas::Math::FloatQuaternion;
+
+// ------------------------------------------------------------------
+// Logger sink that writes to OutputDebugString + an optional log file
+// and (optionally) a dedicated console window.  Stripped-down
+// counterpart of the sink in CanvasModelViewer.
+// ------------------------------------------------------------------
+class CLogSink : public QLog::Sink
+{
+    std::ofstream m_logFile;
+    bool m_consoleOutput;
+
+public:
+    CLogSink(const std::filesystem::path& logFilePath, bool consoleOutput)
+        : m_consoleOutput(consoleOutput)
+    {
+        if (!logFilePath.empty())
+            m_logFile.open(logFilePath, std::ios::out | std::ios::trunc);
+    }
+
+    void Write(const QLog::Message& message) override
+    {
+        std::ostringstream oss;
+        oss << QLog::FormatTimestamp(message)
+            << QLog::ToString(message.level)
+            << ": " << message.text << '\n';
+        const std::string formatted = oss.str();
+
+        OutputDebugStringA(formatted.c_str());
+
+        if (m_logFile.is_open())
+        {
+            m_logFile << formatted;
+            m_logFile.flush();
+        }
+        if (m_consoleOutput)
+            fputs(formatted.c_str(), stdout);
+    }
+};
+
+class CConsole
+{
+    FILE* m_stdout = nullptr;
+    FILE* m_stderr = nullptr;
+
+public:
+    CConsole()
+    {
+        AllocConsole();
+        SetConsoleTitleA("CanvasLightGarden - Log");
+        freopen_s(&m_stdout, "CONOUT$", "w", stdout);
+        freopen_s(&m_stderr, "CONOUT$", "w", stderr);
+    }
+    ~CConsole()
+    {
+        if (m_stdout) fclose(m_stdout);
+        if (m_stderr) fclose(m_stderr);
+        FreeConsole();
+    }
+};
+
+// ------------------------------------------------------------------
+// Procedural cube (unit cube centered at origin, axis-aligned).  Each
+// face is a quad emitted via EmitQuad such that du x dv == +normal,
+// keeping the CCW winding outward-facing for the default D3D12
+// CULL_BACK rasterizer state.  Positions in [-0.5, +0.5]^3; normals
+// are face-aligned (each face owns 4 verts, 2 tris = 6 verts).
+// ------------------------------------------------------------------
+struct MeshCpu
+{
+    std::vector<FloatVector4> Positions;  // W = 1
+    std::vector<FloatVector4> Normals;    // W = 0
+};
+
+void EmitQuad(MeshCpu& mesh,
+              const FloatVector4& origin,
+              const FloatVector4& du,
+              const FloatVector4& dv,
+              const FloatVector4& normal)
+{
+    const FloatVector4 v0 = origin;
+    const FloatVector4 v1 = origin + du;
+    const FloatVector4 v2 = origin + du + dv;
+    const FloatVector4 v3 = origin + dv;
+
+    auto pos = [](const FloatVector4& v) {
+        return FloatVector4(v.X, v.Y, v.Z, 1.0f);
+    };
+
+    mesh.Positions.push_back(pos(v0));
+    mesh.Positions.push_back(pos(v1));
+    mesh.Positions.push_back(pos(v2));
+    mesh.Positions.push_back(pos(v0));
+    mesh.Positions.push_back(pos(v2));
+    mesh.Positions.push_back(pos(v3));
+
+    for (int i = 0; i < 6; ++i)
+        mesh.Normals.push_back(normal);
+}
+
+MeshCpu BuildUnitCube()
+{
+    MeshCpu m;
+    m.Positions.reserve(36);
+    m.Normals  .reserve(36);
+
+    // +X face
+    EmitQuad(m, { 0.5f, -0.5f, -0.5f, 0.0f }, { 0,  1, 0, 0 }, { 0, 0, 1, 0 }, {  1, 0, 0, 0 });
+    // -X face
+    EmitQuad(m, {-0.5f,  0.5f, -0.5f, 0.0f }, { 0, -1, 0, 0 }, { 0, 0, 1, 0 }, { -1, 0, 0, 0 });
+    // +Y face
+    EmitQuad(m, { 0.5f,  0.5f, -0.5f, 0.0f }, {-1,  0, 0, 0 }, { 0, 0, 1, 0 }, { 0,  1, 0, 0 });
+    // -Y face
+    EmitQuad(m, {-0.5f, -0.5f, -0.5f, 0.0f }, { 1,  0, 0, 0 }, { 0, 0, 1, 0 }, { 0, -1, 0, 0 });
+    // +Z face
+    EmitQuad(m, {-0.5f, -0.5f,  0.5f, 0.0f }, { 1,  0, 0, 0 }, { 0, 1, 0, 0 }, { 0, 0,  1, 0 });
+    // -Z face
+    EmitQuad(m, {-0.5f,  0.5f, -0.5f, 0.0f }, { 1,  0, 0, 0 }, { 0,-1, 0, 0 }, { 0, 0, -1, 0 });
+
+    return m;
+}
+
+// Single quad in the XY plane, normal +Z, spanning [-0.5, +0.5] x [-0.5, +0.5].
+MeshCpu BuildUnitPlane()
+{
+    MeshCpu m;
+    m.Positions.reserve(6);
+    m.Normals  .reserve(6);
+    EmitQuad(m, {-0.5f, -0.5f, 0.0f, 0.0f }, { 1, 0, 0, 0 }, { 0, 1, 0, 0 }, { 0, 0, 1, 0 });
+    return m;
+}
+
+Gem::Result CreateMeshFromCpu(Canvas::XGfxDevice* pDevice,
+                              const MeshCpu& cpu,
+                              const char* name,
+                              Canvas::XGfxMeshData** ppOut)
+{
+    Canvas::MeshDataGroupDesc group = {};
+    group.VertexCount = static_cast<uint32_t>(cpu.Positions.size());
+    group.pPositions  = cpu.Positions.data();
+    group.pNormals    = cpu.Normals.data();
+
+    Canvas::MeshDataDesc desc = {};
+    desc.pGroups    = &group;
+    desc.GroupCount = 1;
+    desc.pName      = name;
+    desc.Topology   = Canvas::GfxPrimitiveTopology::TriangleList;
+
+    return pDevice->CreateMeshData(desc, ppOut);
+}
+
+// Build the row-vector basis matrix that orients an object's local +X
+// (forward) along `forward`, and return the corresponding quaternion.
+FloatQuaternion QuaternionLookingAlong(const FloatVector4& forward,
+                                       const FloatVector4& worldUp)
+{
+    FloatMatrix4x4 m = Canvas::Math::IdentityMatrix<float, 4, 4>();
+    m[0] = forward.Normalize();
+    Canvas::Math::ComposePointToBasisVectors(worldUp, m[0], m[1], m[2]);
+    return Canvas::Math::QuaternionFromRotationMatrix(m);
+}
+
+// ------------------------------------------------------------------
+// Procedural scene builder.  All randomness flows from a single
+// std::mt19937 seeded by the caller; the layout is therefore
+// bit-identical across runs for a given (gridSize, seed) pair.
+// ------------------------------------------------------------------
+struct GardenStats
+{
+    uint32_t PointLights    = 0;
+    uint32_t SpotLights     = 0;
+    uint32_t MeshInstances  = 0;
+};
+
+struct GardenConfig
+{
+    uint32_t GridSize     = 8;       // cells per side
+    float    CellMeters   = 10.0f;   // size of each cell
+    float    WallHeight   = 2.0f;
+    uint32_t Seed         = 0xC0FFEEu;
+    float    SpotChance   = 0.30f;   // P(spot light per cell)
+    uint32_t MaxPropsCell = 3;
+    bool     ShadowsAll   = false;   // future: enable per-light shadows
+};
+
+class GardenBuilder
+{
+    Canvas::XCanvas*     m_pCanvas    = nullptr;
+    Canvas::XGfxDevice*  m_pDevice    = nullptr;
+    Canvas::XScene*      m_pScene     = nullptr;
+    Canvas::XLogger*     m_pLogger    = nullptr;
+
+    Gem::TGemPtr<Canvas::XGfxMeshData> m_pFloorMesh;
+    Gem::TGemPtr<Canvas::XGfxMeshData> m_pCubeMesh;
+
+    // Keep all instances alive for the lifetime of the scene.
+    std::vector<Gem::TGemPtr<Canvas::XMeshInstance>> m_Instances;
+    std::vector<Gem::TGemPtr<Canvas::XSceneGraphNode>> m_Nodes;
+    std::vector<Gem::TGemPtr<Canvas::XLight>> m_Lights;
+
+public:
+    GardenStats Stats;
+
+    GardenBuilder(Canvas::XCanvas* pCanvas,
+                  Canvas::XGfxDevice* pDevice,
+                  Canvas::XScene* pScene,
+                  Canvas::XLogger* pLogger)
+        : m_pCanvas(pCanvas), m_pDevice(pDevice), m_pScene(pScene), m_pLogger(pLogger)
+    {}
+
+    void Build(const GardenConfig& cfg)
+    {
+        // ---- Shared meshes (one of each, instanced many times) -----
+        Gem::ThrowGemError(CreateMeshFromCpu(m_pDevice, BuildUnitPlane(), "FloorPlane", &m_pFloorMesh));
+        Gem::ThrowGemError(CreateMeshFromCpu(m_pDevice, BuildUnitCube(),  "UnitCube",   &m_pCubeMesh));
+
+        const float W = cfg.CellMeters * cfg.GridSize; // world footprint
+        const float halfW = 0.5f * W;
+
+        // ---- Floor: one big scaled plane instance ------------------
+        AddInstance(m_pFloorMesh.Get(),
+                    FloatVector4(0, 0, 0, 1),
+                    FloatVector4(W, W, 1, 1),
+                    FloatQuaternion{},
+                    "Floor");
+
+        // ---- Baseline lights: ambient + directional sun ------------
+        AddAmbient(FloatVector4(0.08f, 0.09f, 0.12f, 1.0f), 0.4f);
+        AddDirectionalSun(FloatVector4(-0.4f, -0.3f, -1.0f, 0.0f),
+                          FloatVector4(1.00f, 0.95f, 0.85f, 1.0f),
+                          0.8f);
+
+        // ---- Per-cell content --------------------------------------
+        std::mt19937 rng(cfg.Seed);
+        std::uniform_real_distribution<float> u01(0.0f, 1.0f);
+        std::uniform_real_distribution<float> propScale(0.5f, 1.5f);
+        std::uniform_real_distribution<float> propOffset(-2.5f, 2.5f);
+        std::uniform_real_distribution<float> rotAngle(0.0f, 2.0f * 3.14159265f);
+        std::uniform_int_distribution<int>    propCount(1, static_cast<int>(cfg.MaxPropsCell));
+
+        for (uint32_t gy = 0; gy < cfg.GridSize; ++gy)
+        for (uint32_t gx = 0; gx < cfg.GridSize; ++gx)
+        {
+            const float cx = -halfW + (gx + 0.5f) * cfg.CellMeters;
+            const float cy = -halfW + (gy + 0.5f) * cfg.CellMeters;
+
+            // Cell perimeter walls.  Each cell owns its full perimeter
+            // (duplicates between cells are accepted; this is the
+            // stress test we wanted).  Walls are scaled cube
+            // instances 0.3m thick.
+            const float h = cfg.WallHeight;
+            const float t = 0.3f;
+            const float s = cfg.CellMeters;
+            const float halfS = 0.5f * s;
+            // +X wall, -X wall, +Y wall, -Y wall
+            AddInstance(m_pCubeMesh.Get(), { cx + halfS, cy, h * 0.5f, 1 }, {  t,  s,  h, 1 },
+                        FloatQuaternion{}, "Wall+X");
+            AddInstance(m_pCubeMesh.Get(), { cx - halfS, cy, h * 0.5f, 1 }, {  t,  s,  h, 1 },
+                        FloatQuaternion{}, "Wall-X");
+            AddInstance(m_pCubeMesh.Get(), { cx, cy + halfS, h * 0.5f, 1 }, {  s,  t,  h, 1 },
+                        FloatQuaternion{}, "Wall+Y");
+            AddInstance(m_pCubeMesh.Get(), { cx, cy - halfS, h * 0.5f, 1 }, {  s,  t,  h, 1 },
+                        FloatQuaternion{}, "Wall-Y");
+
+            // Props inside the cell.
+            const int props = propCount(rng);
+            for (int i = 0; i < props; ++i)
+            {
+                const float sx = propScale(rng);
+                const float sy = propScale(rng);
+                const float sz = propScale(rng) * 1.5f;
+                const float px = cx + propOffset(rng);
+                const float py = cy + propOffset(rng);
+                const float yaw = rotAngle(rng);
+                const FloatQuaternion q = Canvas::Math::QuaternionFromRotationMatrix(
+                    YawRotation(yaw));
+                AddInstance(m_pCubeMesh.Get(),
+                            FloatVector4(px, py, sz * 0.5f, 1),
+                            FloatVector4(sx, sy, sz, 1),
+                            q, "Prop");
+            }
+
+            // Per-cell point light (warm/cool palette).
+            const float warmness = u01(rng);
+            const FloatVector4 color = Lerp(
+                FloatVector4(0.45f, 0.65f, 1.00f, 1.0f),   // cool
+                FloatVector4(1.00f, 0.70f, 0.35f, 1.0f),   // warm
+                warmness);
+            const float py = cy + propOffset(rng) * 0.3f;
+            const float px = cx + propOffset(rng) * 0.3f;
+            AddPointLight(FloatVector4(px, py, h * 0.85f, 1),
+                          color, 6.0f, cfg.CellMeters * 0.9f,
+                          cfg.ShadowsAll);
+
+            // ~30% of cells: a spot light angled at a prop.
+            if (u01(rng) < cfg.SpotChance)
+            {
+                const float yaw = rotAngle(rng);
+                const float pitch = -0.6f - 0.5f * u01(rng); // angled downward
+                FloatVector4 dir(
+                    std::cos(yaw) * std::cos(pitch),
+                    std::sin(yaw) * std::cos(pitch),
+                    std::sin(pitch), 0.0f);
+                AddSpotLight(FloatVector4(cx, cy, h * 1.1f, 1),
+                             dir.Normalize(),
+                             FloatVector4(1.0f, 1.0f, 0.9f, 1.0f),
+                             8.0f,
+                             cfg.CellMeters * 1.2f,
+                             /*innerDeg*/ 18.0f,
+                             /*outerDeg*/ 28.0f,
+                             cfg.ShadowsAll);
+            }
+        }
+
+        Canvas::LogInfo(m_pLogger,
+            "LightGarden built: grid=%ux%u cell=%.1fm instances=%u pointLights=%u spotLights=%u",
+            cfg.GridSize, cfg.GridSize, cfg.CellMeters,
+            Stats.MeshInstances, Stats.PointLights, Stats.SpotLights);
+    }
+
+private:
+    static FloatVector4 Lerp(const FloatVector4& a, const FloatVector4& b, float t)
+    {
+        return a * (1.0f - t) + b * t;
+    }
+
+    static FloatMatrix4x4 YawRotation(float yaw)
+    {
+        FloatMatrix4x4 m = Canvas::Math::IdentityMatrix<float, 4, 4>();
+        const float c = std::cos(yaw), s = std::sin(yaw);
+        m[0] = FloatVector4( c,  s, 0, 0);
+        m[1] = FloatVector4(-s,  c, 0, 0);
+        m[2] = FloatVector4( 0,  0, 1, 0);
+        return m;
+    }
+
+    void AddInstance(Canvas::XGfxMeshData* pMesh,
+                     const FloatVector4& translation,
+                     const FloatVector4& scale,
+                     const FloatQuaternion& rotation,
+                     const char* nameHint)
+    {
+        Gem::TGemPtr<Canvas::XMeshInstance> pInst;
+        Gem::ThrowGemError(m_pCanvas->CreateMeshInstance(&pInst, nameHint));
+        pInst->SetMeshData(pMesh);
+
+        Gem::TGemPtr<Canvas::XSceneGraphNode> pNode;
+        Gem::ThrowGemError(m_pCanvas->CreateSceneGraphNode(&pNode, nameHint));
+        pNode->SetLocalTranslation(translation);
+        pNode->SetLocalScale(scale);
+        pNode->SetLocalRotation(rotation);
+        pNode->BindElement(pInst);
+        m_pScene->GetRootNode()->AddChild(pNode);
+
+        m_Instances.emplace_back(std::move(pInst));
+        m_Nodes    .emplace_back(std::move(pNode));
+        ++Stats.MeshInstances;
+    }
+
+    void AddAmbient(const FloatVector4& color, float intensity)
+    {
+        Gem::TGemPtr<Canvas::XLight> pLight;
+        Gem::ThrowGemError(m_pCanvas->CreateLight(Canvas::LightType::Ambient, &pLight, "Ambient"));
+        pLight->SetColor(color);
+        pLight->SetIntensity(intensity);
+        pLight->SetFlags(Canvas::LightFlags::Enabled);
+        AttachLight(pLight, FloatVector4(0, 0, 0, 1),
+                    FloatQuaternion{}, "AmbientNode");
+    }
+
+    void AddDirectionalSun(const FloatVector4& photonDir,
+                           const FloatVector4& color, float intensity)
+    {
+        Gem::TGemPtr<Canvas::XLight> pLight;
+        Gem::ThrowGemError(m_pCanvas->CreateLight(Canvas::LightType::Directional, &pLight, "Sun"));
+        pLight->SetColor(color);
+        pLight->SetIntensity(intensity);
+        pLight->SetFlags(Canvas::LightFlags::Enabled | Canvas::LightFlags::CastsShadows);
+        pLight->SetShadowResolution(2048);
+        pLight->SetShadowDepthBias(1e-4f, 2.0f, 0.5f);
+        const FloatQuaternion q = QuaternionLookingAlong(photonDir, { 0, 0, 1, 0 });
+        AttachLight(pLight, FloatVector4(0, 0, 0, 1), q, "SunNode");
+    }
+
+    void AddPointLight(const FloatVector4& position,
+                       const FloatVector4& color,
+                       float intensity, float range,
+                       bool wantShadows)
+    {
+        Gem::TGemPtr<Canvas::XLight> pLight;
+        Gem::ThrowGemError(m_pCanvas->CreateLight(Canvas::LightType::Point, &pLight, "PointLight"));
+        pLight->SetColor(color);
+        pLight->SetIntensity(intensity);
+        pLight->SetRange(range);
+        // Physically-loose inverse-square falloff.
+        pLight->SetAttenuation(1.0f, 0.0f, 1.0f / (0.25f * range * range));
+        UINT flags = Canvas::LightFlags::Enabled;
+        if (wantShadows) flags |= Canvas::LightFlags::CastsShadows;
+        pLight->SetFlags(flags);
+        AttachLight(pLight, position, FloatQuaternion{}, "PointNode");
+        ++Stats.PointLights;
+    }
+
+    void AddSpotLight(const FloatVector4& position,
+                      const FloatVector4& direction,
+                      const FloatVector4& color,
+                      float intensity, float range,
+                      float innerAngleDeg, float outerAngleDeg,
+                      bool wantShadows)
+    {
+        Gem::TGemPtr<Canvas::XLight> pLight;
+        Gem::ThrowGemError(m_pCanvas->CreateLight(Canvas::LightType::Spot, &pLight, "SpotLight"));
+        pLight->SetColor(color);
+        pLight->SetIntensity(intensity);
+        pLight->SetRange(range);
+        pLight->SetAttenuation(1.0f, 0.0f, 1.0f / (0.25f * range * range));
+        constexpr float kDegToRad = 3.14159265f / 180.0f;
+        pLight->SetSpotAngles(innerAngleDeg * kDegToRad, outerAngleDeg * kDegToRad);
+        UINT flags = Canvas::LightFlags::Enabled;
+        if (wantShadows) flags |= Canvas::LightFlags::CastsShadows;
+        pLight->SetFlags(flags);
+        const FloatQuaternion q = QuaternionLookingAlong(direction, { 0, 0, 1, 0 });
+        AttachLight(pLight, position, q, "SpotNode");
+        ++Stats.SpotLights;
+    }
+
+    void AttachLight(Gem::TGemPtr<Canvas::XLight>& pLight,
+                     const FloatVector4& position,
+                     const FloatQuaternion& rotation,
+                     const char* nodeName)
+    {
+        Gem::TGemPtr<Canvas::XSceneGraphNode> pNode;
+        Gem::ThrowGemError(m_pCanvas->CreateSceneGraphNode(&pNode, nodeName));
+        pNode->SetLocalTranslation(position);
+        pNode->SetLocalRotation(rotation);
+        pNode->BindElement(pLight);
+        m_pScene->GetRootNode()->AddChild(pNode);
+        m_Lights.emplace_back(std::move(pLight));
+        m_Nodes .emplace_back(std::move(pNode));
+    }
+};
+
+// ------------------------------------------------------------------
+// CApp - window, device, scene, render loop.  Slim version of the
+// CApp used by CanvasModelViewer; FBX path removed, procedural scene
+// inlined.
+// ------------------------------------------------------------------
+class CApp
+{
+    std::string m_Title;
+    HINSTANCE   m_hInstance;
+    Gem::TGemPtr<Canvas::XLogger> m_pLogger;
+    Gem::TGemPtr<Canvas::Platform::Win32::XAppWindow> m_pWindow;
+    Gem::TGemPtr<Canvas::Platform::Win32::XRawInput>  m_pInput;
+    Gem::TGemPtr<Canvas::XCanvas>           m_pCanvas;
+    Gem::TGemPtr<Canvas::XCanvasPlugin>     m_pGfxPlugin;
+    Gem::TGemPtr<Canvas::XGfxDevice>        m_pDevice;
+    Gem::TGemPtr<Canvas::XGfxRenderQueue>   m_pRenderQueue;
+    Gem::TGemPtr<Canvas::XGfxSwapChain>     m_pSwapChain;
+    Gem::TGemPtr<Canvas::XScene>            m_pScene;
+    Gem::TGemPtr<Canvas::XCamera>           m_pCamera;
+    Gem::TGemPtr<Canvas::XSceneGraphNode>   m_pCameraNode;
+
+    Gem::TGemPtr<Canvas::XFont> m_pFont;
+    Gem::TGemPtr<Canvas::XFont> m_pFontMono;
+    Gem::TGemPtr<Canvas::XUIGraph> m_pUIGraph;
+    Gem::TGemPtr<Canvas::XUIRectElement> m_pHudPanel;
+    Gem::TGemPtr<Canvas::XUITextElement> m_pTitleText;
+    Gem::TGemPtr<Canvas::XUITextElement> m_pStatsText;
+    Gem::TGemPtr<Canvas::XUITextElement> m_pFpsText;
+
+    std::unique_ptr<GardenBuilder> m_pGarden;
+
+    GardenConfig m_GardenConfig;
+    int m_exitFrameCount;
+    bool m_startFullscreen;
+    bool m_cameraActive = true;
+    int m_lastClientW = 0, m_lastClientH = 0;
+
+    float m_CameraYaw = 0.0f;
+    float m_CameraPitch = 0.0f;
+    float m_fps = 0.0f;
+    std::string m_fpsString;
+
+public:
+    CApp(HINSTANCE hInstance, PCSTR title,
+         Gem::TGemPtr<Canvas::XLogger> pLogger,
+         const GardenConfig& gardenConfig,
+         int exitFrameCount, bool fullscreen)
+        : m_Title(title), m_hInstance(hInstance), m_pLogger(std::move(pLogger)),
+          m_GardenConfig(gardenConfig),
+          m_exitFrameCount(exitFrameCount), m_startFullscreen(fullscreen) {}
+
+    bool Initialize(int nCmdShow)
+    {
+        const char* step = "startup";
+        try
+        {
+            step = "create_window";
+            Canvas::Platform::Win32::AppWindowDesc wdesc;
+            wdesc.Title     = m_Title.c_str();
+            wdesc.hInstance = m_hInstance;
+            wdesc.Width     = 1280;
+            wdesc.Height    = 768;
+            Gem::ThrowGemError(Canvas::Platform::Win32::CreatePlatformWindow(wdesc, &m_pWindow, &m_pInput));
+            m_pWindow->Show(nCmdShow);
+            if (m_startFullscreen)
+                m_pWindow->SetFullscreen(true);
+
+            step = "create_canvas";
+            Gem::ThrowGemError(Canvas::CreateCanvas(m_pLogger.Get(), &m_pCanvas));
+
+            step = "load_gfx_plugin";
+            Gem::ThrowGemError(m_pCanvas->LoadPlugin("CanvasGfx12.dll", &m_pGfxPlugin));
+
+            step = "create_device";
+            Gem::ThrowGemError(m_pGfxPlugin->CreateCanvasElement(
+                m_pCanvas, Canvas::TypeId::TypeId_GfxDevice,
+                "MainDevice", Canvas::XGfxDevice::IId,
+                reinterpret_cast<void**>(&m_pDevice)));
+
+            step = "create_scene";
+            Gem::ThrowGemError(m_pCanvas->CreateScene(m_pDevice, &m_pScene, "LightGarden"));
+
+            step = "create_render_queue";
+            Gem::ThrowGemError(m_pDevice->CreateRenderQueue(&m_pRenderQueue));
+
+            step = "create_swap_chain";
+            Gem::ThrowGemError(m_pRenderQueue->CreateSwapChain(
+                m_pWindow->GetHWND(), true, &m_pSwapChain,
+                Canvas::GfxFormat::R16G16B16A16_Float, 4));
+
+            step = "create_camera";
+            CreateCamera();
+
+            step = "build_scene";
+            m_pGarden = std::make_unique<GardenBuilder>(
+                m_pCanvas.Get(), m_pDevice.Get(), m_pScene.Get(), m_pLogger.Get());
+            m_pGarden->Build(m_GardenConfig);
+
+            // Pre-build the BVH so we can log its size up front (and
+            // shift the cost off of frame 1).
+            m_pScene->BuildBVH();
+
+            step = "load_fonts";
+            LoadFontsAndUi();
+            return true;
+        }
+        catch (const Gem::GemError& e)
+        {
+            Canvas::LogError(m_pLogger.Get(), "Initialize failed at '%s': %s",
+                step, GemResultString(e.Result()));
+            return false;
+        }
+        catch (const std::exception& e)
+        {
+            Canvas::LogError(m_pLogger.Get(), "Initialize failed at '%s': %s", step, e.what());
+            return false;
+        }
+    }
+
+    int Execute()
+    {
+        using clock = std::chrono::high_resolution_clock;
+
+        struct CursorGuard {
+            Canvas::Platform::Win32::XAppWindow* pWindow;
+            ~CursorGuard() { pWindow->SetMouseCaptured(false); }
+        } cursorGuard{ m_pWindow.Get() };
+
+        m_pWindow->SetMouseCaptured(true);
+
+        auto prevTime = clock::time_point{};
+        auto fpsTime  = clock::now();
+        size_t fpsCounter = 0;
+        int frameCount = 0;
+
+        for (bool running = true; running;)
+        {
+            auto currTime = clock::now();
+            float dt = (prevTime != clock::time_point{})
+                ? std::chrono::duration<float>(currTime - prevTime).count() : 0.0f;
+            prevTime = currTime;
+
+            float fpsDt = std::chrono::duration<float>(currTime - fpsTime).count();
+            if (fpsDt > 0.5f)
+            {
+                m_fps = static_cast<float>(fpsCounter) / fpsDt;
+                fpsTime = currTime;
+                fpsCounter = 0;
+            }
+            ++fpsCounter;
+            ++frameCount;
+
+            HandleResize();
+            HandleInputAndCamera(dt);
+
+            if (m_pInput->IsKeyDown(VK_ESCAPE))
+                running = false;
+
+            m_pRenderQueue->BeginFrame(m_pSwapChain);
+            m_pScene->Update(dt);
+            m_pScene->SubmitRenderables(m_pRenderQueue);
+
+            UpdateHud();
+            m_pUIGraph->Update();
+            m_pUIGraph->SubmitRenderables(m_pRenderQueue);
+
+            m_pRenderQueue->EndFrame();
+            m_pRenderQueue->FlushAndPresent(m_pSwapChain);
+
+            if (m_exitFrameCount > 0 && frameCount >= m_exitFrameCount)
+            {
+                Canvas::LogInfo(m_pLogger.Get(), "Auto-exit after %d frames", frameCount);
+                running = false;
+            }
+
+            if (!m_pWindow->PumpMessages())
+                running = false;
+        }
+        return 0;
+    }
+
+private:
+    void CreateCamera()
+    {
+        Gem::ThrowGemError(m_pCanvas->CreateCamera(&m_pCamera, "MainCamera"));
+        m_pCamera->SetNearClip(0.2f);
+        m_pCamera->SetFarClip(500.0f);
+        m_pCamera->SetFovAngle(static_cast<float>(Canvas::Math::Pi / 4.0));
+
+        Gem::ThrowGemError(m_pCanvas->CreateSceneGraphNode(&m_pCameraNode, "MainCameraNode"));
+        m_pCameraNode->BindElement(m_pCamera);
+
+        // Spawn well outside the grid for a wide opening view.
+        const float W = m_GardenConfig.CellMeters * m_GardenConfig.GridSize;
+        const FloatVector4 pos(-W * 0.6f, -W * 0.6f, W * 0.25f, 0.0f);
+        m_pCameraNode->SetLocalTranslation(pos);
+
+        const FloatVector4 forward = (FloatVector4(0, 0, 0, 0) - pos).Normalize();
+        m_pCameraNode->SetLocalRotation(QuaternionLookingAlong(forward, { 0, 0, 1, 0 }));
+
+        m_CameraYaw   = std::atan2(forward.Y, forward.X);
+        m_CameraPitch = std::asin(std::clamp(forward.Z, -1.0f, 1.0f));
+
+        m_pScene->GetRootNode()->AddChild(m_pCameraNode);
+        m_pScene->SetActiveCamera(m_pCamera);
+    }
+
+    void LoadFontsAndUi()
+    {
+        wchar_t exePath[MAX_PATH] = {};
+        GetModuleFileNameW(nullptr, exePath, MAX_PATH);
+        std::filesystem::path fontsDir =
+            std::filesystem::path(exePath).parent_path() / "fonts";
+
+        auto LoadFont = [&](const std::filesystem::path& path, PCSTR name) {
+            std::ifstream f(path, std::ios::binary | std::ios::ate);
+            if (!f.is_open())
+            {
+                Canvas::LogError(m_pLogger.Get(), "Cannot open font: %s", path.string().c_str());
+                Gem::ThrowGemError(Gem::Result::NotFound);
+            }
+            size_t size = static_cast<size_t>(f.tellg());
+            f.seekg(0);
+            std::vector<uint8_t> data(size);
+            f.read(reinterpret_cast<char*>(data.data()), size);
+            Gem::TGemPtr<Canvas::XFont> pF;
+            Gem::ThrowGemError(m_pCanvas->CreateFont(data.data(), data.size(), name, &pF));
+            return pF;
+        };
+
+        m_pFont     = LoadFont(fontsDir / "Inter-Regular.ttf",         "Inter");
+        m_pFontMono = LoadFont(fontsDir / "JetBrainsMono-Regular.ttf", "JetBrainsMono");
+
+        Gem::ThrowGemError(m_pCanvas->CreateUIGraph(m_pDevice, &m_pUIGraph));
+
+        Gem::TGemPtr<Canvas::XUIGraphNode> pHud;
+        Gem::ThrowGemError(m_pUIGraph->CreateNode(nullptr, &pHud));
+        pHud->SetLocalPosition(FloatVector2(6.0f, 6.0f));
+
+        Gem::ThrowGemError(m_pDevice->CreateRectElement(&m_pHudPanel));
+        pHud->BindElement(m_pHudPanel);
+        m_pHudPanel->SetSize(FloatVector2(360.0f, 96.0f));
+        m_pHudPanel->SetFillColor(FloatVector4(0.125f, 0.125f, 0.125f, 0.75f));
+
+        Gem::ThrowGemError(m_pDevice->CreateTextElement(&m_pTitleText));
+        pHud->BindElement(m_pTitleText);
+        m_pTitleText->SetLocalOffset(FloatVector2(4.0f, 4.0f));
+        m_pTitleText->SetFont(m_pFont);
+        Canvas::TextLayoutConfig titleCfg;
+        titleCfg.FontSize = 28.0f;
+        titleCfg.Color = FloatVector4(1, 1, 1, 1);
+        m_pTitleText->SetLayoutConfig(titleCfg);
+        m_pTitleText->SetText("Canvas Light Garden");
+
+        Gem::ThrowGemError(m_pDevice->CreateTextElement(&m_pStatsText));
+        pHud->BindElement(m_pStatsText);
+        m_pStatsText->SetLocalOffset(FloatVector2(4.0f, 38.0f));
+        m_pStatsText->SetFont(m_pFontMono);
+        Canvas::TextLayoutConfig monoCfg;
+        monoCfg.FontSize = 16.0f;
+        monoCfg.Color = FloatVector4(0.85f, 0.85f, 0.85f, 1);
+        m_pStatsText->SetLayoutConfig(monoCfg);
+        const auto& s = m_pGarden->Stats;
+        char buf[128];
+        snprintf(buf, sizeof(buf),
+                 "grid=%ux%u  instances=%u  point=%u  spot=%u",
+                 m_GardenConfig.GridSize, m_GardenConfig.GridSize,
+                 s.MeshInstances, s.PointLights, s.SpotLights);
+        m_pStatsText->SetText(buf);
+
+        Gem::ThrowGemError(m_pDevice->CreateTextElement(&m_pFpsText));
+        pHud->BindElement(m_pFpsText);
+        m_pFpsText->SetLocalOffset(FloatVector2(4.0f, 62.0f));
+        m_pFpsText->SetFont(m_pFontMono);
+        monoCfg.Color = FloatVector4(0.5f, 1.0f, 0.5f, 1);
+        m_pFpsText->SetLayoutConfig(monoCfg);
+        m_pFpsText->SetText("FPS: --");
+    }
+
+    void HandleResize()
+    {
+        int cw = 0, ch = 0;
+        m_pWindow->GetClientSize(cw, ch);
+        if (cw > 0 && ch > 0 && (cw != m_lastClientW || ch != m_lastClientH))
+        {
+            m_pSwapChain->ResizeBuffers(static_cast<uint32_t>(cw), static_cast<uint32_t>(ch));
+            if (m_pCamera)
+                m_pCamera->SetAspectRatio(static_cast<float>(cw) / static_cast<float>(ch));
+            m_lastClientW = cw;
+            m_lastClientH = ch;
+        }
+    }
+
+    void HandleInputAndCamera(float dt)
+    {
+        const bool hasFocus = m_pWindow->HasFocus();
+
+        if (hasFocus && m_pInput->IsKeyDown(VK_MENU) && m_pInput->IsKeyPressed(VK_RETURN))
+            m_pWindow->SetFullscreen(!m_pWindow->IsFullscreen());
+
+        if (hasFocus && m_pInput->IsKeyPressed(VK_TAB))
+            m_cameraActive = !m_cameraActive;
+
+        const bool wantCapture = hasFocus && m_cameraActive;
+        if (wantCapture && !m_pWindow->IsMouseCaptured())
+            m_pWindow->SetMouseCaptured(true);
+        else if (!wantCapture && m_pWindow->IsMouseCaptured())
+            m_pWindow->SetMouseCaptured(false);
+
+        if (!hasFocus || !m_cameraActive)
+            return;
+
+        float dx = 0, dy = 0;
+        m_pInput->GetMouseDelta(dx, dy);
+
+        constexpr float kMouseSens = 0.003f;
+        constexpr float kPitchLimit = static_cast<float>(Canvas::Math::Pi / 2.0) - 0.01f;
+        constexpr float kMoveSpeed = 8.0f;
+
+        m_CameraYaw   -= dx * kMouseSens;
+        m_CameraPitch -= dy * kMouseSens;
+        m_CameraPitch = std::clamp(m_CameraPitch, -kPitchLimit, kPitchLimit);
+
+        const float cy = std::cos(m_CameraYaw), sy = std::sin(m_CameraYaw);
+        const float cp = std::cos(m_CameraPitch), sp = std::sin(m_CameraPitch);
+        const FloatVector4 forward(cy * cp, sy * cp, sp, 0);
+        const FloatVector4 worldUp(0, 0, 1, 0);
+
+        FloatMatrix4x4 rotMat = Canvas::Math::IdentityMatrix<float, 4, 4>();
+        rotMat[0] = forward;
+        Canvas::Math::ComposePointToBasisVectors(worldUp, forward, rotMat[1], rotMat[2]);
+        const FloatVector4 right = rotMat[1];
+
+        FloatVector4 move(0, 0, 0, 0);
+        if (m_pInput->IsKeyDown('W'))        move = move + forward;
+        if (m_pInput->IsKeyDown('S'))        move = move - forward;
+        if (m_pInput->IsKeyDown('A'))        move = move + right;
+        if (m_pInput->IsKeyDown('D'))        move = move - right;
+        if (m_pInput->IsKeyDown(VK_SPACE))   move = move + FloatVector4(0, 0, 1, 0);
+        if (m_pInput->IsKeyDown(VK_CONTROL)) move = move - FloatVector4(0, 0, 1, 0);
+
+        const float mag = std::sqrt(Canvas::Math::DotProduct(move, move));
+        if (mag > 1e-4f)
+            move = move * (kMoveSpeed * dt / mag);
+
+        FloatVector4 pos = m_pCameraNode->GetLocalTranslation();
+        pos = pos + move;
+        m_pCameraNode->SetLocalTranslation(pos);
+        m_pCameraNode->SetLocalRotation(Canvas::Math::QuaternionFromRotationMatrix(rotMat));
+    }
+
+    void UpdateHud()
+    {
+        if (m_fps > 0.0f)
+        {
+            char buf[32];
+            snprintf(buf, sizeof(buf), "FPS: %.1f", m_fps);
+            if (m_fpsString != buf)
+            {
+                m_fpsString = buf;
+                m_pFpsText->SetText(buf);
+            }
+        }
+    }
+};
+
+} // namespace
+
+int APIENTRY WinMain(_In_ HINSTANCE hInstance,
+                     _In_opt_ HINSTANCE hPrevInstance,
+                     _In_ LPSTR lpCmdLine,
+                     _In_ int nCmdShow)
+{
+    UNREFERENCED_PARAMETER(hPrevInstance);
+
+    HRESULT comHr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+    const bool comOwned = SUCCEEDED(comHr);
+
+    // ---- Parse command line --------------------------------------
+    Canvas::CTokenParser tokenParser(lpCmdLine);
+    std::vector<const char*> argv;
+    argv.push_back("CanvasLightGarden");
+    for (size_t i = 0; i < tokenParser.GetTokenCount(); ++i)
+        argv.push_back(tokenParser[i]);
+    int argc = static_cast<int>(argv.size());
+
+    GardenConfig gardenConfig;
+    int exitFrameCount = -1;
+    bool fullscreen = false;
+    bool logConsole = false;
+    std::string logLevel = "warn";
+
+    try
+    {
+        InCommand::CommandParser parser("CanvasLightGarden");
+        auto& root = parser.GetAppCommandDecl();
+        root.SetDescription("Canvas procedural many-light sample");
+
+        int gridSizeOpt = static_cast<int>(gardenConfig.GridSize);
+        int seedOpt     = static_cast<int>(gardenConfig.Seed);
+
+        root.AddOption(InCommand::OptionType::Variable, "gridsize")
+            .SetDescription("Grid cells per side (default 8)").BindTo(gridSizeOpt);
+        root.AddOption(InCommand::OptionType::Variable, "seed")
+            .SetDescription("PRNG seed (default 0xC0FFEE)").BindTo(seedOpt);
+        root.AddOption(InCommand::OptionType::Variable, "exitframecount")
+            .SetDescription("Exit after N frames (testing)").BindTo(exitFrameCount);
+        root.AddOption(InCommand::OptionType::Switch, "fullscreen")
+            .SetDescription("Start in borderless fullscreen").BindTo(fullscreen);
+        root.AddOption(InCommand::OptionType::Switch, "shadows-all")
+            .SetDescription("Request shadows on every light (no-op until engine supports point/spot shadows)")
+            .BindTo(gardenConfig.ShadowsAll);
+
+        auto& logCmd = root.AddSubCommand("log");
+        logCmd.AddOption(InCommand::OptionType::Variable, "level", 'l')
+            .SetDomain({"trace","debug","info","warn","error","critical","off"}).BindTo(logLevel);
+        logCmd.AddOption(InCommand::OptionType::Switch, "console", 'c').BindTo(logConsole);
+
+        std::ostringstream helpStream;
+        parser.EnableAutoHelp("help", 'h', helpStream);
+        parser.ParseArgs(argc, argv.data());
+
+        if (parser.WasAutoHelpRequested())
+        {
+            AllocConsole();
+            SetConsoleTitleA("CanvasLightGarden - Help");
+            FILE* tmpOut = nullptr;
+            freopen_s(&tmpOut, "CONOUT$", "w", stdout);
+            std::cout << helpStream.str() << std::endl;
+            std::cout << "Press any key to close..." << std::endl;
+            (void)_getch();
+            if (tmpOut) fclose(tmpOut);
+            FreeConsole();
+            if (comOwned) CoUninitialize();
+            return 0;
+        }
+
+        gardenConfig.GridSize = static_cast<uint32_t>(std::max(1, gridSizeOpt));
+        gardenConfig.Seed     = static_cast<uint32_t>(seedOpt);
+    }
+    catch (const InCommand::SyntaxException& e)
+    {
+        MessageBoxA(nullptr, e.GetMessage().c_str(), "CanvasLightGarden", MB_OK | MB_ICONERROR);
+        if (comOwned) CoUninitialize();
+        return -1;
+    }
+
+    // ---- Logger --------------------------------------------------
+    QLog::Level qlogLevel = QLog::Level::Warn;
+    if      (logLevel == "trace")    qlogLevel = QLog::Level::Trace;
+    else if (logLevel == "debug")    qlogLevel = QLog::Level::Debug;
+    else if (logLevel == "info")     qlogLevel = QLog::Level::Info;
+    else if (logLevel == "error")    qlogLevel = QLog::Level::Error;
+    else if (logLevel == "critical") qlogLevel = QLog::Level::Critical;
+    else if (logLevel == "off")      qlogLevel = QLog::Level::Off;
+
+    wchar_t exeBuf[MAX_PATH] = {};
+    GetModuleFileNameW(nullptr, exeBuf, MAX_PATH);
+    auto now = std::chrono::system_clock::now();
+    std::time_t tt = std::chrono::system_clock::to_time_t(now);
+    std::tm tm{}; localtime_s(&tm, &tt);
+    char tbuf[32]; std::strftime(tbuf, sizeof(tbuf), "%Y%m%d%H%M%S", &tm);
+    auto logPath = std::filesystem::path(exeBuf).parent_path()
+                 / (std::string("CanvasLightGarden_") + tbuf + ".log");
+
+    std::unique_ptr<CConsole> pConsole;
+    if (logConsole) pConsole = std::make_unique<CConsole>();
+
+    CLogSink sink(logPath, logConsole);
+    auto qlogger = std::make_unique<QLog::Logger>(sink, qlogLevel);
+
+    Gem::TGemPtr<Canvas::QLogAdapter> pAdapter;
+    Gem::ThrowGemError(Gem::TGenericImpl<Canvas::QLogAdapter>::Create(&pAdapter, qlogger.release()));
+    Gem::TGemPtr<Canvas::XLogger> pLogger;
+    pAdapter->QueryInterface(&pLogger);
+
+    Canvas::LogInfo(pLogger.Get(), "CanvasLightGarden starting: grid=%u seed=0x%08X",
+                    gardenConfig.GridSize, gardenConfig.Seed);
+    Canvas::LogInfo(pLogger.Get(), "Log file: %s", logPath.string().c_str());
+
+    int result = 0;
+    {
+        CApp app(hInstance, "CanvasLightGarden",
+                 pLogger, gardenConfig, exitFrameCount, fullscreen);
+        if (!app.Initialize(nCmdShow))
+        {
+            MessageBoxA(nullptr, "Initialization failed; see log for details.",
+                        "CanvasLightGarden", MB_OK | MB_ICONERROR);
+            result = -1;
+        }
+        else
+        {
+            result = app.Execute();
+        }
+    }
+
+    pConsole.reset();
+    if (comOwned) CoUninitialize();
+    return result;
+}

--- a/src/CanvasLightGarden/QLogAdapter.h
+++ b/src/CanvasLightGarden/QLogAdapter.h
@@ -1,0 +1,68 @@
+// QLogAdapter.h - bridges Canvas::XLogger onto QLog::Logger.
+// Mirrors the adapter used by the other Canvas sample apps so each
+// executable can own its logger without forcing STL across the
+// CanvasCore ABI.
+
+#pragma once
+
+#include "CanvasCore.h"
+#include "QLog.h"
+#include <memory>
+
+namespace Canvas
+{
+
+class QLogAdapter : public Gem::TGeneric<XLogger>
+{
+    std::unique_ptr<QLog::Logger> m_Logger;
+
+public:
+    BEGIN_GEM_INTERFACE_MAP()
+        GEM_INTERFACE_ENTRY(XLogger)
+    END_GEM_INTERFACE_MAP()
+
+    explicit QLogAdapter(QLog::Logger* logger) : m_Logger(logger) {}
+
+    void Initialize() {}
+
+    void Log(Canvas::LogLevel level, PCSTR format, va_list args) override
+    {
+        m_Logger->Log(ToQLogLevel(level), format, args);
+    }
+
+    void SetLevel(LogLevel level) override { m_Logger->SetLevel(ToQLogLevel(level)); }
+    LogLevel GetLevel() override { return FromQLogLevel(m_Logger->GetLevel()); }
+    void Flush() override { m_Logger->Flush(); }
+
+private:
+    static QLog::Level ToQLogLevel(LogLevel level)
+    {
+        switch (level)
+        {
+        case LogLevel::Trace:    return QLog::Level::Trace;
+        case LogLevel::Debug:    return QLog::Level::Debug;
+        case LogLevel::Info:     return QLog::Level::Info;
+        case LogLevel::Warn:     return QLog::Level::Warn;
+        case LogLevel::Error:    return QLog::Level::Error;
+        case LogLevel::Critical: return QLog::Level::Critical;
+        case LogLevel::Off:      return QLog::Level::Off;
+        default:                 return QLog::Level::Info;
+        }
+    }
+    static LogLevel FromQLogLevel(QLog::Level level)
+    {
+        switch (level)
+        {
+        case QLog::Level::Trace:    return LogLevel::Trace;
+        case QLog::Level::Debug:    return LogLevel::Debug;
+        case QLog::Level::Info:     return LogLevel::Info;
+        case QLog::Level::Warn:     return LogLevel::Warn;
+        case QLog::Level::Error:    return LogLevel::Error;
+        case QLog::Level::Critical: return LogLevel::Critical;
+        case QLog::Level::Off:      return LogLevel::Off;
+        default:                    return LogLevel::Info;
+        }
+    }
+};
+
+} // namespace Canvas

--- a/src/CanvasLightGarden/pch.h
+++ b/src/CanvasLightGarden/pch.h
@@ -1,0 +1,28 @@
+// pch.h - precompiled header for CanvasLightGarden
+#pragma once
+
+#include "targetver.h"
+
+#include <windows.h>
+#include <objbase.h>
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <string>
+#include <memory>
+#include <vector>
+#include <random>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <iomanip>
+#include <algorithm>
+#include <cmath>
+
+#include "CanvasPlatformWin32.h"
+#include "Gem.hpp"
+#include "CanvasMath.hpp"
+#include "CanvasCore.h"
+#include "QLog.h"

--- a/src/CanvasLightGarden/targetver.h
+++ b/src/CanvasLightGarden/targetver.h
@@ -1,0 +1,4 @@
+#pragma once
+
+// Targeting Windows 10 / 11
+#include <SDKDDKVer.h>

--- a/src/CanvasUnitTest/BVHTest.cpp
+++ b/src/CanvasUnitTest/BVHTest.cpp
@@ -363,12 +363,18 @@ TEST(BVHTest, QuerySphereEmptyAndDegenerate)
     BVH bvh;
     bvh.Build(primitives.data(), primitives.size());
 
-    // r <= 0 must short-circuit to no results.
+    // r < 0 must short-circuit to no results.  r == 0 is a valid
+    // degenerate (point) sphere and must return primitives whose
+    // bounds contain the query point.
     std::vector<uint32_t> out;
-    bvh.QuerySphere(primitives.data(), FloatVector4(0,0,0,0), 0.0f, out);
-    EXPECT_EQ(size_t(0), out.size());
     bvh.QuerySphere(primitives.data(), FloatVector4(0,0,0,0), -1.0f, out);
     EXPECT_EQ(size_t(0), out.size());
+
+    // Query point at (2,0,0) coincides with primitive 2's point AABB.
+    out.clear();
+    bvh.QuerySphere(primitives.data(), FloatVector4(2.0f,0,0,0), 0.0f, out);
+    ASSERT_EQ(size_t(1), out.size());
+    EXPECT_EQ(2u, out[0]);
 
     // Sphere enclosing every primitive must return all 5.
     out.clear();

--- a/src/CanvasUnitTest/BVHTest.cpp
+++ b/src/CanvasUnitTest/BVHTest.cpp
@@ -14,14 +14,11 @@
 //================================================================================================
 
 #include "pch.h"
-#include "CppUnitTest.h"
-
 #include "BVH.h"
 
 #include <algorithm>
 #include <random>
 
-using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 using namespace Canvas;
 using namespace Canvas::Math;
 
@@ -117,456 +114,449 @@ FloatMatrix4x4 BuildViewProj(const FloatVector4& eye, const FloatVector4& target
 
 } // anonymous namespace
 
-TEST_CLASS(BVHTest)
+// Empty BVH must produce empty cull set without crashing or accessing
+// out-of-bounds memory.  Defends the early-out in QueryFrustum.
+TEST(BVHTest, EmptyBVH)
 {
-public:
+    BVH bvh;
+    bvh.Build(nullptr, 0);
+    EXPECT_TRUE(bvh.Empty());
 
-    // Empty BVH must produce empty cull set without crashing or accessing
-    // out-of-bounds memory.  Defends the early-out in QueryFrustum.
-    TEST_METHOD(EmptyBVH)
+    Frustum f = Frustum::FromViewProjection(
+        PerspectiveReverseZ<float>(1.0f, 1.0f, 1.0f, 100.0f), true);
+    std::vector<uint32_t> visible;
+    bvh.QueryFrustum(nullptr, f, visible);
+    EXPECT_EQ(size_t(0), visible.size());
+}
+
+// All-empty primitives (sentinel AABBs) must be silently dropped at
+// build time.  The BVH should report Empty() even though count > 0.
+TEST(BVHTest, EmptySentinelPrimitivesAreDropped)
+{
+    std::vector<BVHPrimitive> primitives;
+    BVHPrimitive a; a.WorldBounds = AABB{}; a.Id = 0;
+    BVHPrimitive b; b.WorldBounds = AABB{}; b.Id = 1;
+    primitives.push_back(a);
+    primitives.push_back(b);
+    BVH bvh;
+    bvh.Build(primitives.data(), primitives.size());
+    EXPECT_TRUE(bvh.Empty());
+}
+
+// Single-leaf-node tree: trivial path through Build, exercises the
+// count <= kMaxPrimitivesPerLeaf early-out.
+TEST(BVHTest, SingleLeafNode)
+{
+    std::vector<BVHPrimitive> primitives;
+    for (uint32_t i = 0; i < 3; ++i)
+        primitives.push_back(MakePointPrimitive(0.0f, 0.0f, 10.0f + float(i), i));
+    BVH bvh;
+    bvh.Build(primitives.data(), primitives.size());
+    EXPECT_FALSE(bvh.Empty());
+    EXPECT_EQ(size_t(3), bvh.PrimitiveCount());
+
+    Frustum f = Frustum::FromViewProjection(
+        PerspectiveReverseZ<float>(float(3.14159 / 2), 1.0f, 0.5f, 100.0f), true);
+    std::vector<uint32_t> visible;
+    bvh.QueryFrustum(primitives.data(), f, visible);
+    EXPECT_EQ(size_t(3), visible.size());
+}
+
+// Brute-force equivalence on a hand-built scene: ensures the
+// dedup/ordering of BVH output matches the reference modulo sort.
+TEST(BVHTest, BruteForceEquivalenceHandBuilt)
+{
+    std::vector<BVHPrimitive> primitives;
+    for (uint32_t i = 0; i < 50; ++i)
     {
-        BVH bvh;
-        bvh.Build(nullptr, 0);
-        Assert::IsTrue(bvh.Empty());
+        const float x = -20.0f + float(i % 10) * 4.0f;
+        const float y = -10.0f + float((i / 10) % 5) * 4.0f;
+        const float z = 5.0f + float(i % 7) * 3.0f;
+        primitives.push_back(MakeBoxPrimitive(
+            FloatVector4(x - 0.5f, y - 0.5f, z - 0.5f, 0.0f),
+            FloatVector4(x + 0.5f, y + 0.5f, z + 0.5f, 0.0f),
+            i));
+    }
+    BVH bvh;
+    bvh.Build(primitives.data(), primitives.size());
 
-        Frustum f = Frustum::FromViewProjection(
-            PerspectiveReverseZ<float>(1.0f, 1.0f, 1.0f, 100.0f), true);
-        std::vector<uint32_t> visible;
-        bvh.QueryFrustum(nullptr, f, visible);
-        Assert::AreEqual(size_t(0), visible.size());
+    FloatMatrix4x4 vp = BuildViewProj(
+        FloatVector4(0.0f, 0.0f, 0.0f, 1.0f),
+        FloatVector4(0.0f, 0.0f, 1.0f, 1.0f),
+        float(3.14159 / 3), 16.0f / 9.0f, 0.5f, 100.0f);
+    Frustum f = Frustum::FromViewProjection(vp, true);
+
+    std::vector<uint32_t> bvhVisible;
+    bvh.QueryFrustum(primitives.data(), f, bvhVisible);
+    std::vector<uint32_t> bfVisible = BruteForceCull(primitives, f);
+
+    EXPECT_EQ(bfVisible.size(), bvhVisible.size()) << "BVH visible count != brute force";
+    auto bvhSorted = SortedCopy(bvhVisible);
+    auto bfSorted  = SortedCopy(bfVisible);
+    for (size_t i = 0; i < bfSorted.size(); ++i)
+        EXPECT_EQ(bfSorted[i], bvhSorted[i]);
+}
+
+// The keystone fuzz: many random scenes, many random cameras, every
+// pairing must agree exactly with brute force.  Seeded RNG so any
+// failure is reproducible from the test log alone.
+TEST(BVHTest, BruteForceEquivalenceFuzz)
+{
+    std::mt19937 rng(0xC0FFEE);
+    std::uniform_real_distribution<float> posDist(-50.0f, 50.0f);
+    std::uniform_real_distribution<float> halfDist(0.25f, 2.5f);
+    std::uniform_real_distribution<float> camDist(-30.0f, 30.0f);
+    std::uniform_real_distribution<float> tgtDist(-30.0f, 30.0f);
+    std::uniform_real_distribution<float> fovDist(0.5f, 2.0f);   // ~28 to 115 deg
+    std::uniform_real_distribution<float> aspDist(0.5f, 2.5f);
+
+    const int kPrimitiveCount = 500;
+    const int kFrustumCount = 25;
+
+    std::vector<BVHPrimitive> primitives;
+    primitives.reserve(kPrimitiveCount);
+    for (int i = 0; i < kPrimitiveCount; ++i)
+    {
+        const float cx = posDist(rng), cy = posDist(rng), cz = posDist(rng);
+        const float hx = halfDist(rng), hy = halfDist(rng), hz = halfDist(rng);
+        primitives.push_back(MakeBoxPrimitive(
+            FloatVector4(cx - hx, cy - hy, cz - hz, 0.0f),
+            FloatVector4(cx + hx, cy + hy, cz + hz, 0.0f),
+            uint32_t(i)));
     }
 
-    // All-empty primitives (sentinel AABBs) must be silently dropped at
-    // build time.  The BVH should report Empty() even though count > 0.
-    TEST_METHOD(EmptySentinelPrimitivesAreDropped)
+    BVH bvh;
+    bvh.Build(primitives.data(), primitives.size());
+    EXPECT_EQ(size_t(kPrimitiveCount), bvh.PrimitiveCount());
+
+    for (int t = 0; t < kFrustumCount; ++t)
     {
-        std::vector<BVHPrimitive> primitives;
-        BVHPrimitive a; a.WorldBounds = AABB{}; a.Id = 0;
-        BVHPrimitive b; b.WorldBounds = AABB{}; b.Id = 1;
-        primitives.push_back(a);
-        primitives.push_back(b);
-        BVH bvh;
-        bvh.Build(primitives.data(), primitives.size());
-        Assert::IsTrue(bvh.Empty());
-    }
+        FloatVector4 eye(camDist(rng), camDist(rng), camDist(rng), 1.0f);
+        FloatVector4 tgt(tgtDist(rng), tgtDist(rng), tgtDist(rng), 1.0f);
+        // Avoid degenerate eye==target.
+        if (std::abs(eye.V[0]-tgt.V[0]) + std::abs(eye.V[1]-tgt.V[1]) + std::abs(eye.V[2]-tgt.V[2]) < 0.1f)
+            tgt.V[2] += 5.0f;
 
-    // Single-leaf-node tree: trivial path through Build, exercises the
-    // count <= kMaxPrimitivesPerLeaf early-out.
-    TEST_METHOD(SingleLeafNode)
-    {
-        std::vector<BVHPrimitive> primitives;
-        for (uint32_t i = 0; i < 3; ++i)
-            primitives.push_back(MakePointPrimitive(0.0f, 0.0f, 10.0f + float(i), i));
-        BVH bvh;
-        bvh.Build(primitives.data(), primitives.size());
-        Assert::IsFalse(bvh.Empty());
-        Assert::AreEqual(size_t(3), bvh.PrimitiveCount());
-
-        Frustum f = Frustum::FromViewProjection(
-            PerspectiveReverseZ<float>(float(3.14159 / 2), 1.0f, 0.5f, 100.0f), true);
-        std::vector<uint32_t> visible;
-        bvh.QueryFrustum(primitives.data(), f, visible);
-        Assert::AreEqual(size_t(3), visible.size());
-    }
-
-    // Brute-force equivalence on a hand-built scene: ensures the
-    // dedup/ordering of BVH output matches the reference modulo sort.
-    TEST_METHOD(BruteForceEquivalenceHandBuilt)
-    {
-        std::vector<BVHPrimitive> primitives;
-        for (uint32_t i = 0; i < 50; ++i)
-        {
-            const float x = -20.0f + float(i % 10) * 4.0f;
-            const float y = -10.0f + float((i / 10) % 5) * 4.0f;
-            const float z = 5.0f + float(i % 7) * 3.0f;
-            primitives.push_back(MakeBoxPrimitive(
-                FloatVector4(x - 0.5f, y - 0.5f, z - 0.5f, 0.0f),
-                FloatVector4(x + 0.5f, y + 0.5f, z + 0.5f, 0.0f),
-                i));
-        }
-        BVH bvh;
-        bvh.Build(primitives.data(), primitives.size());
-
-        FloatMatrix4x4 vp = BuildViewProj(
-            FloatVector4(0.0f, 0.0f, 0.0f, 1.0f),
-            FloatVector4(0.0f, 0.0f, 1.0f, 1.0f),
-            float(3.14159 / 3), 16.0f / 9.0f, 0.5f, 100.0f);
+        FloatMatrix4x4 vp = BuildViewProj(eye, tgt, fovDist(rng), aspDist(rng), 0.5f, 200.0f);
         Frustum f = Frustum::FromViewProjection(vp, true);
 
         std::vector<uint32_t> bvhVisible;
         bvh.QueryFrustum(primitives.data(), f, bvhVisible);
         std::vector<uint32_t> bfVisible = BruteForceCull(primitives, f);
 
-        Assert::AreEqual(bfVisible.size(), bvhVisible.size(),
-                         L"BVH visible count != brute force");
         auto bvhSorted = SortedCopy(bvhVisible);
         auto bfSorted  = SortedCopy(bfVisible);
-        for (size_t i = 0; i < bfSorted.size(); ++i)
-            Assert::AreEqual(bfSorted[i], bvhSorted[i]);
-    }
 
-    // The keystone fuzz: many random scenes, many random cameras, every
-    // pairing must agree exactly with brute force.  Seeded RNG so any
-    // failure is reproducible from the test log alone.
-    TEST_METHOD(BruteForceEquivalenceFuzz)
+        // Detailed assertion: report sizes on the first mismatch so
+        // the failure log is actionable.
+        if (bvhSorted != bfSorted)
+        {
+            std::ostringstream ss;
+            ss << "Mismatch on frustum #" << t
+               << "  bvh.size=" << bvhSorted.size()
+               << "  bf.size=" << bfSorted.size();
+            FAIL() << ss.str();
+        }
+    }
+}
+
+// All-outside: a frustum looking away from any primitive must return
+// empty.  Catches plane-sign inversions that would falsely include
+// everything.
+TEST(BVHTest, FrustumLookingAway)
+{
+    std::vector<BVHPrimitive> primitives;
+    for (uint32_t i = 0; i < 20; ++i)
+        primitives.push_back(MakePointPrimitive(float(i), 0.0f, 50.0f, i));
+    BVH bvh;
+    bvh.Build(primitives.data(), primitives.size());
+
+    // Camera at origin looking down -Z (away from all primitives
+    // which sit at z=50, i.e. behind the camera in this view).
+    FloatMatrix4x4 vp = BuildViewProj(
+        FloatVector4(0,0,0,1), FloatVector4(0,0,-1,1),
+        float(3.14159 / 3), 1.0f, 0.5f, 100.0f);
+    Frustum f = Frustum::FromViewProjection(vp, true);
+
+    std::vector<uint32_t> visible;
+    bvh.QueryFrustum(primitives.data(), f, visible);
+    EXPECT_EQ(size_t(0), visible.size());
+}
+
+// ============================================================
+// QuerySphere / QueryCone / QueryAABB tests.
+//
+// Same contract as the frustum tests: BVH output must equal the
+// brute-force-scan output for the same shape predicate (modulo
+// sort).  The shape tests are exact at the per-primitive tier --
+// the only conservatism is in the cone test, where AABBs are
+// bounded by their outer sphere; the brute force comparator
+// therefore must use the same test on the per-primitive AABB, not
+// a tighter cone-AABB test, to remain an apples-to-apples
+// reference.
+// ============================================================
+TEST(BVHTest, QuerySphereBruteForceEquivalence)
+{
+    std::mt19937 rng(0xB0BACAFE);
+    std::uniform_real_distribution<float> posDist(-30.0f, 30.0f);
+    std::uniform_real_distribution<float> halfDist(0.25f, 2.0f);
+    std::uniform_real_distribution<float> rDist(1.0f, 15.0f);
+
+    std::vector<BVHPrimitive> primitives;
+    primitives.reserve(300);
+    for (int i = 0; i < 300; ++i)
     {
-        std::mt19937 rng(0xC0FFEE);
-        std::uniform_real_distribution<float> posDist(-50.0f, 50.0f);
-        std::uniform_real_distribution<float> halfDist(0.25f, 2.5f);
-        std::uniform_real_distribution<float> camDist(-30.0f, 30.0f);
-        std::uniform_real_distribution<float> tgtDist(-30.0f, 30.0f);
-        std::uniform_real_distribution<float> fovDist(0.5f, 2.0f);   // ~28 to 115 deg
-        std::uniform_real_distribution<float> aspDist(0.5f, 2.5f);
-
-        const int kPrimitiveCount = 500;
-        const int kFrustumCount = 25;
-
-        std::vector<BVHPrimitive> primitives;
-        primitives.reserve(kPrimitiveCount);
-        for (int i = 0; i < kPrimitiveCount; ++i)
-        {
-            const float cx = posDist(rng), cy = posDist(rng), cz = posDist(rng);
-            const float hx = halfDist(rng), hy = halfDist(rng), hz = halfDist(rng);
-            primitives.push_back(MakeBoxPrimitive(
-                FloatVector4(cx - hx, cy - hy, cz - hz, 0.0f),
-                FloatVector4(cx + hx, cy + hy, cz + hz, 0.0f),
-                uint32_t(i)));
-        }
-
-        BVH bvh;
-        bvh.Build(primitives.data(), primitives.size());
-        Assert::AreEqual(size_t(kPrimitiveCount), bvh.PrimitiveCount());
-
-        for (int t = 0; t < kFrustumCount; ++t)
-        {
-            FloatVector4 eye(camDist(rng), camDist(rng), camDist(rng), 1.0f);
-            FloatVector4 tgt(tgtDist(rng), tgtDist(rng), tgtDist(rng), 1.0f);
-            // Avoid degenerate eye==target.
-            if (std::abs(eye.V[0]-tgt.V[0]) + std::abs(eye.V[1]-tgt.V[1]) + std::abs(eye.V[2]-tgt.V[2]) < 0.1f)
-                tgt.V[2] += 5.0f;
-
-            FloatMatrix4x4 vp = BuildViewProj(eye, tgt, fovDist(rng), aspDist(rng), 0.5f, 200.0f);
-            Frustum f = Frustum::FromViewProjection(vp, true);
-
-            std::vector<uint32_t> bvhVisible;
-            bvh.QueryFrustum(primitives.data(), f, bvhVisible);
-            std::vector<uint32_t> bfVisible = BruteForceCull(primitives, f);
-
-            auto bvhSorted = SortedCopy(bvhVisible);
-            auto bfSorted  = SortedCopy(bfVisible);
-
-            // Detailed assertion: report sizes on the first mismatch so
-            // the failure log is actionable.
-            if (bvhSorted != bfSorted)
-            {
-                std::wstringstream ss;
-                ss << L"Mismatch on frustum #" << t
-                   << L"  bvh.size=" << bvhSorted.size()
-                   << L"  bf.size=" << bfSorted.size();
-                Assert::Fail(ss.str().c_str());
-            }
-        }
+        const float cx = posDist(rng), cy = posDist(rng), cz = posDist(rng);
+        const float hx = halfDist(rng), hy = halfDist(rng), hz = halfDist(rng);
+        primitives.push_back(MakeBoxPrimitive(
+            FloatVector4(cx - hx, cy - hy, cz - hz, 0.0f),
+            FloatVector4(cx + hx, cy + hy, cz + hz, 0.0f),
+            uint32_t(i)));
     }
 
-    // All-outside: a frustum looking away from any primitive must return
-    // empty.  Catches plane-sign inversions that would falsely include
-    // everything.
-    TEST_METHOD(FrustumLookingAway)
+    BVH bvh;
+    bvh.Build(primitives.data(), primitives.size());
+
+    // Reference closest-point sphere-AABB test, kept local so the
+    // assertion is decoupled from the implementation under test.
+    auto ref = [](const FloatVector4& c, float r, const AABB& b) {
+        if (b.IsEmpty() || r <= 0.0f) return false;
+        float d2 = 0.0f;
+        for (int i = 0; i < 3; ++i)
+        {
+            if (c.V[i] < b.Min.V[i]) { float d = b.Min.V[i] - c.V[i]; d2 += d*d; }
+            else if (c.V[i] > b.Max.V[i]) { float d = c.V[i] - b.Max.V[i]; d2 += d*d; }
+        }
+        return d2 <= r * r;
+    };
+
+    for (int q = 0; q < 30; ++q)
     {
-        std::vector<BVHPrimitive> primitives;
-        for (uint32_t i = 0; i < 20; ++i)
-            primitives.push_back(MakePointPrimitive(float(i), 0.0f, 50.0f, i));
-        BVH bvh;
-        bvh.Build(primitives.data(), primitives.size());
+        FloatVector4 c(posDist(rng), posDist(rng), posDist(rng), 0.0f);
+        float r = rDist(rng);
 
-        // Camera at origin looking down -Z (away from all primitives
-        // which sit at z=50, i.e. behind the camera in this view).
-        FloatMatrix4x4 vp = BuildViewProj(
-            FloatVector4(0,0,0,1), FloatVector4(0,0,-1,1),
-            float(3.14159 / 3), 1.0f, 0.5f, 100.0f);
-        Frustum f = Frustum::FromViewProjection(vp, true);
+        std::vector<uint32_t> bvhOut;
+        bvh.QuerySphere(primitives.data(), c, r, bvhOut);
 
-        std::vector<uint32_t> visible;
-        bvh.QueryFrustum(primitives.data(), f, visible);
-        Assert::AreEqual(size_t(0), visible.size());
+        std::vector<uint32_t> bfOut;
+        for (uint32_t i = 0; i < primitives.size(); ++i)
+            if (ref(c, r, primitives[i].WorldBounds))
+                bfOut.push_back(i);
+
+        auto a = SortedCopy(bvhOut);
+        auto b = SortedCopy(bfOut);
+        if (a != b)
+        {
+            std::ostringstream ss;
+            ss << "QuerySphere mismatch q=" << q
+               << " bvh=" << a.size() << " bf=" << b.size();
+            FAIL() << ss.str();
+        }
+    }
+}
+
+TEST(BVHTest, QuerySphereEmptyAndDegenerate)
+{
+    std::vector<BVHPrimitive> primitives;
+    for (uint32_t i = 0; i < 5; ++i)
+        primitives.push_back(MakePointPrimitive(float(i), 0, 0, i));
+    BVH bvh;
+    bvh.Build(primitives.data(), primitives.size());
+
+    // r <= 0 must short-circuit to no results.
+    std::vector<uint32_t> out;
+    bvh.QuerySphere(primitives.data(), FloatVector4(0,0,0,0), 0.0f, out);
+    EXPECT_EQ(size_t(0), out.size());
+    bvh.QuerySphere(primitives.data(), FloatVector4(0,0,0,0), -1.0f, out);
+    EXPECT_EQ(size_t(0), out.size());
+
+    // Sphere enclosing every primitive must return all 5.
+    out.clear();
+    bvh.QuerySphere(primitives.data(), FloatVector4(2.0f,0,0,0), 100.0f, out);
+    EXPECT_EQ(size_t(5), out.size());
+}
+
+TEST(BVHTest, QueryAABBBruteForceEquivalence)
+{
+    std::mt19937 rng(0xFEEDFACE);
+    std::uniform_real_distribution<float> posDist(-30.0f, 30.0f);
+    std::uniform_real_distribution<float> halfDist(0.25f, 2.0f);
+    std::uniform_real_distribution<float> boxHalf(1.0f, 12.0f);
+
+    std::vector<BVHPrimitive> primitives;
+    primitives.reserve(400);
+    for (int i = 0; i < 400; ++i)
+    {
+        const float cx = posDist(rng), cy = posDist(rng), cz = posDist(rng);
+        const float hx = halfDist(rng), hy = halfDist(rng), hz = halfDist(rng);
+        primitives.push_back(MakeBoxPrimitive(
+            FloatVector4(cx - hx, cy - hy, cz - hz, 0.0f),
+            FloatVector4(cx + hx, cy + hy, cz + hz, 0.0f),
+            uint32_t(i)));
     }
 
-        // ============================================================
-        // QuerySphere / QueryCone / QueryAABB tests.
-        //
-        // Same contract as the frustum tests: BVH output must equal the
-        // brute-force-scan output for the same shape predicate (modulo
-        // sort).  The shape tests are exact at the per-primitive tier --
-        // the only conservatism is in the cone test, where AABBs are
-        // bounded by their outer sphere; the brute force comparator
-        // therefore must use the same test on the per-primitive AABB, not
-        // a tighter cone-AABB test, to remain an apples-to-apples
-        // reference.
-        // ============================================================
+    BVH bvh;
+    bvh.Build(primitives.data(), primitives.size());
 
-        TEST_METHOD(QuerySphereBruteForceEquivalence)
+    auto refOverlap = [](const AABB& a, const AABB& b) {
+        if (a.IsEmpty() || b.IsEmpty()) return false;
+        return !(a.Max.V[0] < b.Min.V[0] || a.Min.V[0] > b.Max.V[0]
+              || a.Max.V[1] < b.Min.V[1] || a.Min.V[1] > b.Max.V[1]
+              || a.Max.V[2] < b.Min.V[2] || a.Min.V[2] > b.Max.V[2]);
+    };
+
+    for (int q = 0; q < 30; ++q)
+    {
+        const float cx = posDist(rng), cy = posDist(rng), cz = posDist(rng);
+        const float hx = boxHalf(rng), hy = boxHalf(rng), hz = boxHalf(rng);
+        AABB box(FloatVector4(cx-hx, cy-hy, cz-hz, 0),
+                 FloatVector4(cx+hx, cy+hy, cz+hz, 0));
+
+        std::vector<uint32_t> bvhOut;
+        bvh.QueryAABB(primitives.data(), box, bvhOut);
+
+        std::vector<uint32_t> bfOut;
+        for (uint32_t i = 0; i < primitives.size(); ++i)
+            if (refOverlap(box, primitives[i].WorldBounds))
+                bfOut.push_back(i);
+
+        auto a = SortedCopy(bvhOut);
+        auto b = SortedCopy(bfOut);
+        if (a != b)
         {
-            std::mt19937 rng(0xB0BACAFE);
-            std::uniform_real_distribution<float> posDist(-30.0f, 30.0f);
-            std::uniform_real_distribution<float> halfDist(0.25f, 2.0f);
-            std::uniform_real_distribution<float> rDist(1.0f, 15.0f);
-
-            std::vector<BVHPrimitive> primitives;
-            primitives.reserve(300);
-            for (int i = 0; i < 300; ++i)
-            {
-                const float cx = posDist(rng), cy = posDist(rng), cz = posDist(rng);
-                const float hx = halfDist(rng), hy = halfDist(rng), hz = halfDist(rng);
-                primitives.push_back(MakeBoxPrimitive(
-                    FloatVector4(cx - hx, cy - hy, cz - hz, 0.0f),
-                    FloatVector4(cx + hx, cy + hy, cz + hz, 0.0f),
-                    uint32_t(i)));
-            }
-
-            BVH bvh;
-            bvh.Build(primitives.data(), primitives.size());
-
-            // Reference closest-point sphere-AABB test, kept local so the
-            // assertion is decoupled from the implementation under test.
-            auto ref = [](const FloatVector4& c, float r, const AABB& b) {
-                if (b.IsEmpty() || r <= 0.0f) return false;
-                float d2 = 0.0f;
-                for (int i = 0; i < 3; ++i)
-                {
-                    if (c.V[i] < b.Min.V[i]) { float d = b.Min.V[i] - c.V[i]; d2 += d*d; }
-                    else if (c.V[i] > b.Max.V[i]) { float d = c.V[i] - b.Max.V[i]; d2 += d*d; }
-                }
-                return d2 <= r * r;
-            };
-
-            for (int q = 0; q < 30; ++q)
-            {
-                FloatVector4 c(posDist(rng), posDist(rng), posDist(rng), 0.0f);
-                float r = rDist(rng);
-
-                std::vector<uint32_t> bvhOut;
-                bvh.QuerySphere(primitives.data(), c, r, bvhOut);
-
-                std::vector<uint32_t> bfOut;
-                for (uint32_t i = 0; i < primitives.size(); ++i)
-                    if (ref(c, r, primitives[i].WorldBounds))
-                        bfOut.push_back(i);
-
-                auto a = SortedCopy(bvhOut);
-                auto b = SortedCopy(bfOut);
-                if (a != b)
-                {
-                    std::wstringstream ss;
-                    ss << L"QuerySphere mismatch q=" << q
-                       << L" bvh=" << a.size() << L" bf=" << b.size();
-                    Assert::Fail(ss.str().c_str());
-                }
-            }
+            std::ostringstream ss;
+            ss << "QueryAABB mismatch q=" << q
+               << " bvh=" << a.size() << " bf=" << b.size();
+            FAIL() << ss.str();
         }
+    }
 
-        TEST_METHOD(QuerySphereEmptyAndDegenerate)
+    // Empty query box must be a no-op.
+    std::vector<uint32_t> out;
+    bvh.QueryAABB(primitives.data(), AABB{}, out);
+    EXPECT_EQ(size_t(0), out.size());
+}
+
+TEST(BVHTest, QueryConeAcceptsKnownInside)
+{
+    // Hand-built case: cone along +Z, apex at origin, half-angle 30
+    // deg, range 20.  Primitives along the axis must be returned;
+    // a primitive well off-axis must NOT be returned.
+    std::vector<BVHPrimitive> primitives;
+    primitives.push_back(MakePointPrimitive(0, 0,  1, 0));  // on axis
+    primitives.push_back(MakePointPrimitive(0, 0, 10, 1));  // on axis
+    primitives.push_back(MakePointPrimitive(0, 0, 19, 2));  // near range end
+    primitives.push_back(MakePointPrimitive(0, 0, 25, 3));  // past range
+    primitives.push_back(MakePointPrimitive(0, 0, -1, 4));  // behind apex
+    primitives.push_back(MakePointPrimitive(15, 0, 5, 5));  // way off-axis
+    BVH bvh;
+    bvh.Build(primitives.data(), primitives.size());
+
+    Math::Cone cone = Math::Cone::FromAxisAndAngle(
+        FloatVector4(0,0,0,0),
+        FloatVector4(0,0,1,0),
+        20.0f,
+        float(3.14159 / 6)); // 30 deg
+
+    std::vector<uint32_t> out;
+    bvh.QueryCone(primitives.data(), cone, out);
+    auto sorted = SortedCopy(out);
+
+    // Must include the three on-axis points within range.
+    EXPECT_TRUE(std::find(sorted.begin(), sorted.end(), 0u) != sorted.end());
+    EXPECT_TRUE(std::find(sorted.begin(), sorted.end(), 1u) != sorted.end());
+    EXPECT_TRUE(std::find(sorted.begin(), sorted.end(), 2u) != sorted.end());
+    // Must NOT include points past range or behind apex by more than a sphere-radius.
+    EXPECT_TRUE(std::find(sorted.begin(), sorted.end(), 3u) == sorted.end());
+    EXPECT_TRUE(std::find(sorted.begin(), sorted.end(), 4u) == sorted.end());
+    // Way off-axis must be rejected.
+    EXPECT_TRUE(std::find(sorted.begin(), sorted.end(), 5u) == sorted.end());
+}
+
+TEST(BVHTest, QueryConeBruteForceEquivalence)
+{
+    // Conservatism contract: QueryCone uses the AABB outer sphere
+    // at the primitive tier, so the brute-force reference uses the
+    // SAME sphere-cone test on each per-primitive AABB.  Anything
+    // tighter would over-reject relative to the BVH.
+    std::mt19937 rng(0xDEADC0DE);
+    std::uniform_real_distribution<float> posDist(-25.0f, 25.0f);
+    std::uniform_real_distribution<float> halfDist(0.25f, 2.0f);
+    std::uniform_real_distribution<float> rangeDist(8.0f, 30.0f);
+    std::uniform_real_distribution<float> angleDist(0.15f, 1.0f); // ~9 to 57 deg
+    std::uniform_real_distribution<float> dirDist(-1.0f, 1.0f);
+
+    std::vector<BVHPrimitive> primitives;
+    primitives.reserve(250);
+    for (int i = 0; i < 250; ++i)
+    {
+        const float cx = posDist(rng), cy = posDist(rng), cz = posDist(rng);
+        const float hx = halfDist(rng), hy = halfDist(rng), hz = halfDist(rng);
+        primitives.push_back(MakeBoxPrimitive(
+            FloatVector4(cx - hx, cy - hy, cz - hz, 0.0f),
+            FloatVector4(cx + hx, cy + hy, cz + hz, 0.0f),
+            uint32_t(i)));
+    }
+
+    BVH bvh;
+    bvh.Build(primitives.data(), primitives.size());
+
+    // Local sphere-cone reference matching the implementation under test.
+    auto refSphereCone = [](const FloatVector4& c, float r,
+                            const FloatVector4& apex, const FloatVector4& dir,
+                            float range, float tanT, float invCosT) {
+        const float vx = c.V[0] - apex.V[0];
+        const float vy = c.V[1] - apex.V[1];
+        const float vz = c.V[2] - apex.V[2];
+        const float distAxis = vx * dir.V[0] + vy * dir.V[1] + vz * dir.V[2];
+        if (distAxis > range + r) return false;
+        if (distAxis < -r) return false;
+        const float vLenSq = vx*vx + vy*vy + vz*vz;
+        const float perpSq = vLenSq - distAxis * distAxis;
+        const float perp = (perpSq > 0.0f) ? std::sqrt(perpSq) : 0.0f;
+        const float t = (distAxis > 0.0f) ? distAxis : 0.0f;
+        return perp <= t * tanT + r * invCosT;
+    };
+
+    auto refConeAABB = [&](const AABB& b, const Math::Cone& cone) {
+        if (b.IsEmpty()) return false;
+        const FloatVector4 center = b.GetCenter();
+        const FloatVector4 ext    = b.GetExtents();
+        const float radius = std::sqrt(ext.V[0]*ext.V[0] + ext.V[1]*ext.V[1] + ext.V[2]*ext.V[2]);
+        return refSphereCone(center, radius,
+                             cone.Apex, cone.AxisDir,
+                             cone.Range, cone.TanHalfAngle, cone.InvCosHalfAngle);
+    };
+
+    for (int q = 0; q < 30; ++q)
+    {
+        FloatVector4 apex(posDist(rng), posDist(rng), posDist(rng), 0.0f);
+        FloatVector4 dir(dirDist(rng), dirDist(rng), dirDist(rng), 0.0f);
+        // Avoid degenerate axis: FromAxisAndAngle defends with
+        // length>epsilon, but we want a real cone for the test.
+        if (std::abs(dir.V[0]) + std::abs(dir.V[1]) + std::abs(dir.V[2]) < 0.01f)
+            dir = FloatVector4(0, 0, 1, 0);
+
+        Math::Cone cone = Math::Cone::FromAxisAndAngle(apex, dir, rangeDist(rng), angleDist(rng));
+
+        std::vector<uint32_t> bvhOut;
+        bvh.QueryCone(primitives.data(), cone, bvhOut);
+
+        std::vector<uint32_t> bfOut;
+        for (uint32_t i = 0; i < primitives.size(); ++i)
+            if (refConeAABB(primitives[i].WorldBounds, cone))
+                bfOut.push_back(i);
+
+        auto a = SortedCopy(bvhOut);
+        auto b = SortedCopy(bfOut);
+        if (a != b)
         {
-            std::vector<BVHPrimitive> primitives;
-            for (uint32_t i = 0; i < 5; ++i)
-                primitives.push_back(MakePointPrimitive(float(i), 0, 0, i));
-            BVH bvh;
-            bvh.Build(primitives.data(), primitives.size());
-
-            // r <= 0 must short-circuit to no results.
-            std::vector<uint32_t> out;
-            bvh.QuerySphere(primitives.data(), FloatVector4(0,0,0,0), 0.0f, out);
-            Assert::AreEqual(size_t(0), out.size());
-            bvh.QuerySphere(primitives.data(), FloatVector4(0,0,0,0), -1.0f, out);
-            Assert::AreEqual(size_t(0), out.size());
-
-            // Sphere enclosing every primitive must return all 5.
-            out.clear();
-            bvh.QuerySphere(primitives.data(), FloatVector4(2.0f,0,0,0), 100.0f, out);
-            Assert::AreEqual(size_t(5), out.size());
+            std::ostringstream ss;
+            ss << "QueryCone mismatch q=" << q
+               << " bvh=" << a.size() << " bf=" << b.size();
+            FAIL() << ss.str();
         }
-
-        TEST_METHOD(QueryAABBBruteForceEquivalence)
-        {
-            std::mt19937 rng(0xFEEDFACE);
-            std::uniform_real_distribution<float> posDist(-30.0f, 30.0f);
-            std::uniform_real_distribution<float> halfDist(0.25f, 2.0f);
-            std::uniform_real_distribution<float> boxHalf(1.0f, 12.0f);
-
-            std::vector<BVHPrimitive> primitives;
-            primitives.reserve(400);
-            for (int i = 0; i < 400; ++i)
-            {
-                const float cx = posDist(rng), cy = posDist(rng), cz = posDist(rng);
-                const float hx = halfDist(rng), hy = halfDist(rng), hz = halfDist(rng);
-                primitives.push_back(MakeBoxPrimitive(
-                    FloatVector4(cx - hx, cy - hy, cz - hz, 0.0f),
-                    FloatVector4(cx + hx, cy + hy, cz + hz, 0.0f),
-                    uint32_t(i)));
-            }
-
-            BVH bvh;
-            bvh.Build(primitives.data(), primitives.size());
-
-            auto refOverlap = [](const AABB& a, const AABB& b) {
-                if (a.IsEmpty() || b.IsEmpty()) return false;
-                return !(a.Max.V[0] < b.Min.V[0] || a.Min.V[0] > b.Max.V[0]
-                      || a.Max.V[1] < b.Min.V[1] || a.Min.V[1] > b.Max.V[1]
-                      || a.Max.V[2] < b.Min.V[2] || a.Min.V[2] > b.Max.V[2]);
-            };
-
-            for (int q = 0; q < 30; ++q)
-            {
-                const float cx = posDist(rng), cy = posDist(rng), cz = posDist(rng);
-                const float hx = boxHalf(rng), hy = boxHalf(rng), hz = boxHalf(rng);
-                AABB box(FloatVector4(cx-hx, cy-hy, cz-hz, 0),
-                         FloatVector4(cx+hx, cy+hy, cz+hz, 0));
-
-                std::vector<uint32_t> bvhOut;
-                bvh.QueryAABB(primitives.data(), box, bvhOut);
-
-                std::vector<uint32_t> bfOut;
-                for (uint32_t i = 0; i < primitives.size(); ++i)
-                    if (refOverlap(box, primitives[i].WorldBounds))
-                        bfOut.push_back(i);
-
-                auto a = SortedCopy(bvhOut);
-                auto b = SortedCopy(bfOut);
-                if (a != b)
-                {
-                    std::wstringstream ss;
-                    ss << L"QueryAABB mismatch q=" << q
-                       << L" bvh=" << a.size() << L" bf=" << b.size();
-                    Assert::Fail(ss.str().c_str());
-                }
-            }
-
-            // Empty query box must be a no-op.
-            std::vector<uint32_t> out;
-            bvh.QueryAABB(primitives.data(), AABB{}, out);
-            Assert::AreEqual(size_t(0), out.size());
-        }
-
-        TEST_METHOD(QueryConeAcceptsKnownInside)
-        {
-            // Hand-built case: cone along +Z, apex at origin, half-angle 30
-            // deg, range 20.  Primitives along the axis must be returned;
-            // a primitive well off-axis must NOT be returned.
-            std::vector<BVHPrimitive> primitives;
-            primitives.push_back(MakePointPrimitive(0, 0,  1, 0));  // on axis
-            primitives.push_back(MakePointPrimitive(0, 0, 10, 1));  // on axis
-            primitives.push_back(MakePointPrimitive(0, 0, 19, 2));  // near range end
-            primitives.push_back(MakePointPrimitive(0, 0, 25, 3));  // past range
-            primitives.push_back(MakePointPrimitive(0, 0, -1, 4));  // behind apex
-            primitives.push_back(MakePointPrimitive(15, 0, 5, 5));  // way off-axis
-            BVH bvh;
-            bvh.Build(primitives.data(), primitives.size());
-
-            Math::Cone cone = Math::Cone::FromAxisAndAngle(
-                FloatVector4(0,0,0,0),
-                FloatVector4(0,0,1,0),
-                20.0f,
-                float(3.14159 / 6)); // 30 deg
-
-            std::vector<uint32_t> out;
-            bvh.QueryCone(primitives.data(), cone, out);
-            auto sorted = SortedCopy(out);
-
-            // Must include the three on-axis points within range.
-            Assert::IsTrue(std::find(sorted.begin(), sorted.end(), 0u) != sorted.end());
-            Assert::IsTrue(std::find(sorted.begin(), sorted.end(), 1u) != sorted.end());
-            Assert::IsTrue(std::find(sorted.begin(), sorted.end(), 2u) != sorted.end());
-            // Must NOT include points past range or behind apex by more than a sphere-radius.
-            Assert::IsTrue(std::find(sorted.begin(), sorted.end(), 3u) == sorted.end());
-            Assert::IsTrue(std::find(sorted.begin(), sorted.end(), 4u) == sorted.end());
-            // Way off-axis must be rejected.
-            Assert::IsTrue(std::find(sorted.begin(), sorted.end(), 5u) == sorted.end());
-        }
-
-        TEST_METHOD(QueryConeBruteForceEquivalence)
-        {
-            // Conservatism contract: QueryCone uses the AABB outer sphere
-            // at the primitive tier, so the brute-force reference uses the
-            // SAME sphere-cone test on each per-primitive AABB.  Anything
-            // tighter would over-reject relative to the BVH.
-            std::mt19937 rng(0xDEADC0DE);
-            std::uniform_real_distribution<float> posDist(-25.0f, 25.0f);
-            std::uniform_real_distribution<float> halfDist(0.25f, 2.0f);
-            std::uniform_real_distribution<float> rangeDist(8.0f, 30.0f);
-            std::uniform_real_distribution<float> angleDist(0.15f, 1.0f); // ~9 to 57 deg
-            std::uniform_real_distribution<float> dirDist(-1.0f, 1.0f);
-
-            std::vector<BVHPrimitive> primitives;
-            primitives.reserve(250);
-            for (int i = 0; i < 250; ++i)
-            {
-                const float cx = posDist(rng), cy = posDist(rng), cz = posDist(rng);
-                const float hx = halfDist(rng), hy = halfDist(rng), hz = halfDist(rng);
-                primitives.push_back(MakeBoxPrimitive(
-                    FloatVector4(cx - hx, cy - hy, cz - hz, 0.0f),
-                    FloatVector4(cx + hx, cy + hy, cz + hz, 0.0f),
-                    uint32_t(i)));
-            }
-
-            BVH bvh;
-            bvh.Build(primitives.data(), primitives.size());
-
-            // Local sphere-cone reference matching the implementation under test.
-            auto refSphereCone = [](const FloatVector4& c, float r,
-                                    const FloatVector4& apex, const FloatVector4& dir,
-                                    float range, float tanT, float invCosT) {
-                const float vx = c.V[0] - apex.V[0];
-                const float vy = c.V[1] - apex.V[1];
-                const float vz = c.V[2] - apex.V[2];
-                const float distAxis = vx * dir.V[0] + vy * dir.V[1] + vz * dir.V[2];
-                if (distAxis > range + r) return false;
-                if (distAxis < -r) return false;
-                const float vLenSq = vx*vx + vy*vy + vz*vz;
-                const float perpSq = vLenSq - distAxis * distAxis;
-                const float perp = (perpSq > 0.0f) ? std::sqrt(perpSq) : 0.0f;
-                const float t = (distAxis > 0.0f) ? distAxis : 0.0f;
-                return perp <= t * tanT + r * invCosT;
-            };
-
-            auto refConeAABB = [&](const AABB& b, const Math::Cone& cone) {
-                if (b.IsEmpty()) return false;
-                const FloatVector4 center = b.GetCenter();
-                const FloatVector4 ext    = b.GetExtents();
-                const float radius = std::sqrt(ext.V[0]*ext.V[0] + ext.V[1]*ext.V[1] + ext.V[2]*ext.V[2]);
-                return refSphereCone(center, radius,
-                                     cone.Apex, cone.AxisDir,
-                                     cone.Range, cone.TanHalfAngle, cone.InvCosHalfAngle);
-            };
-
-            for (int q = 0; q < 30; ++q)
-            {
-                FloatVector4 apex(posDist(rng), posDist(rng), posDist(rng), 0.0f);
-                FloatVector4 dir(dirDist(rng), dirDist(rng), dirDist(rng), 0.0f);
-                // Avoid degenerate axis: FromAxisAndAngle defends with
-                // length>epsilon, but we want a real cone for the test.
-                if (std::abs(dir.V[0]) + std::abs(dir.V[1]) + std::abs(dir.V[2]) < 0.01f)
-                    dir = FloatVector4(0, 0, 1, 0);
-
-                Math::Cone cone = Math::Cone::FromAxisAndAngle(apex, dir, rangeDist(rng), angleDist(rng));
-
-                std::vector<uint32_t> bvhOut;
-                bvh.QueryCone(primitives.data(), cone, bvhOut);
-
-                std::vector<uint32_t> bfOut;
-                for (uint32_t i = 0; i < primitives.size(); ++i)
-                    if (refConeAABB(primitives[i].WorldBounds, cone))
-                        bfOut.push_back(i);
-
-                auto a = SortedCopy(bvhOut);
-                auto b = SortedCopy(bfOut);
-                if (a != b)
-                {
-                    std::wstringstream ss;
-                    ss << L"QueryCone mismatch q=" << q
-                       << L" bvh=" << a.size() << L" bf=" << b.size();
-                    Assert::Fail(ss.str().c_str());
-                }
-            }
-        }
-};
+    }
+}
 
 } // namespace CanvasUnitTest

--- a/src/CanvasUnitTest/BVHTest.cpp
+++ b/src/CanvasUnitTest/BVHTest.cpp
@@ -1,0 +1,295 @@
+//================================================================================================
+// BVHTest -- keystone correctness test for the scene BVH.
+//
+// Contract: the BVH must produce EXACTLY the same visible set as a
+// brute-force linear scan that applies Frustum::IntersectsAABB to every
+// primitive.  False negatives (silently hidden geometry) are never
+// allowed.  False positives are bounded by the conservative p-vertex
+// test that brute force uses too, so the two sets are equal -- not
+// merely "BVH is a superset."
+//
+// This test fuzzes that property across many random scenes and
+// frustums, plus explicit corner cases.  Any failure is a real bug in
+// the BVH builder or traversal.
+//================================================================================================
+
+#include "pch.h"
+#include "CppUnitTest.h"
+
+#include "BVH.h"
+
+#include <algorithm>
+#include <random>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace Canvas;
+using namespace Canvas::Math;
+
+namespace CanvasUnitTest
+{
+
+namespace
+{
+
+BVHPrimitive MakePointPrimitive(float x, float y, float z, uint32_t id)
+{
+    BVHPrimitive prim;
+    prim.WorldBounds = AABB(FloatVector4(x, y, z, 0.0f), FloatVector4(x, y, z, 0.0f));
+    prim.Id = id;
+    prim.Node = nullptr;
+    prim.Flags = BVHPrimitiveFlag_Static;
+    return prim;
+}
+
+BVHPrimitive MakeBoxPrimitive(const FloatVector4& mn, const FloatVector4& mx, uint32_t id)
+{
+    BVHPrimitive prim;
+    prim.WorldBounds = AABB(mn, mx);
+    prim.Id = id;
+    prim.Node = nullptr;
+    prim.Flags = BVHPrimitiveFlag_Static;
+    return prim;
+}
+
+// Brute-force reference: returns the indices (into primitives) of every
+// primitive whose bounds pass the frustum test, in ascending order.
+std::vector<uint32_t> BruteForceCull(const std::vector<BVHPrimitive>& primitives, const Frustum& f)
+{
+    std::vector<uint32_t> out;
+    out.reserve(primitives.size());
+    for (uint32_t i = 0; i < primitives.size(); ++i)
+        if (f.IntersectsAABB(primitives[i].WorldBounds))
+            out.push_back(i);
+    return out;
+}
+
+std::vector<uint32_t> SortedCopy(std::vector<uint32_t> v)
+{
+    std::sort(v.begin(), v.end());
+    return v;
+}
+
+// Build a perspective view-proj from a camera at `eye` looking at `target`
+// with worldUp = +Y.  Returns a row-vector view*proj suitable for
+// Frustum::FromViewProjection(reverseZ=true).
+//
+// View basis (Canvas view space is LHS, +X right, +Y up, +Z forward):
+//   forward = normalize(target - eye)
+//   side    = normalize(up x forward)
+//   up      = forward x side
+FloatMatrix4x4 BuildViewProj(const FloatVector4& eye, const FloatVector4& target,
+                             float fovY, float aspect, float zn, float zf)
+{
+    float fx = target.V[0] - eye.V[0];
+    float fy = target.V[1] - eye.V[1];
+    float fz = target.V[2] - eye.V[2];
+    float flen = std::sqrt(fx*fx + fy*fy + fz*fz);
+    if (flen < 1e-6f) { fx = 0; fy = 0; fz = 1; flen = 1; }
+    fx /= flen; fy /= flen; fz /= flen;
+
+    // side = (0,1,0) x forward = (fz, 0, -fx)
+    float sx = fz;
+    float sy = 0.0f;
+    float sz = -fx;
+    float slen = std::sqrt(sx*sx + sy*sy + sz*sz);
+    if (slen < 1e-6f) { sx = 1; sy = 0; sz = 0; slen = 1; }
+    sx /= slen; sy /= slen; sz /= slen;
+
+    // up = forward x side
+    const float ux = fy * sz - fz * sy;
+    const float uy = fz * sx - fx * sz;
+    const float uz = fx * sy - fy * sx;
+
+    // Row-vector world->view matrix: basis vectors as columns,
+    // translation is -dot(eye, basis_row) per row.
+    FloatMatrix4x4 view = {};
+    view.M[0][0] = sx;  view.M[0][1] = ux;  view.M[0][2] = fx;  view.M[0][3] = 0.0f;
+    view.M[1][0] = sy;  view.M[1][1] = uy;  view.M[1][2] = fy;  view.M[1][3] = 0.0f;
+    view.M[2][0] = sz;  view.M[2][1] = uz;  view.M[2][2] = fz;  view.M[2][3] = 0.0f;
+    view.M[3][0] = -(eye.V[0]*sx + eye.V[1]*sy + eye.V[2]*sz);
+    view.M[3][1] = -(eye.V[0]*ux + eye.V[1]*uy + eye.V[2]*uz);
+    view.M[3][2] = -(eye.V[0]*fx + eye.V[1]*fy + eye.V[2]*fz);
+    view.M[3][3] = 1.0f;
+
+    FloatMatrix4x4 proj = PerspectiveReverseZ<float>(fovY, aspect, zn, zf);
+    return view * proj;
+}
+
+} // anonymous namespace
+
+TEST_CLASS(BVHTest)
+{
+public:
+
+    // Empty BVH must produce empty cull set without crashing or accessing
+    // out-of-bounds memory.  Defends the early-out in QueryFrustum.
+    TEST_METHOD(EmptyBVH)
+    {
+        BVH bvh;
+        bvh.Build(nullptr, 0);
+        Assert::IsTrue(bvh.Empty());
+
+        Frustum f = Frustum::FromViewProjection(
+            PerspectiveReverseZ<float>(1.0f, 1.0f, 1.0f, 100.0f), true);
+        std::vector<uint32_t> visible;
+        bvh.QueryFrustum(nullptr, f, visible);
+        Assert::AreEqual(size_t(0), visible.size());
+    }
+
+    // All-empty primitives (sentinel AABBs) must be silently dropped at
+    // build time.  The BVH should report Empty() even though count > 0.
+    TEST_METHOD(EmptySentinelPrimitivesAreDropped)
+    {
+        std::vector<BVHPrimitive> primitives;
+        BVHPrimitive a; a.WorldBounds = AABB{}; a.Id = 0;
+        BVHPrimitive b; b.WorldBounds = AABB{}; b.Id = 1;
+        primitives.push_back(a);
+        primitives.push_back(b);
+        BVH bvh;
+        bvh.Build(primitives.data(), primitives.size());
+        Assert::IsTrue(bvh.Empty());
+    }
+
+    // Single-leaf-node tree: trivial path through Build, exercises the
+    // count <= kMaxPrimitivesPerLeaf early-out.
+    TEST_METHOD(SingleLeafNode)
+    {
+        std::vector<BVHPrimitive> primitives;
+        for (uint32_t i = 0; i < 3; ++i)
+            primitives.push_back(MakePointPrimitive(0.0f, 0.0f, 10.0f + float(i), i));
+        BVH bvh;
+        bvh.Build(primitives.data(), primitives.size());
+        Assert::IsFalse(bvh.Empty());
+        Assert::AreEqual(size_t(3), bvh.PrimitiveCount());
+
+        Frustum f = Frustum::FromViewProjection(
+            PerspectiveReverseZ<float>(float(3.14159 / 2), 1.0f, 0.5f, 100.0f), true);
+        std::vector<uint32_t> visible;
+        bvh.QueryFrustum(primitives.data(), f, visible);
+        Assert::AreEqual(size_t(3), visible.size());
+    }
+
+    // Brute-force equivalence on a hand-built scene: ensures the
+    // dedup/ordering of BVH output matches the reference modulo sort.
+    TEST_METHOD(BruteForceEquivalenceHandBuilt)
+    {
+        std::vector<BVHPrimitive> primitives;
+        for (uint32_t i = 0; i < 50; ++i)
+        {
+            const float x = -20.0f + float(i % 10) * 4.0f;
+            const float y = -10.0f + float((i / 10) % 5) * 4.0f;
+            const float z = 5.0f + float(i % 7) * 3.0f;
+            primitives.push_back(MakeBoxPrimitive(
+                FloatVector4(x - 0.5f, y - 0.5f, z - 0.5f, 0.0f),
+                FloatVector4(x + 0.5f, y + 0.5f, z + 0.5f, 0.0f),
+                i));
+        }
+        BVH bvh;
+        bvh.Build(primitives.data(), primitives.size());
+
+        FloatMatrix4x4 vp = BuildViewProj(
+            FloatVector4(0.0f, 0.0f, 0.0f, 1.0f),
+            FloatVector4(0.0f, 0.0f, 1.0f, 1.0f),
+            float(3.14159 / 3), 16.0f / 9.0f, 0.5f, 100.0f);
+        Frustum f = Frustum::FromViewProjection(vp, true);
+
+        std::vector<uint32_t> bvhVisible;
+        bvh.QueryFrustum(primitives.data(), f, bvhVisible);
+        std::vector<uint32_t> bfVisible = BruteForceCull(primitives, f);
+
+        Assert::AreEqual(bfVisible.size(), bvhVisible.size(),
+                         L"BVH visible count != brute force");
+        auto bvhSorted = SortedCopy(bvhVisible);
+        auto bfSorted  = SortedCopy(bfVisible);
+        for (size_t i = 0; i < bfSorted.size(); ++i)
+            Assert::AreEqual(bfSorted[i], bvhSorted[i]);
+    }
+
+    // The keystone fuzz: many random scenes, many random cameras, every
+    // pairing must agree exactly with brute force.  Seeded RNG so any
+    // failure is reproducible from the test log alone.
+    TEST_METHOD(BruteForceEquivalenceFuzz)
+    {
+        std::mt19937 rng(0xC0FFEE);
+        std::uniform_real_distribution<float> posDist(-50.0f, 50.0f);
+        std::uniform_real_distribution<float> halfDist(0.25f, 2.5f);
+        std::uniform_real_distribution<float> camDist(-30.0f, 30.0f);
+        std::uniform_real_distribution<float> tgtDist(-30.0f, 30.0f);
+        std::uniform_real_distribution<float> fovDist(0.5f, 2.0f);   // ~28 to 115 deg
+        std::uniform_real_distribution<float> aspDist(0.5f, 2.5f);
+
+        const int kPrimitiveCount = 500;
+        const int kFrustumCount = 25;
+
+        std::vector<BVHPrimitive> primitives;
+        primitives.reserve(kPrimitiveCount);
+        for (int i = 0; i < kPrimitiveCount; ++i)
+        {
+            const float cx = posDist(rng), cy = posDist(rng), cz = posDist(rng);
+            const float hx = halfDist(rng), hy = halfDist(rng), hz = halfDist(rng);
+            primitives.push_back(MakeBoxPrimitive(
+                FloatVector4(cx - hx, cy - hy, cz - hz, 0.0f),
+                FloatVector4(cx + hx, cy + hy, cz + hz, 0.0f),
+                uint32_t(i)));
+        }
+
+        BVH bvh;
+        bvh.Build(primitives.data(), primitives.size());
+        Assert::AreEqual(size_t(kPrimitiveCount), bvh.PrimitiveCount());
+
+        for (int t = 0; t < kFrustumCount; ++t)
+        {
+            FloatVector4 eye(camDist(rng), camDist(rng), camDist(rng), 1.0f);
+            FloatVector4 tgt(tgtDist(rng), tgtDist(rng), tgtDist(rng), 1.0f);
+            // Avoid degenerate eye==target.
+            if (std::abs(eye.V[0]-tgt.V[0]) + std::abs(eye.V[1]-tgt.V[1]) + std::abs(eye.V[2]-tgt.V[2]) < 0.1f)
+                tgt.V[2] += 5.0f;
+
+            FloatMatrix4x4 vp = BuildViewProj(eye, tgt, fovDist(rng), aspDist(rng), 0.5f, 200.0f);
+            Frustum f = Frustum::FromViewProjection(vp, true);
+
+            std::vector<uint32_t> bvhVisible;
+            bvh.QueryFrustum(primitives.data(), f, bvhVisible);
+            std::vector<uint32_t> bfVisible = BruteForceCull(primitives, f);
+
+            auto bvhSorted = SortedCopy(bvhVisible);
+            auto bfSorted  = SortedCopy(bfVisible);
+
+            // Detailed assertion: report sizes on the first mismatch so
+            // the failure log is actionable.
+            if (bvhSorted != bfSorted)
+            {
+                std::wstringstream ss;
+                ss << L"Mismatch on frustum #" << t
+                   << L"  bvh.size=" << bvhSorted.size()
+                   << L"  bf.size=" << bfSorted.size();
+                Assert::Fail(ss.str().c_str());
+            }
+        }
+    }
+
+    // All-outside: a frustum looking away from any primitive must return
+    // empty.  Catches plane-sign inversions that would falsely include
+    // everything.
+    TEST_METHOD(FrustumLookingAway)
+    {
+        std::vector<BVHPrimitive> primitives;
+        for (uint32_t i = 0; i < 20; ++i)
+            primitives.push_back(MakePointPrimitive(float(i), 0.0f, 50.0f, i));
+        BVH bvh;
+        bvh.Build(primitives.data(), primitives.size());
+
+        // Camera at origin looking down -Z (away from all primitives
+        // which sit at z=50, i.e. behind the camera in this view).
+        FloatMatrix4x4 vp = BuildViewProj(
+            FloatVector4(0,0,0,1), FloatVector4(0,0,-1,1),
+            float(3.14159 / 3), 1.0f, 0.5f, 100.0f);
+        Frustum f = Frustum::FromViewProjection(vp, true);
+
+        std::vector<uint32_t> visible;
+        bvh.QueryFrustum(primitives.data(), f, visible);
+        Assert::AreEqual(size_t(0), visible.size());
+    }
+};
+
+} // namespace CanvasUnitTest

--- a/src/CanvasUnitTest/BVHTest.cpp
+++ b/src/CanvasUnitTest/BVHTest.cpp
@@ -290,6 +290,283 @@ public:
         bvh.QueryFrustum(primitives.data(), f, visible);
         Assert::AreEqual(size_t(0), visible.size());
     }
+
+        // ============================================================
+        // QuerySphere / QueryCone / QueryAABB tests.
+        //
+        // Same contract as the frustum tests: BVH output must equal the
+        // brute-force-scan output for the same shape predicate (modulo
+        // sort).  The shape tests are exact at the per-primitive tier --
+        // the only conservatism is in the cone test, where AABBs are
+        // bounded by their outer sphere; the brute force comparator
+        // therefore must use the same test on the per-primitive AABB, not
+        // a tighter cone-AABB test, to remain an apples-to-apples
+        // reference.
+        // ============================================================
+
+        TEST_METHOD(QuerySphereBruteForceEquivalence)
+        {
+            std::mt19937 rng(0xB0BACAFE);
+            std::uniform_real_distribution<float> posDist(-30.0f, 30.0f);
+            std::uniform_real_distribution<float> halfDist(0.25f, 2.0f);
+            std::uniform_real_distribution<float> rDist(1.0f, 15.0f);
+
+            std::vector<BVHPrimitive> primitives;
+            primitives.reserve(300);
+            for (int i = 0; i < 300; ++i)
+            {
+                const float cx = posDist(rng), cy = posDist(rng), cz = posDist(rng);
+                const float hx = halfDist(rng), hy = halfDist(rng), hz = halfDist(rng);
+                primitives.push_back(MakeBoxPrimitive(
+                    FloatVector4(cx - hx, cy - hy, cz - hz, 0.0f),
+                    FloatVector4(cx + hx, cy + hy, cz + hz, 0.0f),
+                    uint32_t(i)));
+            }
+
+            BVH bvh;
+            bvh.Build(primitives.data(), primitives.size());
+
+            // Reference closest-point sphere-AABB test, kept local so the
+            // assertion is decoupled from the implementation under test.
+            auto ref = [](const FloatVector4& c, float r, const AABB& b) {
+                if (b.IsEmpty() || r <= 0.0f) return false;
+                float d2 = 0.0f;
+                for (int i = 0; i < 3; ++i)
+                {
+                    if (c.V[i] < b.Min.V[i]) { float d = b.Min.V[i] - c.V[i]; d2 += d*d; }
+                    else if (c.V[i] > b.Max.V[i]) { float d = c.V[i] - b.Max.V[i]; d2 += d*d; }
+                }
+                return d2 <= r * r;
+            };
+
+            for (int q = 0; q < 30; ++q)
+            {
+                FloatVector4 c(posDist(rng), posDist(rng), posDist(rng), 0.0f);
+                float r = rDist(rng);
+
+                std::vector<uint32_t> bvhOut;
+                bvh.QuerySphere(primitives.data(), c, r, bvhOut);
+
+                std::vector<uint32_t> bfOut;
+                for (uint32_t i = 0; i < primitives.size(); ++i)
+                    if (ref(c, r, primitives[i].WorldBounds))
+                        bfOut.push_back(i);
+
+                auto a = SortedCopy(bvhOut);
+                auto b = SortedCopy(bfOut);
+                if (a != b)
+                {
+                    std::wstringstream ss;
+                    ss << L"QuerySphere mismatch q=" << q
+                       << L" bvh=" << a.size() << L" bf=" << b.size();
+                    Assert::Fail(ss.str().c_str());
+                }
+            }
+        }
+
+        TEST_METHOD(QuerySphereEmptyAndDegenerate)
+        {
+            std::vector<BVHPrimitive> primitives;
+            for (uint32_t i = 0; i < 5; ++i)
+                primitives.push_back(MakePointPrimitive(float(i), 0, 0, i));
+            BVH bvh;
+            bvh.Build(primitives.data(), primitives.size());
+
+            // r <= 0 must short-circuit to no results.
+            std::vector<uint32_t> out;
+            bvh.QuerySphere(primitives.data(), FloatVector4(0,0,0,0), 0.0f, out);
+            Assert::AreEqual(size_t(0), out.size());
+            bvh.QuerySphere(primitives.data(), FloatVector4(0,0,0,0), -1.0f, out);
+            Assert::AreEqual(size_t(0), out.size());
+
+            // Sphere enclosing every primitive must return all 5.
+            out.clear();
+            bvh.QuerySphere(primitives.data(), FloatVector4(2.0f,0,0,0), 100.0f, out);
+            Assert::AreEqual(size_t(5), out.size());
+        }
+
+        TEST_METHOD(QueryAABBBruteForceEquivalence)
+        {
+            std::mt19937 rng(0xFEEDFACE);
+            std::uniform_real_distribution<float> posDist(-30.0f, 30.0f);
+            std::uniform_real_distribution<float> halfDist(0.25f, 2.0f);
+            std::uniform_real_distribution<float> boxHalf(1.0f, 12.0f);
+
+            std::vector<BVHPrimitive> primitives;
+            primitives.reserve(400);
+            for (int i = 0; i < 400; ++i)
+            {
+                const float cx = posDist(rng), cy = posDist(rng), cz = posDist(rng);
+                const float hx = halfDist(rng), hy = halfDist(rng), hz = halfDist(rng);
+                primitives.push_back(MakeBoxPrimitive(
+                    FloatVector4(cx - hx, cy - hy, cz - hz, 0.0f),
+                    FloatVector4(cx + hx, cy + hy, cz + hz, 0.0f),
+                    uint32_t(i)));
+            }
+
+            BVH bvh;
+            bvh.Build(primitives.data(), primitives.size());
+
+            auto refOverlap = [](const AABB& a, const AABB& b) {
+                if (a.IsEmpty() || b.IsEmpty()) return false;
+                return !(a.Max.V[0] < b.Min.V[0] || a.Min.V[0] > b.Max.V[0]
+                      || a.Max.V[1] < b.Min.V[1] || a.Min.V[1] > b.Max.V[1]
+                      || a.Max.V[2] < b.Min.V[2] || a.Min.V[2] > b.Max.V[2]);
+            };
+
+            for (int q = 0; q < 30; ++q)
+            {
+                const float cx = posDist(rng), cy = posDist(rng), cz = posDist(rng);
+                const float hx = boxHalf(rng), hy = boxHalf(rng), hz = boxHalf(rng);
+                AABB box(FloatVector4(cx-hx, cy-hy, cz-hz, 0),
+                         FloatVector4(cx+hx, cy+hy, cz+hz, 0));
+
+                std::vector<uint32_t> bvhOut;
+                bvh.QueryAABB(primitives.data(), box, bvhOut);
+
+                std::vector<uint32_t> bfOut;
+                for (uint32_t i = 0; i < primitives.size(); ++i)
+                    if (refOverlap(box, primitives[i].WorldBounds))
+                        bfOut.push_back(i);
+
+                auto a = SortedCopy(bvhOut);
+                auto b = SortedCopy(bfOut);
+                if (a != b)
+                {
+                    std::wstringstream ss;
+                    ss << L"QueryAABB mismatch q=" << q
+                       << L" bvh=" << a.size() << L" bf=" << b.size();
+                    Assert::Fail(ss.str().c_str());
+                }
+            }
+
+            // Empty query box must be a no-op.
+            std::vector<uint32_t> out;
+            bvh.QueryAABB(primitives.data(), AABB{}, out);
+            Assert::AreEqual(size_t(0), out.size());
+        }
+
+        TEST_METHOD(QueryConeAcceptsKnownInside)
+        {
+            // Hand-built case: cone along +Z, apex at origin, half-angle 30
+            // deg, range 20.  Primitives along the axis must be returned;
+            // a primitive well off-axis must NOT be returned.
+            std::vector<BVHPrimitive> primitives;
+            primitives.push_back(MakePointPrimitive(0, 0,  1, 0));  // on axis
+            primitives.push_back(MakePointPrimitive(0, 0, 10, 1));  // on axis
+            primitives.push_back(MakePointPrimitive(0, 0, 19, 2));  // near range end
+            primitives.push_back(MakePointPrimitive(0, 0, 25, 3));  // past range
+            primitives.push_back(MakePointPrimitive(0, 0, -1, 4));  // behind apex
+            primitives.push_back(MakePointPrimitive(15, 0, 5, 5));  // way off-axis
+            BVH bvh;
+            bvh.Build(primitives.data(), primitives.size());
+
+            Math::Cone cone = Math::Cone::FromAxisAndAngle(
+                FloatVector4(0,0,0,0),
+                FloatVector4(0,0,1,0),
+                20.0f,
+                float(3.14159 / 6)); // 30 deg
+
+            std::vector<uint32_t> out;
+            bvh.QueryCone(primitives.data(), cone, out);
+            auto sorted = SortedCopy(out);
+
+            // Must include the three on-axis points within range.
+            Assert::IsTrue(std::find(sorted.begin(), sorted.end(), 0u) != sorted.end());
+            Assert::IsTrue(std::find(sorted.begin(), sorted.end(), 1u) != sorted.end());
+            Assert::IsTrue(std::find(sorted.begin(), sorted.end(), 2u) != sorted.end());
+            // Must NOT include points past range or behind apex by more than a sphere-radius.
+            Assert::IsTrue(std::find(sorted.begin(), sorted.end(), 3u) == sorted.end());
+            Assert::IsTrue(std::find(sorted.begin(), sorted.end(), 4u) == sorted.end());
+            // Way off-axis must be rejected.
+            Assert::IsTrue(std::find(sorted.begin(), sorted.end(), 5u) == sorted.end());
+        }
+
+        TEST_METHOD(QueryConeBruteForceEquivalence)
+        {
+            // Conservatism contract: QueryCone uses the AABB outer sphere
+            // at the primitive tier, so the brute-force reference uses the
+            // SAME sphere-cone test on each per-primitive AABB.  Anything
+            // tighter would over-reject relative to the BVH.
+            std::mt19937 rng(0xDEADC0DE);
+            std::uniform_real_distribution<float> posDist(-25.0f, 25.0f);
+            std::uniform_real_distribution<float> halfDist(0.25f, 2.0f);
+            std::uniform_real_distribution<float> rangeDist(8.0f, 30.0f);
+            std::uniform_real_distribution<float> angleDist(0.15f, 1.0f); // ~9 to 57 deg
+            std::uniform_real_distribution<float> dirDist(-1.0f, 1.0f);
+
+            std::vector<BVHPrimitive> primitives;
+            primitives.reserve(250);
+            for (int i = 0; i < 250; ++i)
+            {
+                const float cx = posDist(rng), cy = posDist(rng), cz = posDist(rng);
+                const float hx = halfDist(rng), hy = halfDist(rng), hz = halfDist(rng);
+                primitives.push_back(MakeBoxPrimitive(
+                    FloatVector4(cx - hx, cy - hy, cz - hz, 0.0f),
+                    FloatVector4(cx + hx, cy + hy, cz + hz, 0.0f),
+                    uint32_t(i)));
+            }
+
+            BVH bvh;
+            bvh.Build(primitives.data(), primitives.size());
+
+            // Local sphere-cone reference matching the implementation under test.
+            auto refSphereCone = [](const FloatVector4& c, float r,
+                                    const FloatVector4& apex, const FloatVector4& dir,
+                                    float range, float tanT, float invCosT) {
+                const float vx = c.V[0] - apex.V[0];
+                const float vy = c.V[1] - apex.V[1];
+                const float vz = c.V[2] - apex.V[2];
+                const float distAxis = vx * dir.V[0] + vy * dir.V[1] + vz * dir.V[2];
+                if (distAxis > range + r) return false;
+                if (distAxis < -r) return false;
+                const float vLenSq = vx*vx + vy*vy + vz*vz;
+                const float perpSq = vLenSq - distAxis * distAxis;
+                const float perp = (perpSq > 0.0f) ? std::sqrt(perpSq) : 0.0f;
+                const float t = (distAxis > 0.0f) ? distAxis : 0.0f;
+                return perp <= t * tanT + r * invCosT;
+            };
+
+            auto refConeAABB = [&](const AABB& b, const Math::Cone& cone) {
+                if (b.IsEmpty()) return false;
+                const FloatVector4 center = b.GetCenter();
+                const FloatVector4 ext    = b.GetExtents();
+                const float radius = std::sqrt(ext.V[0]*ext.V[0] + ext.V[1]*ext.V[1] + ext.V[2]*ext.V[2]);
+                return refSphereCone(center, radius,
+                                     cone.Apex, cone.AxisDir,
+                                     cone.Range, cone.TanHalfAngle, cone.InvCosHalfAngle);
+            };
+
+            for (int q = 0; q < 30; ++q)
+            {
+                FloatVector4 apex(posDist(rng), posDist(rng), posDist(rng), 0.0f);
+                FloatVector4 dir(dirDist(rng), dirDist(rng), dirDist(rng), 0.0f);
+                // Avoid degenerate axis: FromAxisAndAngle defends with
+                // length>epsilon, but we want a real cone for the test.
+                if (std::abs(dir.V[0]) + std::abs(dir.V[1]) + std::abs(dir.V[2]) < 0.01f)
+                    dir = FloatVector4(0, 0, 1, 0);
+
+                Math::Cone cone = Math::Cone::FromAxisAndAngle(apex, dir, rangeDist(rng), angleDist(rng));
+
+                std::vector<uint32_t> bvhOut;
+                bvh.QueryCone(primitives.data(), cone, bvhOut);
+
+                std::vector<uint32_t> bfOut;
+                for (uint32_t i = 0; i < primitives.size(); ++i)
+                    if (refConeAABB(primitives[i].WorldBounds, cone))
+                        bfOut.push_back(i);
+
+                auto a = SortedCopy(bvhOut);
+                auto b = SortedCopy(bfOut);
+                if (a != b)
+                {
+                    std::wstringstream ss;
+                    ss << L"QueryCone mismatch q=" << q
+                       << L" bvh=" << a.size() << L" bf=" << b.size();
+                    Assert::Fail(ss.str().c_str());
+                }
+            }
+        }
 };
 
 } // namespace CanvasUnitTest

--- a/src/CanvasUnitTest/CMakeLists.txt
+++ b/src/CanvasUnitTest/CMakeLists.txt
@@ -1,10 +1,19 @@
-# CanvasUnitTest - Unit tests for Canvas 3D Graphics Engine
+# CanvasUnitTest - Unit tests for Canvas 3D Graphics Engine (GoogleTest)
 cmake_minimum_required(VERSION 3.24)
 
-# This project uses Microsoft CppUnitTestFramework
+include(FetchContent)
 
-# Define the test library (Microsoft Test Framework requires DLL)
-add_library(CanvasUnitTest SHARED
+# Fetch GoogleTest (same version used by sibling deps to avoid duplicate fetches)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+)
+FetchContent_MakeAvailable(googletest)
+
+# Define the test executable (GoogleTest)
+add_executable(CanvasUnitTest
     CanvasInterfacesTest.cpp
     CanvasMathTest.cpp
     CanvasTextTest.cpp
@@ -47,7 +56,7 @@ if(WIN32)
         WIN32
         _CONSOLE
     )
-    
+
     # Link with Windows libraries (excluding d3d12/dxgi/d3dcompiler - inherited from D3D12ResourceUtils)
     target_link_libraries(CanvasUnitTest PRIVATE
         kernel32
@@ -63,7 +72,6 @@ if(WIN32)
         odbc32
         odbccp32
     )
-
 endif()
 
 # Link with Canvas libraries
@@ -72,98 +80,26 @@ target_link_libraries(CanvasUnitTest PRIVATE
     CanvasText
     RectanglePacker
     D3D12ResourceUtils
+    GTest::gtest
+    GTest::gtest_main
 )
-
-# Use Microsoft CppUnitTestFramework
-target_compile_definitions(CanvasUnitTest PRIVATE
-    _WINDLL
-)
-
-# Link with Microsoft Test Framework
-find_library(MS_UNITTEST_FRAMEWORK
-    NAMES Microsoft.VisualStudio.TestTools.CppUnitTestFramework
-    PATHS
-        "$ENV{VCInstallDir}Auxiliary/VS/UnitTest/lib"
-        "$ENV{VSINSTALLDIR}VC/Auxiliary/VS/UnitTest/lib"
-    PATH_SUFFIXES x64
-    REQUIRED
-)
-
-target_link_libraries(CanvasUnitTest PRIVATE ${MS_UNITTEST_FRAMEWORK})
 
 # Use precompiled headers
 target_precompile_headers(CanvasUnitTest PRIVATE pch.h)
 
-# Register tests with CTest using vstest.console.exe for Microsoft Test Framework
+# Register tests with CTest via GoogleTest discovery.
 enable_testing()
-
-# For Microsoft Test Framework, find vstest.console.exe using more robust methods
-find_program(VSTEST_CONSOLE
-    NAMES vstest.console.exe
-    HINTS
-        # Try environment variables first (most reliable)
-        "$ENV{VSINSTALLDIR}Common7/IDE/CommonExtensions/Microsoft/TestWindow"
-        "$ENV{DevEnvDir}CommonExtensions/Microsoft/TestWindow"
-    PATHS
-        # Use vswhere.exe to find Visual Studio installations dynamically
-        [HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\VisualStudio\\SxS\\VS7;15.0]/Common7/IDE/CommonExtensions/Microsoft/TestWindow
-        [HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\VisualStudio\\SxS\\VS7;16.0]/Common7/IDE/CommonExtensions/Microsoft/TestWindow  
-        [HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\VisualStudio\\SxS\\VS7;17.0]/Common7/IDE/CommonExtensions/Microsoft/TestWindow
-    PATH_SUFFIXES
-        Common7/IDE/CommonExtensions/Microsoft/TestWindow
-    DOC "Visual Studio Test Console executable"
-)
-
-# If not found, try using vswhere.exe to locate Visual Studio
-if(NOT VSTEST_CONSOLE AND WIN32)
-    find_program(VSWHERE_EXE
-        NAMES vswhere.exe
-        PATHS
-            "$ENV{ProgramFiles(x86)}/Microsoft Visual Studio/Installer"
-            "${CMAKE_CURRENT_SOURCE_DIR}/tools"
-        DOC "Visual Studio Locator tool"
-    )
-    
-    if(VSWHERE_EXE)
-        execute_process(
-            COMMAND ${VSWHERE_EXE} -latest -property installationPath
-            OUTPUT_VARIABLE VS_INSTALL_PATH
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-            ERROR_QUIET
-        )
-        
-        if(VS_INSTALL_PATH)
-            find_program(VSTEST_CONSOLE
-                NAMES vstest.console.exe
-                PATHS "${VS_INSTALL_PATH}/Common7/IDE/CommonExtensions/Microsoft/TestWindow"
-                NO_DEFAULT_PATH
-            )
-        endif()
-    endif()
-endif()
-
-if(VSTEST_CONSOLE)
-    # Run tests from the shared runtime image directory — all DLLs are already there.
-    add_test(NAME CanvasUnitTests 
-        COMMAND ${VSTEST_CONSOLE} "$<TARGET_FILE:CanvasUnitTest>" "--logger:console;verbosity=normal"
-        WORKING_DIRECTORY "${CANVAS_RUNTIME_DIR}"
-    )
-    message(STATUS "Found VSTest Console: ${VSTEST_CONSOLE}")
-    
-    set_tests_properties(CanvasUnitTests PROPERTIES
+include(GoogleTest)
+gtest_discover_tests(CanvasUnitTest
+    WORKING_DIRECTORY "${CANVAS_RUNTIME_DIR}"
+    PROPERTIES
         TIMEOUT 300
-        LABELS "UnitTest;Microsoft"
-    )
-else()
-    message(WARNING "VSTest Console not found - CanvasUnitTest will not be runnable via CTest")
-    message(STATUS "You can still run the tests manually using Visual Studio Test Explorer")
-    message(STATUS "Or run: vstest.console.exe ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CanvasUnitTest.dll")
-endif()
+        LABELS "UnitTest"
+)
 
 # Installation
 install(TARGETS CanvasUnitTest
     RUNTIME DESTINATION ${CANVAS_INSTALL_DEST}/bin
-    LIBRARY DESTINATION ${CANVAS_INSTALL_DEST}/bin
 )
 
 # Install PDB files for debugging

--- a/src/CanvasUnitTest/CMakeLists.txt
+++ b/src/CanvasUnitTest/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(CanvasUnitTest SHARED
     D3D12ResourceUtilsTest.cpp
     GpuTaskGraphTest.cpp
     BVHTest.cpp
+    LightBVHTest.cpp
     pch.h
     targetver.h
 )

--- a/src/CanvasUnitTest/CMakeLists.txt
+++ b/src/CanvasUnitTest/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(CanvasUnitTest SHARED
     CanvasTextTest.cpp
     D3D12ResourceUtilsTest.cpp
     GpuTaskGraphTest.cpp
+    BVHTest.cpp
     pch.h
     targetver.h
 )

--- a/src/CanvasUnitTest/CanvasInterfacesTest.cpp
+++ b/src/CanvasUnitTest/CanvasInterfacesTest.cpp
@@ -3,1218 +3,1215 @@
 //================================================================================================
 
 #include "pch.h"
-#include "CppUnitTest.h"
-
-using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 using namespace Canvas;
 
 namespace CanvasUnitTest
 {
-    TEST_CLASS(CanvasInterfacesTest)
+namespace {
+
+// Helpers for equality checks
+
+static bool AlmostZero(float n)
+{
+    return std::abs(n) < FLT_EPSILON;
+}
+
+static bool AlmostEqual(const Canvas::Math::FloatVector4 &a, const Canvas::Math::FloatVector4 &b)
+{
+    auto d = b - a;
+    float lensq = Canvas::Math::DotProduct(d, d);
+    return AlmostZero(lensq);
+}
+
+static bool AlmostEqual(const Canvas::Math::FloatQuaternion &a, const Canvas::Math::FloatQuaternion &b)
+{
+    auto d = b - a;
+    float lensq = Canvas::Math::DotProduct(d, d);
+    return AlmostZero(lensq);
+}
+
+static bool AlmostEqual(const Canvas::Math::FloatMatrix4x4 &m0, const Canvas::Math::FloatMatrix4x4 &m1)
+{
+    for (unsigned int row = 0; row < Canvas::Math::FloatMatrix4x4::Rows; ++row)
     {
-    public:
-
-        TEST_METHOD(SimpleInterfaces)
-        {
-            // Create XCanvas object
-            Gem::TGemPtr<XCanvas> pCanvas;
-            Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
-            CreateTestCanvasAndDevice(pCanvas, pDevice);
-
-            // Create XScene object
-            Gem::TGemPtr<Canvas::XScene> pScene;
-            Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
-
-            // Create an empty XSceneGraphNode
-            Gem::TGemPtr<Canvas::XSceneGraphNode> pSceneGraphNode;
-            const char szNodeName[] = "NullNode";
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pSceneGraphNode)));
-            pSceneGraphNode->SetName(szNodeName);
-
-            // Verify QI for XGeneric
-            Gem::TGemPtr<XGeneric> pGeneric;
-            Assert::IsTrue(Succeeded(pSceneGraphNode->QueryInterface(&pGeneric)));
-
-            // Validate the name
-            Assert::IsTrue(0 == strncmp(pSceneGraphNode->GetName(), szNodeName, _countof(szNodeName)));
-        }
-
-        TEST_METHOD(SceneGraphNodesTest)
-        {
-            // Create XCanvas object
-            Gem::TGemPtr<XCanvas> pCanvas;
-            Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
-            CreateTestCanvasAndDevice(pCanvas, pDevice);
-
-            // Create XScene object
-            Gem::TGemPtr<XScene> pScene;
-            Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
-
-            // Create nodes
-            Gem::TGemPtr<XSceneGraphNode> pNodes[6];
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pNodes[0])));
-            pNodes[0]->SetName("Node0");
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pNodes[1])));
-            pNodes[1]->SetName("Node1");
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pNodes[2])));
-            pNodes[2]->SetName("Node2");
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pNodes[3])));
-            pNodes[3]->SetName("Node3");
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pNodes[4])));
-            pNodes[4]->SetName("Node4");
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pNodes[5])));
-            pNodes[5]->SetName("Node5");
-
-            // Build the following tree
-            // Root
-            //  - Node0
-            //      - Node2
-            //      - Node3
-            //  - Node1
-            //      - Node4
-            //          - Node5
-
-            Gem::TGemPtr<XSceneGraphNode> pRoot = pScene->GetRootNode();
-            Assert::IsNotNull(pRoot.Get());
-            Assert::IsTrue(Succeeded(pRoot->AddChild(pNodes[0])));
-            Assert::IsTrue(Succeeded(pRoot->AddChild(pNodes[1])));
-            Assert::IsTrue(Succeeded(pNodes[0]->AddChild(pNodes[2])));
-            Assert::IsTrue(Succeeded(pNodes[0]->AddChild(pNodes[3])));
-            Assert::IsTrue(Succeeded(pNodes[1]->AddChild(pNodes[4])));
-            Assert::IsTrue(Succeeded(pNodes[4]->AddChild(pNodes[5])));
-        }
-
-        // Helpers for equality checks
-        static bool AlmostZero(float n)
-        {
-            return std::abs(n) < FLT_EPSILON;
-        }
-        static bool AlmostEqual(const Canvas::Math::FloatVector4 &a, const Canvas::Math::FloatVector4 &b)
-        {
-            auto d = b - a;
-            float lensq = Canvas::Math::DotProduct(d, d);
-            return AlmostZero(lensq);
-        }
-        static bool AlmostEqual(const Canvas::Math::FloatQuaternion &a, const Canvas::Math::FloatQuaternion &b)
-        {
-            auto d = b - a;
-            float lensq = Canvas::Math::DotProduct(d, d);
-            return AlmostZero(lensq);
-        }
-        static bool AlmostEqual(const Canvas::Math::FloatMatrix4x4 &m0, const Canvas::Math::FloatMatrix4x4 &m1)
-        {
-            for (unsigned int row = 0; row < Canvas::Math::FloatMatrix4x4::Rows; ++row)
-            {
-                auto d = m1[row] - m0[row];
-                float lensq = Canvas::Math::DotProduct(d, d);
-                if (!AlmostZero(lensq)) return false;
-            }
-            return true;
-        }
-
-        TEST_METHOD(SceneGraphTransforms)
-        {
-            using namespace Canvas::Math;
-
-            // Create Canvas and Scene
-            Gem::TGemPtr<XCanvas> pCanvas;
-            Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
-            CreateTestCanvasAndDevice(pCanvas, pDevice);
-            Gem::TGemPtr<XScene> pScene;
-            Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
-
-            // Create a small hierarchy: root -> A -> B
-            Gem::TGemPtr<XSceneGraphNode> pA, pB;
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pA)));
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pB)));
-
-            Gem::TGemPtr<XSceneGraphNode> pRoot = pScene->GetRootNode();
-            Assert::IsNotNull(pRoot.Get());
-            Assert::IsTrue(Succeeded(pRoot->AddChild(pA)));
-            Assert::IsTrue(Succeeded(pA->AddChild(pB)));
-
-            // Set locals
-            // A: rotate 90 deg around Z, translate (1,2,0)
-            const float ninety = float(3.14159265358979323846 / 2.0);
-            auto qA = FloatQuaternion::FromEulerXYZ(0.0f, 0.0f, ninety);
-            pA->SetLocalRotation(qA);
-            pA->SetLocalTranslation(FloatVector4(1.0f, 2.0f, 0.0f, 1.0f));
-
-            // B: rotate 90 deg around X, translate (1,0,0)
-            auto qB = FloatQuaternion::FromEulerXYZ(ninety, 0.0f, 0.0f);
-            pB->SetLocalRotation(qB);
-            pB->SetLocalTranslation(FloatVector4(1.0f, 0.0f, 0.0f, 1.0f));
-
-            // Verify A local matrix matches quaternion + translation
-            auto mA_local = pA->GetLocalMatrix();
-            auto mA_expected = QuaternionToRotationMatrix(qA);
-            mA_expected[3][0] = 1.0f; mA_expected[3][1] = 2.0f; mA_expected[3][2] = 0.0f; mA_expected[3][3] = 1.0f;
-            Assert::IsTrue(AlmostEqual(mA_local, mA_expected));
-
-            // Verify B local matrix
-            auto mB_local = pB->GetLocalMatrix();
-            auto mB_expected = QuaternionToRotationMatrix(qB);
-            mB_expected[3][0] = 1.0f; mB_expected[3][1] = 0.0f; mB_expected[3][2] = 0.0f; mB_expected[3][3] = 1.0f;
-            Assert::IsTrue(AlmostEqual(mB_local, mB_expected));
-
-            // Global rotations: Rg(A) = qA, Rg(B) = qA * qB
-            auto qA_g = pA->GetGlobalRotation();
-            auto qB_g = pB->GetGlobalRotation();
-            Assert::IsTrue(AlmostEqual(qA_g, qA.Normalize()));
-            Assert::IsTrue(AlmostEqual(qB_g, (qA * qB).Normalize()));
-
-            // Global translations:
-            // Tg(A) = rotate(qRoot, (1,2,0)) + Troot = (1,2,0)
-            // Tg(B) = Tg(A) + rotate(Rg(A), (1,0,0)) = (1,2,0) + (0,1,0) = (1,3,0)
-            auto tA_g = pA->GetGlobalTranslation();
-            auto tB_g = pB->GetGlobalTranslation();
-            Assert::IsTrue(AlmostEqual(tA_g, FloatVector4(1.0f, 2.0f, 0.0f, 1.0f)));
-            Assert::IsTrue(AlmostEqual(tB_g, FloatVector4(1.0f, 3.0f, 0.0f, 1.0f)));
-
-            // Global matrices: Mg = Mparent * Mlocal (row-vector convention)
-            auto mA_global = pA->GetGlobalMatrix();
-            auto mB_global = pB->GetGlobalMatrix();
-            auto mRoot = FloatMatrix4x4::Identity();
-            auto mA_global_expected = mRoot * mA_local; // root is identity
-            auto mB_global_expected = mA_global_expected * mB_local;
-            Assert::IsTrue(AlmostEqual(mA_global, mA_global_expected));
-            Assert::IsTrue(AlmostEqual(mB_global, mB_global_expected));
-
-            // Test scenario: Move B from A to Root after transforms are resolved
-            // This tests that dirty flags are properly set when parent changes
-            
-            // First, create a new node C under Root for verification
-            Gem::TGemPtr<XSceneGraphNode> pC;
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pC)));
-            auto qC = FloatQuaternion::FromEulerXYZ(0.0f, ninety, 0.0f);  // 90° around Y
-            pC->SetLocalRotation(qC);
-            pC->SetLocalTranslation(FloatVector4(0.0f, 0.0f, 1.0f, 1.0f));
-            Assert::IsTrue(Succeeded(pRoot->AddChild(pC)));
-
-            // Verify C's initial global transforms
-            auto qC_g_initial = pC->GetGlobalRotation();
-            auto tC_g_initial = pC->GetGlobalTranslation();
-            Assert::IsTrue(AlmostEqual(qC_g_initial, qC.Normalize()));
-            Assert::IsTrue(AlmostEqual(tC_g_initial, FloatVector4(0.0f, 0.0f, 1.0f, 1.0f)));
-
-            // Now move B from A to C (B was previously under A)
-            // B's local is: rotation 90° around X, translation (1,0,0)
-            // When B is under C (which has 90° Y rotation and translation (0,0,1)):
-            //   - B's global rotation should be: qC * qB
-            //   - B's global translation should be: tC + rotate(qC, (1,0,0)) = (0,0,1) + (0,0,-1) = (0,0,0)
-
-            Assert::IsTrue(Succeeded(pC->AddChild(pB)));
-
-            // After moving, B's global transforms should reflect new parent C
-            auto qB_g_moved = pB->GetGlobalRotation();
-            auto tB_g_moved = pB->GetGlobalTranslation();
-            auto mB_global_moved = pB->GetGlobalMatrix();
-
-            // Expected: qC * qB
-            auto qB_g_expected_moved = (qC * qB).Normalize();
-            Assert::IsTrue(AlmostEqual(qB_g_moved, qB_g_expected_moved));
-
-            // Expected translation: C's translation (0,0,1) + rotate(qC, B's local translation (1,0,0))
-            // qC rotates (1,0,0) by 90° around Y: (1,0,0) -> (0,0,-1)
-            const FloatQuaternion vB_local(1.0f, 0.0f, 0.0f, 0.0f);
-            const auto qC_conj = Conjugate(qC.Normalize());
-            const auto vB_rotated = qC.Normalize() * vB_local * qC_conj;
-            FloatVector4 tB_expected_moved = tC_g_initial + FloatVector4(vB_rotated.X, vB_rotated.Y, vB_rotated.Z, 0.0f);
-            tB_expected_moved.W = 1.0f;
-            Assert::IsTrue(AlmostEqual(tB_g_moved, tB_expected_moved));
-
-            // Expected matrix: C_global * B_local
-            auto mC_global = pC->GetGlobalMatrix();
-            auto mB_global_expected_moved = mC_global * mB_local;
-            Assert::IsTrue(AlmostEqual(mB_global_moved, mB_global_expected_moved));
-
-            // Verify that A's child is no longer B (B was moved to C)
-            auto pA_firstChild = pA->GetFirstChild();
-            Assert::IsTrue(pA_firstChild == nullptr || pA_firstChild != pB.Get());
-
-            // Test that changing a parent's transform propagates to descendants
-            // B is currently a child of C. If we change C's rotation/translation,
-            // B's global transforms should update accordingly.
-            
-            // Get B's current global matrix and local matrix (local shouldn't change)
-            auto mB_before_parent_change = pB->GetGlobalMatrix();
-            auto mB_local_saved = pB->GetLocalMatrix();
-            
-            // Change C's local translation
-            pC->SetLocalTranslation(FloatVector4(5.0f, 5.0f, 5.0f, 1.0f));
-            
-            // B's local matrix should remain unchanged
-            auto mB_local_check = pB->GetLocalMatrix();
-            Assert::IsTrue(AlmostEqual(mB_local_saved, mB_local_check));
-            
-            // B's global matrix should now be different (dirty flags propagated)
-            auto mB_after_translation = pB->GetGlobalMatrix();
-            Assert::IsFalse(AlmostEqual(mB_before_parent_change, mB_after_translation));
-            
-            // Verify the new value is correct: C_new_global * B_local
-            auto mC_global_new = pC->GetGlobalMatrix();
-            auto mB_expected_new = mC_global_new * mB_local_saved;
-            Assert::IsTrue(AlmostEqual(mB_after_translation, mB_expected_new));
-            
-            // Change C's rotation
-            auto qC_new = FloatQuaternion::FromEulerXYZ(ninety, 0.0f, 0.0f);  // 90° around X instead of Y
-            pC->SetLocalRotation(qC_new);
-            
-            // B's global transforms should update again
-            auto mB_after_rotation = pB->GetGlobalMatrix();
-            Assert::IsFalse(AlmostEqual(mB_after_translation, mB_after_rotation));
-            
-            // Verify correctness after rotation change
-            auto mC_global_final = pC->GetGlobalMatrix();
-            auto mB_expected_final = mC_global_final * mB_local_saved;
-            Assert::IsTrue(AlmostEqual(mB_after_rotation, mB_expected_final));
-        }
-
-        TEST_METHOD(CameraTest)
-        {
-            using namespace Canvas::Math;
-
-            // Create Canvas and Scene
-            Gem::TGemPtr<XCanvas> pCanvas;
-            Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
-            CreateTestCanvasAndDevice(pCanvas, pDevice);
-            Gem::TGemPtr<XScene> pScene;
-            Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
-
-            // Create a hierarchy: root -> A -> B -> cameraNode
-            Gem::TGemPtr<XSceneGraphNode> pA, pB, pCameraNode;
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pA)));
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pB)));
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pCameraNode)));
-
-            Gem::TGemPtr<XSceneGraphNode> pRoot = pScene->GetRootNode();
-            Assert::IsNotNull(pRoot.Get());
-            Assert::IsTrue(Succeeded(pRoot->AddChild(pA)));
-            Assert::IsTrue(Succeeded(pA->AddChild(pB)));
-            Assert::IsTrue(Succeeded(pB->AddChild(pCameraNode)));
-
-            // Create camera and attach to cameraNode
-            Gem::TGemPtr<XCamera> pCamera;
-            Assert::IsTrue(Succeeded(pCanvas->CreateCamera(&pCamera)));
-            Assert::IsTrue(Succeeded(pCameraNode->BindElement(pCamera)));
-
-            // Set initial camera parameters
-            const float fov = float(3.14159265358979323846 / 4.0); // 45 degrees
-            const float aspect = 16.0f / 9.0f;
-            const float nearClip = 0.1f;
-            const float farClip = 1000.0f;
-            pCamera->SetFovAngle(fov);
-            pCamera->SetAspectRatio(aspect);
-            pCamera->SetNearClip(nearClip);
-            pCamera->SetFarClip(farClip);
-
-            // Set transforms for the hierarchy
-            const float ninety = float(3.14159265358979323846 / 2.0);
-            auto qA = FloatQuaternion::FromEulerXYZ(0.0f, 0.0f, ninety);
-            pA->SetLocalRotation(qA);
-            pA->SetLocalTranslation(FloatVector4(1.0f, 0.0f, 0.0f, 1.0f));
-
-            auto qB = FloatQuaternion::FromEulerXYZ(ninety, 0.0f, 0.0f);
-            pB->SetLocalRotation(qB);
-            pB->SetLocalTranslation(FloatVector4(0.0f, 1.0f, 0.0f, 1.0f));
-
-            pCameraNode->SetLocalTranslation(FloatVector4(0.0f, 0.0f, 5.0f, 1.0f));
-
-            // Update scene graph and camera (simulates frame update)
-            Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
-
-            // Get initial matrices - this will compute and cache them
-            auto viewMatrix1 = pCamera->GetViewMatrix();
-            auto projMatrix1 = pCamera->GetProjectionMatrix();
-            auto viewProjMatrix1 = pCamera->GetViewProjectionMatrix();
-
-            // Verify matrices are not identity
-            auto identity = FloatMatrix4x4::Identity();
-            Assert::IsFalse(AlmostEqual(viewMatrix1, identity), L"View matrix should not be identity");
-            Assert::IsFalse(AlmostEqual(projMatrix1, identity), L"Projection matrix should not be identity");
-            
-            // Projection now produces standard D3D LHS clip space from a
-            // view space where +X=right, +Y=up, +Z=forward. The matrix
-            // should look like:
-            // Row 0: [ f/aspect, 0,    0,    0 ]  (x_view=right    -> x_clip)
-            // Row 1: [    0,     f,    0,    0 ]  (y_view=up       -> y_clip)
-            // Row 2: [    0,     0,    A,    1 ]  (z_view=forward  -> z_clip + w_clip)
-            // Row 3: [    0,     0,    B,    0 ]  (const           -> z_clip depth bias)
-
-            // Check specific elements to validate the projection matrix structure
-            const float tolerance = 1e-5f;
-            float f = 1.0f / std::tan(fov * 0.5f);  // approx 2.414
-
-            // Row 0, col 0: f / aspect (right -> x_clip)
-            Assert::IsTrue(std::abs(projMatrix1[0][0] - f / aspect) < 0.01f,
-                L"proj[0][0] should be approximately f/aspect");
-
-            // Row 1, col 1: f (up -> y_clip)
-            Assert::IsTrue(std::abs(projMatrix1[1][1] - f) < 0.01f,
-                L"proj[1][1] should be approximately 2.414 (f)");
-
-            // Row 2, col 3: Should have 1.0 for perspective divide (forward -> w_clip)
-            Assert::IsTrue(std::abs(projMatrix1[2][3] - 1.0f) < tolerance,
-                L"proj[2][3] should be 1.0 for perspective divide");
-
-            // The old shape's hot cells should now be zero.
-            Assert::IsTrue(std::abs(projMatrix1[0][3]) < tolerance, L"proj[0][3] should be 0 in new convention");
-            Assert::IsTrue(std::abs(projMatrix1[1][0]) < tolerance, L"proj[1][0] should be 0 in new convention");
-            Assert::IsTrue(std::abs(projMatrix1[2][1]) < tolerance, L"proj[2][1] should be 0 in new convention");
-            Assert::IsTrue(std::abs(projMatrix1[3][3]) < tolerance, L"proj[3][3] should be 0");
-
-            // Verify view-projection is the product of view and projection
-            auto expectedViewProj = viewMatrix1 * projMatrix1;
-            Assert::IsTrue(AlmostEqual(viewProjMatrix1, expectedViewProj));
-
-            // Test 1: Modify camera node's local transform
-            // This should invalidate view matrix after Update()
-            pCameraNode->SetLocalTranslation(FloatVector4(0.0f, 0.0f, 10.0f, 1.0f));
-            Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
-
-            auto viewMatrix2 = pCamera->GetViewMatrix();
-            Assert::IsFalse(AlmostEqual(viewMatrix1, viewMatrix2)); // Should be different
-
-            // Projection should remain the same (no parameters changed)
-            auto projMatrix2 = pCamera->GetProjectionMatrix();
-            Assert::IsTrue(AlmostEqual(projMatrix1, projMatrix2));
-
-            // View-projection should be different
-            auto viewProjMatrix2 = pCamera->GetViewProjectionMatrix();
-            Assert::IsFalse(AlmostEqual(viewProjMatrix1, viewProjMatrix2));
-
-            // Test 2: Modify parent node B's transform
-            // This should invalidate camera's view matrix (ancestor changed)
-            pB->SetLocalTranslation(FloatVector4(0.0f, 2.0f, 0.0f, 1.0f));
-            Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
-
-            auto viewMatrix3 = pCamera->GetViewMatrix();
-            Assert::IsFalse(AlmostEqual(viewMatrix2, viewMatrix3)); // Should be different from previous
-
-            // Test 3: Modify grandparent node A's transform
-            // This should also invalidate camera's view matrix
-            pA->SetLocalTranslation(FloatVector4(2.0f, 0.0f, 0.0f, 1.0f));
-            Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
-
-            auto viewMatrix4 = pCamera->GetViewMatrix();
-            Assert::IsFalse(AlmostEqual(viewMatrix3, viewMatrix4)); // Should be different
-
-            // Test 4: Modify projection parameters
-            // This should invalidate projection and view-projection matrices
-            pCamera->SetFovAngle(float(3.14159265358979323846 / 3.0)); // 60 degrees
-            auto projMatrix3 = pCamera->GetProjectionMatrix();
-            Assert::IsFalse(AlmostEqual(projMatrix2, projMatrix3)); // Should be different
-
-            auto viewProjMatrix3 = pCamera->GetViewProjectionMatrix();
-            Assert::IsFalse(AlmostEqual(viewProjMatrix2, viewProjMatrix3));
-
-            // Verify new view-projection is correct product
-            auto viewMatrixCurrent = pCamera->GetViewMatrix();
-            auto projMatrixCurrent = pCamera->GetProjectionMatrix();
-            auto expectedViewProjCurrent = viewMatrixCurrent * projMatrixCurrent;
-            Assert::IsTrue(AlmostEqual(viewProjMatrix3, expectedViewProjCurrent));
-
-            // Test 5: Modify aspect ratio
-            pCamera->SetAspectRatio(4.0f / 3.0f);
-            auto projMatrix4 = pCamera->GetProjectionMatrix();
-            Assert::IsFalse(AlmostEqual(projMatrix3, projMatrix4));
-
-            // Test 6: Modify near/far clip planes
-            pCamera->SetNearClip(0.5f);
-            auto projMatrix5 = pCamera->GetProjectionMatrix();
-            Assert::IsFalse(AlmostEqual(projMatrix4, projMatrix5));
-
-            pCamera->SetFarClip(500.0f);
-            auto projMatrix6 = pCamera->GetProjectionMatrix();
-            Assert::IsFalse(AlmostEqual(projMatrix5, projMatrix6));
-        }
-
-        TEST_METHOD(CameraNodeReparenting)
-        {
-            using namespace Canvas::Math;
-
-            // Create Canvas and Scene
-            Gem::TGemPtr<XCanvas> pCanvas;
-            Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
-            CreateTestCanvasAndDevice(pCanvas, pDevice);
-            Gem::TGemPtr<XScene> pScene;
-            Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
-
-            // Create two separate branches: root -> A and root -> B
-            Gem::TGemPtr<XSceneGraphNode> pA, pB, pCameraNode;
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pA)));
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pB)));
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pCameraNode)));
-
-            Gem::TGemPtr<XSceneGraphNode> pRoot = pScene->GetRootNode();
-            Assert::IsNotNull(pRoot.Get());
-            
-            // Initial setup: cameraNode is under A
-            Assert::IsTrue(Succeeded(pRoot->AddChild(pA)));
-            Assert::IsTrue(Succeeded(pRoot->AddChild(pB)));
-            Assert::IsTrue(Succeeded(pA->AddChild(pCameraNode)));
-
-            // Create camera and attach
-            Gem::TGemPtr<XCamera> pCamera;
-            Assert::IsTrue(Succeeded(pCanvas->CreateCamera(&pCamera)));
-            Assert::IsTrue(Succeeded(pCameraNode->BindElement(pCamera)));
-
-            // Set different transforms for A and B
-            const float ninety = float(3.14159265358979323846 / 2.0);
-            auto qA = FloatQuaternion::FromEulerXYZ(0.0f, 0.0f, ninety); // Rotate 90° around Z
-            pA->SetLocalRotation(qA);
-            pA->SetLocalTranslation(FloatVector4(5.0f, 0.0f, 0.0f, 1.0f));
-
-            auto qB = FloatQuaternion::FromEulerXYZ(0.0f, ninety, 0.0f); // Rotate 90° around Y
-            pB->SetLocalRotation(qB);
-            pB->SetLocalTranslation(FloatVector4(0.0f, 5.0f, 0.0f, 1.0f));
-
-            pCameraNode->SetLocalTranslation(FloatVector4(1.0f, 0.0f, 0.0f, 1.0f));
-
-            // Update and get initial view matrix (camera is under A)
-            Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
-            auto viewMatrix1 = pCamera->GetViewMatrix();
-            auto viewProjMatrix1 = pCamera->GetViewProjectionMatrix();
-
-            // Move camera node from A to B
-            // This changes the camera's parent, so its world transform will change
-            Assert::IsTrue(Succeeded(pB->AddChild(pCameraNode)));
-
-            // Update scene to mark view matrix dirty
-            Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
-
-            // Get new matrices - should be different due to different parent transform
-            auto viewMatrix2 = pCamera->GetViewMatrix();
-            auto viewProjMatrix2 = pCamera->GetViewProjectionMatrix();
-
-            // Matrices should be different (different parent transforms)
-            Assert::IsFalse(AlmostEqual(viewMatrix1, viewMatrix2));
-            Assert::IsFalse(AlmostEqual(viewProjMatrix1, viewProjMatrix2));
-
-            // The view matrix bakes in the world(X-fwd, Y-left, Z-up) ->
-            // view(X-right, Y-up, Z-fwd) basis remap, so world * view is no
-            // longer identity.  The invariant that does hold is that the
-            // camera's world-space position maps to the view-space origin.
-            auto cameraWorldMatrix = pCameraNode->GetGlobalMatrix();
-            FloatVector4 cameraWorldPos(
-                cameraWorldMatrix[3][0], cameraWorldMatrix[3][1],
-                cameraWorldMatrix[3][2], 1.0f);
-            FloatVector4 cameraViewPos = cameraWorldPos * viewMatrix2;
-            Assert::IsTrue(std::abs(cameraViewPos.X) < 1e-4f);
-            Assert::IsTrue(std::abs(cameraViewPos.Y) < 1e-4f);
-            Assert::IsTrue(std::abs(cameraViewPos.Z) < 1e-4f);
-            Assert::IsTrue(std::abs(cameraViewPos.W - 1.0f) < 1e-4f);
-
-            // Test moving to root (no parent transform)
-            Assert::IsTrue(Succeeded(pRoot->AddChild(pCameraNode)));
-            Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
-
-            auto viewMatrix3 = pCamera->GetViewMatrix();
-            Assert::IsFalse(AlmostEqual(viewMatrix2, viewMatrix3));
-
-            // With only local transform, world matrix should equal local matrix
-            auto cameraLocalMatrix = pCameraNode->GetLocalMatrix();
-            auto cameraWorldMatrix2 = pCameraNode->GetGlobalMatrix();
-            Assert::IsTrue(AlmostEqual(cameraLocalMatrix, cameraWorldMatrix2));
-        }
-
-        TEST_METHOD(CameraMatrixConsistency)
-        {
-            using namespace Canvas::Math;
-
-            // Create Canvas and Scene
-            Gem::TGemPtr<XCanvas> pCanvas;
-            Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
-            CreateTestCanvasAndDevice(pCanvas, pDevice);
-            Gem::TGemPtr<XScene> pScene;
-            Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
-
-            // Create camera node
-            Gem::TGemPtr<XSceneGraphNode> pCameraNode;
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pCameraNode)));
-            
-            Gem::TGemPtr<XSceneGraphNode> pRoot = pScene->GetRootNode();
-            Assert::IsTrue(Succeeded(pRoot->AddChild(pCameraNode)));
-
-            // Create and attach camera
-            Gem::TGemPtr<XCamera> pCamera;
-            Assert::IsTrue(Succeeded(pCanvas->CreateCamera(&pCamera)));
-            Assert::IsTrue(Succeeded(pCameraNode->BindElement(pCamera)));
-
-            // Set camera parameters
-            pCamera->SetFovAngle(float(3.14159265358979323846 / 4.0));
-            pCamera->SetAspectRatio(16.0f / 9.0f);
-            pCamera->SetNearClip(0.1f);
-            pCamera->SetFarClip(1000.0f);
-
-            // Position camera
-            const float ninety = float(3.14159265358979323846 / 2.0);
-            auto qCamera = FloatQuaternion::FromEulerXYZ(0.0f, ninety, 0.0f);
-            pCameraNode->SetLocalRotation(qCamera);
-            pCameraNode->SetLocalTranslation(FloatVector4(10.0f, 5.0f, 0.0f, 1.0f));
-
-            Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
-
-            // Test: Calling GetViewProjectionMatrix should compute all three matrices
-            auto viewProjMatrix = pCamera->GetViewProjectionMatrix();
-            
-            // Now calling individual getters should return cached values (not recompute)
-            auto viewMatrix = pCamera->GetViewMatrix();
-            auto projMatrix = pCamera->GetProjectionMatrix();
-
-            // Verify view-projection is the correct product
-            auto expectedViewProj = viewMatrix * projMatrix;
-            Assert::IsTrue(AlmostEqual(viewProjMatrix, expectedViewProj));
-
-            // Test: Calling individual getters first, then combined
-            pCameraNode->SetLocalTranslation(FloatVector4(20.0f, 10.0f, 0.0f, 1.0f));
-            Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
-
-            auto viewMatrix2 = pCamera->GetViewMatrix();
-            auto projMatrix2 = pCamera->GetProjectionMatrix();
-            auto viewProjMatrix2 = pCamera->GetViewProjectionMatrix();
-
-            // Verify consistency
-            auto expectedViewProj2 = viewMatrix2 * projMatrix2;
-            Assert::IsTrue(AlmostEqual(viewProjMatrix2, expectedViewProj2));
-
-            // Test: Multiple calls without changes should return same matrices
-            auto viewMatrix3 = pCamera->GetViewMatrix();
-            auto projMatrix3 = pCamera->GetProjectionMatrix();
-            auto viewProjMatrix3 = pCamera->GetViewProjectionMatrix();
-
-            Assert::IsTrue(AlmostEqual(viewMatrix2, viewMatrix3));
-            Assert::IsTrue(AlmostEqual(projMatrix2, projMatrix3));
-            Assert::IsTrue(AlmostEqual(viewProjMatrix2, viewProjMatrix3));
-        }
-
-        TEST_METHOD(LightTest)
-        {
-            using namespace Canvas::Math;
-
-            // Create Canvas and Scene
-            Gem::TGemPtr<XCanvas> pCanvas;
-            Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
-            CreateTestCanvasAndDevice(pCanvas, pDevice);
-            Gem::TGemPtr<XScene> pScene;
-            Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
-
-            // Create a hierarchy: root -> A -> B -> lightNode
-            Gem::TGemPtr<XSceneGraphNode> pA, pB, pLightNode;
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pA)));
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pB)));
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pLightNode)));
-
-            Gem::TGemPtr<XSceneGraphNode> pRoot = pScene->GetRootNode();
-            Assert::IsNotNull(pRoot.Get());
-            Assert::IsTrue(Succeeded(pRoot->AddChild(pA)));
-            Assert::IsTrue(Succeeded(pA->AddChild(pB)));
-            Assert::IsTrue(Succeeded(pB->AddChild(pLightNode)));
-
-            // Create light and attach to lightNode
-            Gem::TGemPtr<XLight> pLight;
-            Assert::IsTrue(Succeeded(pCanvas->CreateLight(LightType::Point, &pLight)));
-            Assert::IsTrue(Succeeded(pLightNode->BindElement(pLight)));
-
-            // Verify light is attached to correct node
-            Assert::IsTrue(pLight->GetAttachedNode() == pLightNode.Get());
-
-            // Set transforms for the hierarchy
-            // A: rotate 90° around Z, translate (5,0,0)
-            const float ninety = float(3.14159265358979323846 / 2.0);
-            auto qA = FloatQuaternion::FromEulerXYZ(0.0f, 0.0f, ninety);
-            pA->SetLocalRotation(qA);
-            pA->SetLocalTranslation(FloatVector4(5.0f, 0.0f, 0.0f, 1.0f));
-
-            // B: rotate 90° around Y, translate (0,3,0)
-            auto qB = FloatQuaternion::FromEulerXYZ(0.0f, ninety, 0.0f);
-            pB->SetLocalRotation(qB);
-            pB->SetLocalTranslation(FloatVector4(0.0f, 3.0f, 0.0f, 1.0f));
-
-            // LightNode: translate (2,0,0)
-            pLightNode->SetLocalTranslation(FloatVector4(2.0f, 0.0f, 0.0f, 1.0f));
-
-            // Update scene to compute global transforms
-            Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
-
-            // Verify light's world transform through its attached node
-            auto lightWorldMatrix = pLightNode->GetGlobalMatrix();
-            auto lightWorldTranslation = pLightNode->GetGlobalTranslation();
-
-            // Light position should reflect the full hierarchy transform
-            // This verifies the light properly inherits ancestor transforms
-            Assert::IsTrue(lightWorldTranslation.W == 1.0f);
-
-            // Change ancestor transform and verify light position updates
-            pA->SetLocalTranslation(FloatVector4(10.0f, 0.0f, 0.0f, 1.0f));
-            Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
-
-            auto lightWorldTranslation2 = pLightNode->GetGlobalTranslation();
-            
-            // Light position should have changed due to ancestor change
-            Assert::IsFalse(AlmostEqual(lightWorldTranslation, lightWorldTranslation2));
-        }
-
-        TEST_METHOD(LightNodeReparenting)
-        {
-            using namespace Canvas::Math;
-
-            // Create Canvas and Scene
-            Gem::TGemPtr<XCanvas> pCanvas;
-            Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
-            CreateTestCanvasAndDevice(pCanvas, pDevice);
-            Gem::TGemPtr<XScene> pScene;
-            Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
-
-            // Create nodes: A, B, and lightNode
-            Gem::TGemPtr<XSceneGraphNode> pA, pB, pLightNode;
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pA)));
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pB)));
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pLightNode)));
-
-            Gem::TGemPtr<XSceneGraphNode> pRoot = pScene->GetRootNode();
-            
-            // Initial hierarchy: root -> A -> lightNode
-            Assert::IsTrue(Succeeded(pRoot->AddChild(pA)));
-            Assert::IsTrue(Succeeded(pRoot->AddChild(pB)));
-            Assert::IsTrue(Succeeded(pA->AddChild(pLightNode)));
-
-            // Create and attach light
-            Gem::TGemPtr<XLight> pLight;
-            Assert::IsTrue(Succeeded(pCanvas->CreateLight(LightType::Spot, &pLight)));
-            Assert::IsTrue(Succeeded(pLightNode->BindElement(pLight)));
-
-            // Set different transforms for A and B
-            const float ninety = float(3.14159265358979323846 / 2.0);
-            auto qA = FloatQuaternion::FromEulerXYZ(0.0f, 0.0f, ninety); // Rotate 90° around Z
-            pA->SetLocalRotation(qA);
-            pA->SetLocalTranslation(FloatVector4(5.0f, 0.0f, 0.0f, 1.0f));
-
-            auto qB = FloatQuaternion::FromEulerXYZ(0.0f, ninety, 0.0f); // Rotate 90° around Y
-            pB->SetLocalRotation(qB);
-            pB->SetLocalTranslation(FloatVector4(0.0f, 5.0f, 0.0f, 1.0f));
-
-            pLightNode->SetLocalTranslation(FloatVector4(1.0f, 0.0f, 0.0f, 1.0f));
-
-            // Get initial light world transform (under A)
-            Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
-            auto lightTranslation1 = pLightNode->GetGlobalTranslation();
-            auto lightRotation1 = pLightNode->GetGlobalRotation();
-
-            // Move light node from A to B
-            Assert::IsTrue(Succeeded(pB->AddChild(pLightNode)));
-            Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
-
-            // Light's world transform should be different (different parent)
-            auto lightTranslation2 = pLightNode->GetGlobalTranslation();
-            auto lightRotation2 = pLightNode->GetGlobalRotation();
-
-            Assert::IsFalse(AlmostEqual(lightTranslation1, lightTranslation2));
-            Assert::IsFalse(AlmostEqual(lightRotation1, lightRotation2));
-
-            // Move light to root (no parent transform)
-            Assert::IsTrue(Succeeded(pRoot->AddChild(pLightNode)));
-            Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
-
-            auto lightTranslation3 = pLightNode->GetGlobalTranslation();
-            auto lightRotation3 = pLightNode->GetGlobalRotation();
-
-            // Under root, light's world transform should equal its local transform
-            auto lightLocalTranslation = pLightNode->GetLocalTranslation();
-            auto lightLocalRotation = pLightNode->GetLocalRotation();
-
-            Assert::IsTrue(AlmostEqual(lightTranslation3, lightLocalTranslation));
-            Assert::IsTrue(AlmostEqual(lightRotation3, lightLocalRotation));
-        }
-
-        TEST_METHOD(LightTransformPropagation)
-        {
-            using namespace Canvas::Math;
-
-            // Create Canvas and Scene
-            Gem::TGemPtr<XCanvas> pCanvas;
-            Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
-            CreateTestCanvasAndDevice(pCanvas, pDevice);
-            Gem::TGemPtr<XScene> pScene;
-            Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
-
-            // Create hierarchy: root -> parent -> lightNode
-            Gem::TGemPtr<XSceneGraphNode> pParent, pLightNode;
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pParent)));
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pLightNode)));
-
-            Gem::TGemPtr<XSceneGraphNode> pRoot = pScene->GetRootNode();
-            Assert::IsTrue(Succeeded(pRoot->AddChild(pParent)));
-            Assert::IsTrue(Succeeded(pParent->AddChild(pLightNode)));
-
-            // Create and attach light
-            Gem::TGemPtr<XLight> pLight;
-            Assert::IsTrue(Succeeded(pCanvas->CreateLight(LightType::Directional, &pLight)));
-            Assert::IsTrue(Succeeded(pLightNode->BindElement(pLight)));
-
-            // Set initial transforms
-            const float ninety = float(3.14159265358979323846 / 2.0);
-            auto qParent = FloatQuaternion::FromEulerXYZ(0.0f, 0.0f, ninety);
-            pParent->SetLocalRotation(qParent);
-            pParent->SetLocalTranslation(FloatVector4(5.0f, 5.0f, 0.0f, 1.0f));
-            pLightNode->SetLocalTranslation(FloatVector4(2.0f, 0.0f, 0.0f, 1.0f));
-
-            Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
-            auto lightTranslation1 = pLightNode->GetGlobalTranslation();
-
-            // Change parent's translation - light should update
-            pParent->SetLocalTranslation(FloatVector4(10.0f, 10.0f, 0.0f, 1.0f));
-            Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
-
-            auto lightTranslation2 = pLightNode->GetGlobalTranslation();
-            Assert::IsFalse(AlmostEqual(lightTranslation1, lightTranslation2));
-
-            // Verify the light's world transform is computed correctly
-            // Row vectors: world = parent_global * light_local
-            auto parentGlobal = pParent->GetGlobalMatrix();
-            auto lightLocal = pLightNode->GetLocalMatrix();
-            auto expectedLightGlobal = parentGlobal * lightLocal;
-            auto actualLightGlobal = pLightNode->GetGlobalMatrix();
-            Assert::IsTrue(AlmostEqual(expectedLightGlobal, actualLightGlobal));
-
-            // Change parent's rotation - light should update
-            auto qParentNew = FloatQuaternion::FromEulerXYZ(0.0f, ninety, 0.0f);
-            pParent->SetLocalRotation(qParentNew);
-            Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
-
-            auto lightTranslation3 = pLightNode->GetGlobalTranslation();
-            Assert::IsFalse(AlmostEqual(lightTranslation2, lightTranslation3));
-
-            // Verify correctness again after rotation change
-            auto parentGlobal2 = pParent->GetGlobalMatrix();
-            auto expectedLightGlobal2 = parentGlobal2 * lightLocal;
-            auto actualLightGlobal2 = pLightNode->GetGlobalMatrix();
-            Assert::IsTrue(AlmostEqual(expectedLightGlobal2, actualLightGlobal2));
-        }
-
-        TEST_METHOD(LightProperties)
-        {
-            using namespace Canvas::Math;
-
-            // Create Canvas
-            Gem::TGemPtr<XCanvas> pCanvas;
-            Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
-            CreateTestCanvasAndDevice(pCanvas, pDevice);
-
-            // Test Point Light
-            Gem::TGemPtr<XLight> pPointLight;
-            Assert::IsTrue(Succeeded(pCanvas->CreateLight(LightType::Point, &pPointLight)));
-            
-            // Verify immutable type
-            Assert::IsTrue(pPointLight->GetType() == LightType::Point);
-
-            // Test Color
-            FloatVector4 testColor(1.0f, 0.5f, 0.25f, 1.0f);
-            pPointLight->SetColor(testColor);
-            auto retrievedColor = pPointLight->GetColor();
-            Assert::IsTrue(AlmostEqual(retrievedColor, testColor));
-
-            // Test Intensity
-            pPointLight->SetIntensity(2.5f);
-            Assert::AreEqual(2.5f, pPointLight->GetIntensity());
-
-            // Test Flags
-            pPointLight->SetFlags(LightFlags::CastsShadows | LightFlags::Enabled);
-            Assert::AreEqual((UINT)(LightFlags::CastsShadows | LightFlags::Enabled), pPointLight->GetFlags());
-
-            // Test Range
-            pPointLight->SetRange(500.0f);
-            Assert::AreEqual(500.0f, pPointLight->GetRange());
-
-            // Test Attenuation
-            pPointLight->SetAttenuation(1.0f, 0.09f, 0.032f);
-            float constant = 0.0f, linear = 0.0f, quadratic = 0.0f;
-            pPointLight->GetAttenuation(&constant, &linear, &quadratic);
-            Assert::AreEqual(1.0f, constant);
-            Assert::AreEqual(0.09f, linear);
-            Assert::AreEqual(0.032f, quadratic);
-
-            // Test Spot Light
-            Gem::TGemPtr<XLight> pSpotLight;
-            Assert::IsTrue(Succeeded(pCanvas->CreateLight(LightType::Spot, &pSpotLight)));
-            
-            // Verify type
-            Assert::IsTrue(pSpotLight->GetType() == LightType::Spot);
-
-            // Test Spot Angles
-            const float innerAngle = 0.523599f; // 30 degrees
-            const float outerAngle = 0.785398f; // 45 degrees
-            pSpotLight->SetSpotAngles(innerAngle, outerAngle);
-            float retrievedInner = 0.0f, retrievedOuter = 0.0f;
-            pSpotLight->GetSpotAngles(&retrievedInner, &retrievedOuter);
-            Assert::AreEqual(innerAngle, retrievedInner);
-            Assert::AreEqual(outerAngle, retrievedOuter);
-
-            // Test Directional Light
-            Gem::TGemPtr<XLight> pDirectionalLight;
-            Assert::IsTrue(Succeeded(pCanvas->CreateLight(LightType::Directional, &pDirectionalLight)));
-            Assert::IsTrue(pDirectionalLight->GetType() == LightType::Directional);
-
-            // Directional lights can still have color and intensity
-            FloatVector4 sunColor(1.0f, 0.95f, 0.8f, 1.0f);
-            pDirectionalLight->SetColor(sunColor);
-            pDirectionalLight->SetIntensity(1.5f);
-            Assert::IsTrue(AlmostEqual(pDirectionalLight->GetColor(), sunColor));
-            Assert::AreEqual(1.5f, pDirectionalLight->GetIntensity());
-
-            // Test Ambient Light
-            Gem::TGemPtr<XLight> pAmbientLight;
-            Assert::IsTrue(Succeeded(pCanvas->CreateLight(LightType::Ambient, &pAmbientLight)));
-            Assert::IsTrue(pAmbientLight->GetType() == LightType::Ambient);
-
-            // Ambient light should support color and intensity
-            FloatVector4 ambientColor(0.2f, 0.2f, 0.3f, 1.0f);
-            pAmbientLight->SetColor(ambientColor);
-            pAmbientLight->SetIntensity(0.5f);
-            Assert::IsTrue(AlmostEqual(pAmbientLight->GetColor(), ambientColor));
-            Assert::AreEqual(0.5f, pAmbientLight->GetIntensity());
-        }
-
-        // ============================================================
-        // XModel Tests
-        // ============================================================
-
-        TEST_METHOD(ModelCreation)
-        {
-            Gem::TGemPtr<XCanvas> pCanvas;
-            Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
-            CreateTestCanvasAndDevice(pCanvas, pDevice);
-
-            // Create a model
-            Gem::TGemPtr<Canvas::XModel> pModel;
-            Assert::IsTrue(Succeeded(pCanvas->CreateModel(pDevice, &pModel, "TestModel")));
-            Assert::IsNotNull(pModel.Get());
-
-            // Model should have a root node
-            Canvas::XSceneGraphNode *pRoot = pModel->GetRootNode();
-            Assert::IsNotNull(pRoot);
-
-            // Device should be accessible
-            Assert::IsTrue(pModel->GetDevice() == pDevice.Get());
-
-            // Empty model should have no resources
-            Assert::AreEqual(0u, pModel->GetMeshDataCount());
-            Assert::AreEqual(0u, pModel->GetMaterialCount());
-            Assert::AreEqual(0u, pModel->GetTextureCount());
-
-            // Active camera node should be null initially
-            Assert::IsNull(pModel->GetActiveCameraNode());
-        }
-
-        TEST_METHOD(ModelResourceLibrary)
-        {
-            using namespace Canvas::Math;
-
-            Gem::TGemPtr<XCanvas> pCanvas;
-            Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
-            CreateTestCanvasAndDevice(pCanvas, pDevice);
-
-            Gem::TGemPtr<Canvas::XModel> pModel;
-            Assert::IsTrue(Succeeded(pCanvas->CreateModel(pDevice, &pModel, "ResourceModel")));
-
-            // Create a debug mesh and add it to the model
-            FloatVector4 positions[] = {
-                {0, 0, 0, 1}, {1, 0, 0, 1}, {0, 1, 0, 1}
-            };
-            FloatVector4 normals[] = {
-                {0, 0, 1, 0}, {0, 0, 1, 0}, {0, 0, 1, 0}
-            };
-            Gem::TGemPtr<Canvas::XGfxMeshData> pMesh;
-            Assert::IsTrue(Succeeded(pDevice->CreateDebugMeshData(3, positions, normals, &pMesh, "TriMesh")));
-
-            Assert::IsTrue(Succeeded(pModel->AddMeshData(pMesh)));
-            Assert::AreEqual(1u, pModel->GetMeshDataCount());
-            Assert::IsTrue(pModel->GetMeshData(0) == pMesh.Get());
-            Assert::IsNull(pModel->GetMeshData(1)); // out of range
-
-            // Create and add a material
-            Gem::TGemPtr<Canvas::XGfxMaterial> pMaterial;
-            Assert::IsTrue(Succeeded(pDevice->CreateMaterial(&pMaterial)));
-            Assert::IsTrue(Succeeded(pModel->AddMaterial(pMaterial)));
-            Assert::AreEqual(1u, pModel->GetMaterialCount());
-            Assert::IsTrue(pModel->GetMaterial(0) == pMaterial.Get());
-
-            // Null arguments should fail
-            Assert::IsTrue(Gem::Failed(pModel->AddMeshData(nullptr)));
-            Assert::IsTrue(Gem::Failed(pModel->AddMaterial(nullptr)));
-            Assert::IsTrue(Gem::Failed(pModel->AddTexture(nullptr)));
-        }
-
-        TEST_METHOD(ModelAuthoringAndInstantiation)
-        {
-            using namespace Canvas::Math;
-
-            Gem::TGemPtr<XCanvas> pCanvas;
-            Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
-            CreateTestCanvasAndDevice(pCanvas, pDevice);
-
-            // Build a model with a simple hierarchy:
-            // ModelRoot
-            //   - NodeA (mesh)
-            //   - NodeB
-            //       - NodeC (mesh)
-            Gem::TGemPtr<Canvas::XModel> pModel;
-            Assert::IsTrue(Succeeded(pCanvas->CreateModel(pDevice, &pModel, "TestModel")));
-
-            FloatVector4 positions[] = {
-                {0, 0, 0, 1}, {1, 0, 0, 1}, {0, 1, 0, 1}
-            };
-            FloatVector4 normals[] = {
-                {0, 0, 1, 0}, {0, 0, 1, 0}, {0, 0, 1, 0}
-            };
-            Gem::TGemPtr<Canvas::XGfxMeshData> pMesh;
-            Assert::IsTrue(Succeeded(pDevice->CreateDebugMeshData(3, positions, normals, &pMesh, "SharedMesh")));
-            pModel->AddMeshData(pMesh);
-
-            Canvas::XSceneGraphNode *pModelRoot = pModel->GetRootNode();
-
-            // NodeA with mesh
-            Gem::TGemPtr<Canvas::XSceneGraphNode> pNodeA;
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pNodeA, "NodeA")));
-            pNodeA->SetLocalTranslation(FloatVector4(1.0f, 0.0f, 0.0f, 1.0f));
-            Gem::TGemPtr<Canvas::XMeshInstance> pMeshA;
-            Assert::IsTrue(Succeeded(pCanvas->CreateMeshInstance(&pMeshA, "MeshA")));
-            pMeshA->SetMeshData(pMesh);
-            Assert::IsTrue(Succeeded(pNodeA->BindElement(pMeshA)));
-            Assert::IsTrue(Succeeded(pModelRoot->AddChild(pNodeA)));
-
-            // NodeB
-            Gem::TGemPtr<Canvas::XSceneGraphNode> pNodeB;
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pNodeB, "NodeB")));
-            pNodeB->SetLocalTranslation(FloatVector4(0.0f, 2.0f, 0.0f, 1.0f));
-            Assert::IsTrue(Succeeded(pModelRoot->AddChild(pNodeB)));
-
-            // NodeC under NodeB with mesh
-            Gem::TGemPtr<Canvas::XSceneGraphNode> pNodeC;
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pNodeC, "NodeC")));
-            pNodeC->SetLocalTranslation(FloatVector4(0.0f, 0.0f, 3.0f, 1.0f));
-            Gem::TGemPtr<Canvas::XMeshInstance> pMeshC;
-            Assert::IsTrue(Succeeded(pCanvas->CreateMeshInstance(&pMeshC, "MeshC")));
-            pMeshC->SetMeshData(pMesh);
-            Assert::IsTrue(Succeeded(pNodeC->BindElement(pMeshC)));
-            Assert::IsTrue(Succeeded(pNodeB->AddChild(pNodeC)));
-
-            // Instantiate into a scene
-            Gem::TGemPtr<Canvas::XScene> pScene;
-            Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene, "TestScene")));
-
-            Canvas::ModelInstantiateResult result{};
-            Assert::IsTrue(Succeeded(pModel->Instantiate(pScene->GetRootNode(), &result)));
-
-            // Verify instance root was created
-            Assert::IsNotNull(result.pInstanceRoot);
-            Assert::IsNull(result.pActiveCamera); // no camera in model
-
-            // Instance root should be a child of scene root
-            Canvas::XSceneGraphNode *pSceneRoot = pScene->GetRootNode();
-            Assert::IsTrue(pSceneRoot->GetFirstChild() == result.pInstanceRoot);
-
-            // Instance root should have 2 children (cloned NodeA and NodeB)
-            Canvas::XSceneGraphNode *pClonedA = result.pInstanceRoot->GetFirstChild();
-            Assert::IsNotNull(pClonedA);
-            Canvas::XSceneGraphNode *pClonedB = result.pInstanceRoot->GetNextChild(pClonedA);
-            Assert::IsNotNull(pClonedB);
-            Assert::IsNull(result.pInstanceRoot->GetNextChild(pClonedB)); // no more children
-
-            // Verify transforms were copied
-            Assert::IsTrue(AlmostEqual(pClonedA->GetLocalTranslation(), FloatVector4(1.0f, 0.0f, 0.0f, 1.0f)));
-            Assert::IsTrue(AlmostEqual(pClonedB->GetLocalTranslation(), FloatVector4(0.0f, 2.0f, 0.0f, 1.0f)));
-
-            // ClonedB should have one child (cloned NodeC)
-            Canvas::XSceneGraphNode *pClonedC = pClonedB->GetFirstChild();
-            Assert::IsNotNull(pClonedC);
-            Assert::IsTrue(AlmostEqual(pClonedC->GetLocalTranslation(), FloatVector4(0.0f, 0.0f, 3.0f, 1.0f)));
-
-            // Verify mesh instances share the same GPU mesh data
-            Assert::AreEqual(1u, pClonedA->GetBoundElementCount());
-            Canvas::XSceneGraphElement *pClonedElemA = pClonedA->GetBoundElement(0);
-            Gem::TGemPtr<Canvas::XMeshInstance> pClonedMeshA;
-            Assert::IsTrue(Succeeded(pClonedElemA->QueryInterface(&pClonedMeshA)));
-            Assert::IsTrue(pClonedMeshA->GetMeshData() == pMesh.Get()); // shared GPU data
-
-            Assert::AreEqual(1u, pClonedC->GetBoundElementCount());
-            Canvas::XSceneGraphElement *pClonedElemC = pClonedC->GetBoundElement(0);
-            Gem::TGemPtr<Canvas::XMeshInstance> pClonedMeshC;
-            Assert::IsTrue(Succeeded(pClonedElemC->QueryInterface(&pClonedMeshC)));
-            Assert::IsTrue(pClonedMeshC->GetMeshData() == pMesh.Get()); // shared GPU data
-        }
-
-        TEST_METHOD(ModelInstantiateTransformIndependence)
-        {
-            using namespace Canvas::Math;
-
-            Gem::TGemPtr<XCanvas> pCanvas;
-            Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
-            CreateTestCanvasAndDevice(pCanvas, pDevice);
-
-            Gem::TGemPtr<Canvas::XModel> pModel;
-            Assert::IsTrue(Succeeded(pCanvas->CreateModel(pDevice, &pModel, "TestModel")));
-
-            Gem::TGemPtr<Canvas::XSceneGraphNode> pNodeA;
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pNodeA, "NodeA")));
-            pNodeA->SetLocalTranslation(FloatVector4(1.0f, 0.0f, 0.0f, 1.0f));
-            Assert::IsTrue(Succeeded(pModel->GetRootNode()->AddChild(pNodeA)));
-
-            // Create scene and instantiate twice
-            Gem::TGemPtr<Canvas::XScene> pScene;
-            Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene, "TestScene")));
-
-            Canvas::ModelInstantiateResult result1{}, result2{};
-            Assert::IsTrue(Succeeded(pModel->Instantiate(pScene->GetRootNode(), &result1)));
-            Assert::IsTrue(Succeeded(pModel->Instantiate(pScene->GetRootNode(), &result2)));
-
-            // Both instances should exist independently
-            Assert::IsNotNull(result1.pInstanceRoot);
-            Assert::IsNotNull(result2.pInstanceRoot);
-            Assert::IsTrue(result1.pInstanceRoot != result2.pInstanceRoot);
-
-            // Modify instance 1's child transform
-            Canvas::XSceneGraphNode *pCloned1A = result1.pInstanceRoot->GetFirstChild();
-            Canvas::XSceneGraphNode *pCloned2A = result2.pInstanceRoot->GetFirstChild();
-            Assert::IsNotNull(pCloned1A);
-            Assert::IsNotNull(pCloned2A);
-
-            pCloned1A->SetLocalTranslation(FloatVector4(99.0f, 0.0f, 0.0f, 1.0f));
-
-            // Instance 2 should be unaffected
-            Assert::IsTrue(AlmostEqual(pCloned2A->GetLocalTranslation(), FloatVector4(1.0f, 0.0f, 0.0f, 1.0f)));
-        }
-
-        TEST_METHOD(ModelActiveCameraInstantiation)
-        {
-            using namespace Canvas::Math;
-
-            Gem::TGemPtr<XCanvas> pCanvas;
-            Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
-            CreateTestCanvasAndDevice(pCanvas, pDevice);
-
-            Gem::TGemPtr<Canvas::XModel> pModel;
-            Assert::IsTrue(Succeeded(pCanvas->CreateModel(pDevice, &pModel, "CameraModel")));
-
-            // Add a camera node to the model
-            Gem::TGemPtr<Canvas::XSceneGraphNode> pCamNode;
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pCamNode, "CamNode")));
-            pCamNode->SetLocalTranslation(FloatVector4(0.0f, -5.0f, 2.0f, 1.0f));
-
-            Gem::TGemPtr<Canvas::XCamera> pCamera;
-            Assert::IsTrue(Succeeded(pCanvas->CreateCamera(&pCamera, "ModelCamera")));
-            pCamera->SetFovAngle(1.2f);
-            pCamera->SetNearClip(0.5f);
-            pCamera->SetFarClip(500.0f);
-            Assert::IsTrue(Succeeded(pCamNode->BindElement(pCamera)));
-            Assert::IsTrue(Succeeded(pModel->GetRootNode()->AddChild(pCamNode)));
-
-            // Set as active camera node
-            pModel->SetActiveCameraNode(pCamNode);
-            Assert::IsTrue(pModel->GetActiveCameraNode() == pCamNode.Get());
-
-            // Instantiate
-            Gem::TGemPtr<Canvas::XScene> pScene;
-            Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene, "TestScene")));
-
-            Canvas::ModelInstantiateResult result{};
-            Assert::IsTrue(Succeeded(pModel->Instantiate(pScene->GetRootNode(), &result)));
-
-            // Active camera should be mapped in result
-            Assert::IsNotNull(result.pActiveCamera);
-
-            // Camera properties should be cloned
-            Assert::AreEqual(1.2f, result.pActiveCamera->GetFovAngle());
-            Assert::AreEqual(0.5f, result.pActiveCamera->GetNearClip());
-            Assert::AreEqual(500.0f, result.pActiveCamera->GetFarClip());
-
-            // Camera should be attached to the cloned node, not the model's node
-            Canvas::XSceneGraphNode *pClonedCamNode = result.pActiveCamera->GetAttachedNode();
-            Assert::IsNotNull(pClonedCamNode);
-            Assert::IsTrue(pClonedCamNode != pCamNode.Get()); // different node instance
-            Assert::IsTrue(AlmostEqual(pClonedCamNode->GetLocalTranslation(), FloatVector4(0.0f, -5.0f, 2.0f, 1.0f)));
-        }
-
-        TEST_METHOD(ModelLightCloning)
-        {
-            using namespace Canvas::Math;
-
-            Gem::TGemPtr<XCanvas> pCanvas;
-            Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
-            CreateTestCanvasAndDevice(pCanvas, pDevice);
-
-            Gem::TGemPtr<Canvas::XModel> pModel;
-            Assert::IsTrue(Succeeded(pCanvas->CreateModel(pDevice, &pModel, "LightModel")));
-
-            // Add a light node
-            Gem::TGemPtr<Canvas::XSceneGraphNode> pLightNode;
-            Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pLightNode, "LightNode")));
-
-            Gem::TGemPtr<Canvas::XLight> pLight;
-            Assert::IsTrue(Succeeded(pCanvas->CreateLight(Canvas::LightType::Point, &pLight, "PointLight")));
-            pLight->SetColor(FloatVector4(1.0f, 0.5f, 0.0f, 1.0f));
-            pLight->SetIntensity(3.0f);
-            pLight->SetRange(50.0f);
-            Assert::IsTrue(Succeeded(pLightNode->BindElement(pLight)));
-            Assert::IsTrue(Succeeded(pModel->GetRootNode()->AddChild(pLightNode)));
-
-            // Instantiate
-            Gem::TGemPtr<Canvas::XScene> pScene;
-            Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene, "TestScene")));
-
-            Canvas::ModelInstantiateResult result{};
-            Assert::IsTrue(Succeeded(pModel->Instantiate(pScene->GetRootNode(), &result)));
-
-            // Find cloned light
-            Canvas::XSceneGraphNode *pClonedLightNode = result.pInstanceRoot->GetFirstChild();
-            Assert::IsNotNull(pClonedLightNode);
-            Assert::AreEqual(1u, pClonedLightNode->GetBoundElementCount());
-
-            Gem::TGemPtr<Canvas::XLight> pClonedLight;
-            Assert::IsTrue(Succeeded(pClonedLightNode->GetBoundElement(0)->QueryInterface(&pClonedLight)));
-
-            Assert::IsTrue(pClonedLight->GetType() == Canvas::LightType::Point);
-            Assert::IsTrue(AlmostEqual(pClonedLight->GetColor(), FloatVector4(1.0f, 0.5f, 0.0f, 1.0f)));
-            Assert::AreEqual(3.0f, pClonedLight->GetIntensity());
-            Assert::AreEqual(50.0f, pClonedLight->GetRange());
-        }
-
-        TEST_METHOD(ModelEmptyInstantiation)
-        {
-            Gem::TGemPtr<XCanvas> pCanvas;
-            Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
-            CreateTestCanvasAndDevice(pCanvas, pDevice);
-
-            // Create empty model (no child nodes)
-            Gem::TGemPtr<Canvas::XModel> pModel;
-            Assert::IsTrue(Succeeded(pCanvas->CreateModel(pDevice, &pModel, "EmptyModel")));
-
-            Gem::TGemPtr<Canvas::XScene> pScene;
-            Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene, "TestScene")));
-
-            Canvas::ModelInstantiateResult result{};
-            Assert::IsTrue(Succeeded(pModel->Instantiate(pScene->GetRootNode(), &result)));
-
-            // Should still create a synthetic instance root
-            Assert::IsNotNull(result.pInstanceRoot);
-            Assert::IsNull(result.pActiveCamera);
-
-            // Instance root should have no children
-            Assert::IsNull(result.pInstanceRoot->GetFirstChild());
-        }
-
-        TEST_METHOD(ModelInstantiateNullTargetFails)
-        {
-            Gem::TGemPtr<XCanvas> pCanvas;
-            Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
-            CreateTestCanvasAndDevice(pCanvas, pDevice);
-
-            Gem::TGemPtr<Canvas::XModel> pModel;
-            Assert::IsTrue(Succeeded(pCanvas->CreateModel(pDevice, &pModel, "TestModel")));
-
-            // Null target should fail
-            Assert::IsTrue(Gem::Failed(pModel->Instantiate(nullptr)));
-        }
+        auto d = m1[row] - m0[row];
+        float lensq = Canvas::Math::DotProduct(d, d);
+        if (!AlmostZero(lensq)) return false;
+    }
+    return true;
+}
+
+} // anonymous namespace
+
+TEST(CanvasInterfacesTest, SimpleInterfaces)
+{
+    // Create XCanvas object
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+
+    // Create XScene object
+    Gem::TGemPtr<Canvas::XScene> pScene;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
+
+    // Create an empty XSceneGraphNode
+    Gem::TGemPtr<Canvas::XSceneGraphNode> pSceneGraphNode;
+    const char szNodeName[] = "NullNode";
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pSceneGraphNode)));
+    pSceneGraphNode->SetName(szNodeName);
+
+    // Verify QI for XGeneric
+    Gem::TGemPtr<XGeneric> pGeneric;
+    EXPECT_TRUE(Succeeded(pSceneGraphNode->QueryInterface(&pGeneric)));
+
+    // Validate the name
+    EXPECT_TRUE(0 == strncmp(pSceneGraphNode->GetName(), szNodeName, _countof(szNodeName)));
+}
+
+TEST(CanvasInterfacesTest, SceneGraphNodesTest)
+{
+    // Create XCanvas object
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+
+    // Create XScene object
+    Gem::TGemPtr<XScene> pScene;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
+
+    // Create nodes
+    Gem::TGemPtr<XSceneGraphNode> pNodes[6];
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pNodes[0])));
+    pNodes[0]->SetName("Node0");
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pNodes[1])));
+    pNodes[1]->SetName("Node1");
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pNodes[2])));
+    pNodes[2]->SetName("Node2");
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pNodes[3])));
+    pNodes[3]->SetName("Node3");
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pNodes[4])));
+    pNodes[4]->SetName("Node4");
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pNodes[5])));
+    pNodes[5]->SetName("Node5");
+
+    // Build the following tree
+    // Root
+    //  - Node0
+    //      - Node2
+    //      - Node3
+    //  - Node1
+    //      - Node4
+    //          - Node5
+
+    Gem::TGemPtr<XSceneGraphNode> pRoot = pScene->GetRootNode();
+    EXPECT_NE(pRoot.Get(), nullptr);
+    EXPECT_TRUE(Succeeded(pRoot->AddChild(pNodes[0])));
+    EXPECT_TRUE(Succeeded(pRoot->AddChild(pNodes[1])));
+    EXPECT_TRUE(Succeeded(pNodes[0]->AddChild(pNodes[2])));
+    EXPECT_TRUE(Succeeded(pNodes[0]->AddChild(pNodes[3])));
+    EXPECT_TRUE(Succeeded(pNodes[1]->AddChild(pNodes[4])));
+    EXPECT_TRUE(Succeeded(pNodes[4]->AddChild(pNodes[5])));
+}
+
+TEST(CanvasInterfacesTest, SceneGraphTransforms)
+{
+    using namespace Canvas::Math;
+
+    // Create Canvas and Scene
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+    Gem::TGemPtr<XScene> pScene;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
+
+    // Create a small hierarchy: root -> A -> B
+    Gem::TGemPtr<XSceneGraphNode> pA, pB;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pA)));
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pB)));
+
+    Gem::TGemPtr<XSceneGraphNode> pRoot = pScene->GetRootNode();
+    EXPECT_NE(pRoot.Get(), nullptr);
+    EXPECT_TRUE(Succeeded(pRoot->AddChild(pA)));
+    EXPECT_TRUE(Succeeded(pA->AddChild(pB)));
+
+    // Set locals
+    // A: rotate 90 deg around Z, translate (1,2,0)
+    const float ninety = float(3.14159265358979323846 / 2.0);
+    auto qA = FloatQuaternion::FromEulerXYZ(0.0f, 0.0f, ninety);
+    pA->SetLocalRotation(qA);
+    pA->SetLocalTranslation(FloatVector4(1.0f, 2.0f, 0.0f, 1.0f));
+
+    // B: rotate 90 deg around X, translate (1,0,0)
+    auto qB = FloatQuaternion::FromEulerXYZ(ninety, 0.0f, 0.0f);
+    pB->SetLocalRotation(qB);
+    pB->SetLocalTranslation(FloatVector4(1.0f, 0.0f, 0.0f, 1.0f));
+
+    // Verify A local matrix matches quaternion + translation
+    auto mA_local = pA->GetLocalMatrix();
+    auto mA_expected = QuaternionToRotationMatrix(qA);
+    mA_expected[3][0] = 1.0f; mA_expected[3][1] = 2.0f; mA_expected[3][2] = 0.0f; mA_expected[3][3] = 1.0f;
+    EXPECT_TRUE(AlmostEqual(mA_local, mA_expected));
+
+    // Verify B local matrix
+    auto mB_local = pB->GetLocalMatrix();
+    auto mB_expected = QuaternionToRotationMatrix(qB);
+    mB_expected[3][0] = 1.0f; mB_expected[3][1] = 0.0f; mB_expected[3][2] = 0.0f; mB_expected[3][3] = 1.0f;
+    EXPECT_TRUE(AlmostEqual(mB_local, mB_expected));
+
+    // Global rotations: Rg(A) = qA, Rg(B) = qA * qB
+    auto qA_g = pA->GetGlobalRotation();
+    auto qB_g = pB->GetGlobalRotation();
+    EXPECT_TRUE(AlmostEqual(qA_g, qA.Normalize()));
+    EXPECT_TRUE(AlmostEqual(qB_g, (qA * qB).Normalize()));
+
+    // Global translations:
+    // Tg(A) = rotate(qRoot, (1,2,0)) + Troot = (1,2,0)
+    // Tg(B) = Tg(A) + rotate(Rg(A), (1,0,0)) = (1,2,0) + (0,1,0) = (1,3,0)
+    auto tA_g = pA->GetGlobalTranslation();
+    auto tB_g = pB->GetGlobalTranslation();
+    EXPECT_TRUE(AlmostEqual(tA_g, FloatVector4(1.0f, 2.0f, 0.0f, 1.0f)));
+    EXPECT_TRUE(AlmostEqual(tB_g, FloatVector4(1.0f, 3.0f, 0.0f, 1.0f)));
+
+    // Global matrices: Mg = Mparent * Mlocal (row-vector convention)
+    auto mA_global = pA->GetGlobalMatrix();
+    auto mB_global = pB->GetGlobalMatrix();
+    auto mRoot = FloatMatrix4x4::Identity();
+    auto mA_global_expected = mRoot * mA_local; // root is identity
+    auto mB_global_expected = mA_global_expected * mB_local;
+    EXPECT_TRUE(AlmostEqual(mA_global, mA_global_expected));
+    EXPECT_TRUE(AlmostEqual(mB_global, mB_global_expected));
+
+    // Test scenario: Move B from A to Root after transforms are resolved
+    // This tests that dirty flags are properly set when parent changes
+
+    // First, create a new node C under Root for verification
+    Gem::TGemPtr<XSceneGraphNode> pC;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pC)));
+    auto qC = FloatQuaternion::FromEulerXYZ(0.0f, ninety, 0.0f);  // 90° around Y
+    pC->SetLocalRotation(qC);
+    pC->SetLocalTranslation(FloatVector4(0.0f, 0.0f, 1.0f, 1.0f));
+    EXPECT_TRUE(Succeeded(pRoot->AddChild(pC)));
+
+    // Verify C's initial global transforms
+    auto qC_g_initial = pC->GetGlobalRotation();
+    auto tC_g_initial = pC->GetGlobalTranslation();
+    EXPECT_TRUE(AlmostEqual(qC_g_initial, qC.Normalize()));
+    EXPECT_TRUE(AlmostEqual(tC_g_initial, FloatVector4(0.0f, 0.0f, 1.0f, 1.0f)));
+
+    // Now move B from A to C (B was previously under A)
+    // B's local is: rotation 90° around X, translation (1,0,0)
+    // When B is under C (which has 90° Y rotation and translation (0,0,1)):
+    //   - B's global rotation should be: qC * qB
+    //   - B's global translation should be: tC + rotate(qC, (1,0,0)) = (0,0,1) + (0,0,-1) = (0,0,0)
+
+    EXPECT_TRUE(Succeeded(pC->AddChild(pB)));
+
+    // After moving, B's global transforms should reflect new parent C
+    auto qB_g_moved = pB->GetGlobalRotation();
+    auto tB_g_moved = pB->GetGlobalTranslation();
+    auto mB_global_moved = pB->GetGlobalMatrix();
+
+    // Expected: qC * qB
+    auto qB_g_expected_moved = (qC * qB).Normalize();
+    EXPECT_TRUE(AlmostEqual(qB_g_moved, qB_g_expected_moved));
+
+    // Expected translation: C's translation (0,0,1) + rotate(qC, B's local translation (1,0,0))
+    // qC rotates (1,0,0) by 90° around Y: (1,0,0) -> (0,0,-1)
+    const FloatQuaternion vB_local(1.0f, 0.0f, 0.0f, 0.0f);
+    const auto qC_conj = Conjugate(qC.Normalize());
+    const auto vB_rotated = qC.Normalize() * vB_local * qC_conj;
+    FloatVector4 tB_expected_moved = tC_g_initial + FloatVector4(vB_rotated.X, vB_rotated.Y, vB_rotated.Z, 0.0f);
+    tB_expected_moved.W = 1.0f;
+    EXPECT_TRUE(AlmostEqual(tB_g_moved, tB_expected_moved));
+
+    // Expected matrix: C_global * B_local
+    auto mC_global = pC->GetGlobalMatrix();
+    auto mB_global_expected_moved = mC_global * mB_local;
+    EXPECT_TRUE(AlmostEqual(mB_global_moved, mB_global_expected_moved));
+
+    // Verify that A's child is no longer B (B was moved to C)
+    auto pA_firstChild = pA->GetFirstChild();
+    EXPECT_TRUE(pA_firstChild == nullptr || pA_firstChild != pB.Get());
+
+    // Test that changing a parent's transform propagates to descendants
+    // B is currently a child of C. If we change C's rotation/translation,
+    // B's global transforms should update accordingly.
+
+    // Get B's current global matrix and local matrix (local shouldn't change)
+    auto mB_before_parent_change = pB->GetGlobalMatrix();
+    auto mB_local_saved = pB->GetLocalMatrix();
+
+    // Change C's local translation
+    pC->SetLocalTranslation(FloatVector4(5.0f, 5.0f, 5.0f, 1.0f));
+
+    // B's local matrix should remain unchanged
+    auto mB_local_check = pB->GetLocalMatrix();
+    EXPECT_TRUE(AlmostEqual(mB_local_saved, mB_local_check));
+
+    // B's global matrix should now be different (dirty flags propagated)
+    auto mB_after_translation = pB->GetGlobalMatrix();
+    EXPECT_FALSE(AlmostEqual(mB_before_parent_change, mB_after_translation));
+
+    // Verify the new value is correct: C_new_global * B_local
+    auto mC_global_new = pC->GetGlobalMatrix();
+    auto mB_expected_new = mC_global_new * mB_local_saved;
+    EXPECT_TRUE(AlmostEqual(mB_after_translation, mB_expected_new));
+
+    // Change C's rotation
+    auto qC_new = FloatQuaternion::FromEulerXYZ(ninety, 0.0f, 0.0f);  // 90° around X instead of Y
+    pC->SetLocalRotation(qC_new);
+
+    // B's global transforms should update again
+    auto mB_after_rotation = pB->GetGlobalMatrix();
+    EXPECT_FALSE(AlmostEqual(mB_after_translation, mB_after_rotation));
+
+    // Verify correctness after rotation change
+    auto mC_global_final = pC->GetGlobalMatrix();
+    auto mB_expected_final = mC_global_final * mB_local_saved;
+    EXPECT_TRUE(AlmostEqual(mB_after_rotation, mB_expected_final));
+}
+
+TEST(CanvasInterfacesTest, CameraTest)
+{
+    using namespace Canvas::Math;
+
+    // Create Canvas and Scene
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+    Gem::TGemPtr<XScene> pScene;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
+
+    // Create a hierarchy: root -> A -> B -> cameraNode
+    Gem::TGemPtr<XSceneGraphNode> pA, pB, pCameraNode;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pA)));
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pB)));
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pCameraNode)));
+
+    Gem::TGemPtr<XSceneGraphNode> pRoot = pScene->GetRootNode();
+    EXPECT_NE(pRoot.Get(), nullptr);
+    EXPECT_TRUE(Succeeded(pRoot->AddChild(pA)));
+    EXPECT_TRUE(Succeeded(pA->AddChild(pB)));
+    EXPECT_TRUE(Succeeded(pB->AddChild(pCameraNode)));
+
+    // Create camera and attach to cameraNode
+    Gem::TGemPtr<XCamera> pCamera;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateCamera(&pCamera)));
+    EXPECT_TRUE(Succeeded(pCameraNode->BindElement(pCamera)));
+
+    // Set initial camera parameters
+    const float fov = float(3.14159265358979323846 / 4.0); // 45 degrees
+    const float aspect = 16.0f / 9.0f;
+    const float nearClip = 0.1f;
+    const float farClip = 1000.0f;
+    pCamera->SetFovAngle(fov);
+    pCamera->SetAspectRatio(aspect);
+    pCamera->SetNearClip(nearClip);
+    pCamera->SetFarClip(farClip);
+
+    // Set transforms for the hierarchy
+    const float ninety = float(3.14159265358979323846 / 2.0);
+    auto qA = FloatQuaternion::FromEulerXYZ(0.0f, 0.0f, ninety);
+    pA->SetLocalRotation(qA);
+    pA->SetLocalTranslation(FloatVector4(1.0f, 0.0f, 0.0f, 1.0f));
+
+    auto qB = FloatQuaternion::FromEulerXYZ(ninety, 0.0f, 0.0f);
+    pB->SetLocalRotation(qB);
+    pB->SetLocalTranslation(FloatVector4(0.0f, 1.0f, 0.0f, 1.0f));
+
+    pCameraNode->SetLocalTranslation(FloatVector4(0.0f, 0.0f, 5.0f, 1.0f));
+
+    // Update scene graph and camera (simulates frame update)
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
+
+    // Get initial matrices - this will compute and cache them
+    auto viewMatrix1 = pCamera->GetViewMatrix();
+    auto projMatrix1 = pCamera->GetProjectionMatrix();
+    auto viewProjMatrix1 = pCamera->GetViewProjectionMatrix();
+
+    // Verify matrices are not identity
+    auto identity = FloatMatrix4x4::Identity();
+    EXPECT_FALSE(AlmostEqual(viewMatrix1, identity)) << "View matrix should not be identity";
+    EXPECT_FALSE(AlmostEqual(projMatrix1, identity)) << "Projection matrix should not be identity";
+
+    // Projection now produces standard D3D LHS clip space from a
+    // view space where +X=right, +Y=up, +Z=forward. The matrix
+    // should look like:
+    // Row 0: [ f/aspect, 0,    0,    0 ]  (x_view=right    -> x_clip)
+    // Row 1: [    0,     f,    0,    0 ]  (y_view=up       -> y_clip)
+    // Row 2: [    0,     0,    A,    1 ]  (z_view=forward  -> z_clip + w_clip)
+    // Row 3: [    0,     0,    B,    0 ]  (const           -> z_clip depth bias)
+
+    // Check specific elements to validate the projection matrix structure
+    const float tolerance = 1e-5f;
+    float f = 1.0f / std::tan(fov * 0.5f);  // approx 2.414
+
+    // Row 0, col 0: f / aspect (right -> x_clip)
+    EXPECT_TRUE(std::abs(projMatrix1[0][0] - f / aspect) < 0.01f) << "proj[0][0] should be approximately f/aspect";
+
+    // Row 1, col 1: f (up -> y_clip)
+    EXPECT_TRUE(std::abs(projMatrix1[1][1] - f) < 0.01f) << "proj[1][1] should be approximately 2.414 (f)";
+
+    // Row 2, col 3: Should have 1.0 for perspective divide (forward -> w_clip)
+    EXPECT_TRUE(std::abs(projMatrix1[2][3] - 1.0f) < tolerance) << "proj[2][3] should be 1.0 for perspective divide";
+
+    // The old shape's hot cells should now be zero.
+    EXPECT_TRUE(std::abs(projMatrix1[0][3]) < tolerance) << "proj[0][3] should be 0 in new convention";
+    EXPECT_TRUE(std::abs(projMatrix1[1][0]) < tolerance) << "proj[1][0] should be 0 in new convention";
+    EXPECT_TRUE(std::abs(projMatrix1[2][1]) < tolerance) << "proj[2][1] should be 0 in new convention";
+    EXPECT_TRUE(std::abs(projMatrix1[3][3]) < tolerance) << "proj[3][3] should be 0";
+
+    // Verify view-projection is the product of view and projection
+    auto expectedViewProj = viewMatrix1 * projMatrix1;
+    EXPECT_TRUE(AlmostEqual(viewProjMatrix1, expectedViewProj));
+
+    // Test 1: Modify camera node's local transform
+    // This should invalidate view matrix after Update()
+    pCameraNode->SetLocalTranslation(FloatVector4(0.0f, 0.0f, 10.0f, 1.0f));
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
+
+    auto viewMatrix2 = pCamera->GetViewMatrix();
+    EXPECT_FALSE(AlmostEqual(viewMatrix1, viewMatrix2)); // Should be different
+
+    // Projection should remain the same (no parameters changed)
+    auto projMatrix2 = pCamera->GetProjectionMatrix();
+    EXPECT_TRUE(AlmostEqual(projMatrix1, projMatrix2));
+
+    // View-projection should be different
+    auto viewProjMatrix2 = pCamera->GetViewProjectionMatrix();
+    EXPECT_FALSE(AlmostEqual(viewProjMatrix1, viewProjMatrix2));
+
+    // Test 2: Modify parent node B's transform
+    // This should invalidate camera's view matrix (ancestor changed)
+    pB->SetLocalTranslation(FloatVector4(0.0f, 2.0f, 0.0f, 1.0f));
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
+
+    auto viewMatrix3 = pCamera->GetViewMatrix();
+    EXPECT_FALSE(AlmostEqual(viewMatrix2, viewMatrix3)); // Should be different from previous
+
+    // Test 3: Modify grandparent node A's transform
+    // This should also invalidate camera's view matrix
+    pA->SetLocalTranslation(FloatVector4(2.0f, 0.0f, 0.0f, 1.0f));
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
+
+    auto viewMatrix4 = pCamera->GetViewMatrix();
+    EXPECT_FALSE(AlmostEqual(viewMatrix3, viewMatrix4)); // Should be different
+
+    // Test 4: Modify projection parameters
+    // This should invalidate projection and view-projection matrices
+    pCamera->SetFovAngle(float(3.14159265358979323846 / 3.0)); // 60 degrees
+    auto projMatrix3 = pCamera->GetProjectionMatrix();
+    EXPECT_FALSE(AlmostEqual(projMatrix2, projMatrix3)); // Should be different
+
+    auto viewProjMatrix3 = pCamera->GetViewProjectionMatrix();
+    EXPECT_FALSE(AlmostEqual(viewProjMatrix2, viewProjMatrix3));
+
+    // Verify new view-projection is correct product
+    auto viewMatrixCurrent = pCamera->GetViewMatrix();
+    auto projMatrixCurrent = pCamera->GetProjectionMatrix();
+    auto expectedViewProjCurrent = viewMatrixCurrent * projMatrixCurrent;
+    EXPECT_TRUE(AlmostEqual(viewProjMatrix3, expectedViewProjCurrent));
+
+    // Test 5: Modify aspect ratio
+    pCamera->SetAspectRatio(4.0f / 3.0f);
+    auto projMatrix4 = pCamera->GetProjectionMatrix();
+    EXPECT_FALSE(AlmostEqual(projMatrix3, projMatrix4));
+
+    // Test 6: Modify near/far clip planes
+    pCamera->SetNearClip(0.5f);
+    auto projMatrix5 = pCamera->GetProjectionMatrix();
+    EXPECT_FALSE(AlmostEqual(projMatrix4, projMatrix5));
+
+    pCamera->SetFarClip(500.0f);
+    auto projMatrix6 = pCamera->GetProjectionMatrix();
+    EXPECT_FALSE(AlmostEqual(projMatrix5, projMatrix6));
+}
+
+TEST(CanvasInterfacesTest, CameraNodeReparenting)
+{
+    using namespace Canvas::Math;
+
+    // Create Canvas and Scene
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+    Gem::TGemPtr<XScene> pScene;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
+
+    // Create two separate branches: root -> A and root -> B
+    Gem::TGemPtr<XSceneGraphNode> pA, pB, pCameraNode;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pA)));
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pB)));
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pCameraNode)));
+
+    Gem::TGemPtr<XSceneGraphNode> pRoot = pScene->GetRootNode();
+    EXPECT_NE(pRoot.Get(), nullptr);
+
+    // Initial setup: cameraNode is under A
+    EXPECT_TRUE(Succeeded(pRoot->AddChild(pA)));
+    EXPECT_TRUE(Succeeded(pRoot->AddChild(pB)));
+    EXPECT_TRUE(Succeeded(pA->AddChild(pCameraNode)));
+
+    // Create camera and attach
+    Gem::TGemPtr<XCamera> pCamera;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateCamera(&pCamera)));
+    EXPECT_TRUE(Succeeded(pCameraNode->BindElement(pCamera)));
+
+    // Set different transforms for A and B
+    const float ninety = float(3.14159265358979323846 / 2.0);
+    auto qA = FloatQuaternion::FromEulerXYZ(0.0f, 0.0f, ninety); // Rotate 90° around Z
+    pA->SetLocalRotation(qA);
+    pA->SetLocalTranslation(FloatVector4(5.0f, 0.0f, 0.0f, 1.0f));
+
+    auto qB = FloatQuaternion::FromEulerXYZ(0.0f, ninety, 0.0f); // Rotate 90° around Y
+    pB->SetLocalRotation(qB);
+    pB->SetLocalTranslation(FloatVector4(0.0f, 5.0f, 0.0f, 1.0f));
+
+    pCameraNode->SetLocalTranslation(FloatVector4(1.0f, 0.0f, 0.0f, 1.0f));
+
+    // Update and get initial view matrix (camera is under A)
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
+    auto viewMatrix1 = pCamera->GetViewMatrix();
+    auto viewProjMatrix1 = pCamera->GetViewProjectionMatrix();
+
+    // Move camera node from A to B
+    // This changes the camera's parent, so its world transform will change
+    EXPECT_TRUE(Succeeded(pB->AddChild(pCameraNode)));
+
+    // Update scene to mark view matrix dirty
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
+
+    // Get new matrices - should be different due to different parent transform
+    auto viewMatrix2 = pCamera->GetViewMatrix();
+    auto viewProjMatrix2 = pCamera->GetViewProjectionMatrix();
+
+    // Matrices should be different (different parent transforms)
+    EXPECT_FALSE(AlmostEqual(viewMatrix1, viewMatrix2));
+    EXPECT_FALSE(AlmostEqual(viewProjMatrix1, viewProjMatrix2));
+
+    // The view matrix bakes in the world(X-fwd, Y-left, Z-up) ->
+    // view(X-right, Y-up, Z-fwd) basis remap, so world * view is no
+    // longer identity.  The invariant that does hold is that the
+    // camera's world-space position maps to the view-space origin.
+    auto cameraWorldMatrix = pCameraNode->GetGlobalMatrix();
+    FloatVector4 cameraWorldPos(
+        cameraWorldMatrix[3][0], cameraWorldMatrix[3][1],
+        cameraWorldMatrix[3][2], 1.0f);
+    FloatVector4 cameraViewPos = cameraWorldPos * viewMatrix2;
+    EXPECT_TRUE(std::abs(cameraViewPos.X) < 1e-4f);
+    EXPECT_TRUE(std::abs(cameraViewPos.Y) < 1e-4f);
+    EXPECT_TRUE(std::abs(cameraViewPos.Z) < 1e-4f);
+    EXPECT_TRUE(std::abs(cameraViewPos.W - 1.0f) < 1e-4f);
+
+    // Test moving to root (no parent transform)
+    EXPECT_TRUE(Succeeded(pRoot->AddChild(pCameraNode)));
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
+
+    auto viewMatrix3 = pCamera->GetViewMatrix();
+    EXPECT_FALSE(AlmostEqual(viewMatrix2, viewMatrix3));
+
+    // With only local transform, world matrix should equal local matrix
+    auto cameraLocalMatrix = pCameraNode->GetLocalMatrix();
+    auto cameraWorldMatrix2 = pCameraNode->GetGlobalMatrix();
+    EXPECT_TRUE(AlmostEqual(cameraLocalMatrix, cameraWorldMatrix2));
+}
+
+TEST(CanvasInterfacesTest, CameraMatrixConsistency)
+{
+    using namespace Canvas::Math;
+
+    // Create Canvas and Scene
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+    Gem::TGemPtr<XScene> pScene;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
+
+    // Create camera node
+    Gem::TGemPtr<XSceneGraphNode> pCameraNode;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pCameraNode)));
+
+    Gem::TGemPtr<XSceneGraphNode> pRoot = pScene->GetRootNode();
+    EXPECT_TRUE(Succeeded(pRoot->AddChild(pCameraNode)));
+
+    // Create and attach camera
+    Gem::TGemPtr<XCamera> pCamera;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateCamera(&pCamera)));
+    EXPECT_TRUE(Succeeded(pCameraNode->BindElement(pCamera)));
+
+    // Set camera parameters
+    pCamera->SetFovAngle(float(3.14159265358979323846 / 4.0));
+    pCamera->SetAspectRatio(16.0f / 9.0f);
+    pCamera->SetNearClip(0.1f);
+    pCamera->SetFarClip(1000.0f);
+
+    // Position camera
+    const float ninety = float(3.14159265358979323846 / 2.0);
+    auto qCamera = FloatQuaternion::FromEulerXYZ(0.0f, ninety, 0.0f);
+    pCameraNode->SetLocalRotation(qCamera);
+    pCameraNode->SetLocalTranslation(FloatVector4(10.0f, 5.0f, 0.0f, 1.0f));
+
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
+
+    // Test: Calling GetViewProjectionMatrix should compute all three matrices
+    auto viewProjMatrix = pCamera->GetViewProjectionMatrix();
+
+    // Now calling individual getters should return cached values (not recompute)
+    auto viewMatrix = pCamera->GetViewMatrix();
+    auto projMatrix = pCamera->GetProjectionMatrix();
+
+    // Verify view-projection is the correct product
+    auto expectedViewProj = viewMatrix * projMatrix;
+    EXPECT_TRUE(AlmostEqual(viewProjMatrix, expectedViewProj));
+
+    // Test: Calling individual getters first, then combined
+    pCameraNode->SetLocalTranslation(FloatVector4(20.0f, 10.0f, 0.0f, 1.0f));
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
+
+    auto viewMatrix2 = pCamera->GetViewMatrix();
+    auto projMatrix2 = pCamera->GetProjectionMatrix();
+    auto viewProjMatrix2 = pCamera->GetViewProjectionMatrix();
+
+    // Verify consistency
+    auto expectedViewProj2 = viewMatrix2 * projMatrix2;
+    EXPECT_TRUE(AlmostEqual(viewProjMatrix2, expectedViewProj2));
+
+    // Test: Multiple calls without changes should return same matrices
+    auto viewMatrix3 = pCamera->GetViewMatrix();
+    auto projMatrix3 = pCamera->GetProjectionMatrix();
+    auto viewProjMatrix3 = pCamera->GetViewProjectionMatrix();
+
+    EXPECT_TRUE(AlmostEqual(viewMatrix2, viewMatrix3));
+    EXPECT_TRUE(AlmostEqual(projMatrix2, projMatrix3));
+    EXPECT_TRUE(AlmostEqual(viewProjMatrix2, viewProjMatrix3));
+}
+
+TEST(CanvasInterfacesTest, LightTest)
+{
+    using namespace Canvas::Math;
+
+    // Create Canvas and Scene
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+    Gem::TGemPtr<XScene> pScene;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
+
+    // Create a hierarchy: root -> A -> B -> lightNode
+    Gem::TGemPtr<XSceneGraphNode> pA, pB, pLightNode;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pA)));
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pB)));
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pLightNode)));
+
+    Gem::TGemPtr<XSceneGraphNode> pRoot = pScene->GetRootNode();
+    EXPECT_NE(pRoot.Get(), nullptr);
+    EXPECT_TRUE(Succeeded(pRoot->AddChild(pA)));
+    EXPECT_TRUE(Succeeded(pA->AddChild(pB)));
+    EXPECT_TRUE(Succeeded(pB->AddChild(pLightNode)));
+
+    // Create light and attach to lightNode
+    Gem::TGemPtr<XLight> pLight;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateLight(LightType::Point, &pLight)));
+    EXPECT_TRUE(Succeeded(pLightNode->BindElement(pLight)));
+
+    // Verify light is attached to correct node
+    EXPECT_TRUE(pLight->GetAttachedNode() == pLightNode.Get());
+
+    // Set transforms for the hierarchy
+    // A: rotate 90° around Z, translate (5,0,0)
+    const float ninety = float(3.14159265358979323846 / 2.0);
+    auto qA = FloatQuaternion::FromEulerXYZ(0.0f, 0.0f, ninety);
+    pA->SetLocalRotation(qA);
+    pA->SetLocalTranslation(FloatVector4(5.0f, 0.0f, 0.0f, 1.0f));
+
+    // B: rotate 90° around Y, translate (0,3,0)
+    auto qB = FloatQuaternion::FromEulerXYZ(0.0f, ninety, 0.0f);
+    pB->SetLocalRotation(qB);
+    pB->SetLocalTranslation(FloatVector4(0.0f, 3.0f, 0.0f, 1.0f));
+
+    // LightNode: translate (2,0,0)
+    pLightNode->SetLocalTranslation(FloatVector4(2.0f, 0.0f, 0.0f, 1.0f));
+
+    // Update scene to compute global transforms
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
+
+    // Verify light's world transform through its attached node
+    auto lightWorldMatrix = pLightNode->GetGlobalMatrix();
+    auto lightWorldTranslation = pLightNode->GetGlobalTranslation();
+
+    // Light position should reflect the full hierarchy transform
+    // This verifies the light properly inherits ancestor transforms
+    EXPECT_TRUE(lightWorldTranslation.W == 1.0f);
+
+    // Change ancestor transform and verify light position updates
+    pA->SetLocalTranslation(FloatVector4(10.0f, 0.0f, 0.0f, 1.0f));
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
+
+    auto lightWorldTranslation2 = pLightNode->GetGlobalTranslation();
+
+    // Light position should have changed due to ancestor change
+    EXPECT_FALSE(AlmostEqual(lightWorldTranslation, lightWorldTranslation2));
+}
+
+TEST(CanvasInterfacesTest, LightNodeReparenting)
+{
+    using namespace Canvas::Math;
+
+    // Create Canvas and Scene
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+    Gem::TGemPtr<XScene> pScene;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
+
+    // Create nodes: A, B, and lightNode
+    Gem::TGemPtr<XSceneGraphNode> pA, pB, pLightNode;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pA)));
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pB)));
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pLightNode)));
+
+    Gem::TGemPtr<XSceneGraphNode> pRoot = pScene->GetRootNode();
+
+    // Initial hierarchy: root -> A -> lightNode
+    EXPECT_TRUE(Succeeded(pRoot->AddChild(pA)));
+    EXPECT_TRUE(Succeeded(pRoot->AddChild(pB)));
+    EXPECT_TRUE(Succeeded(pA->AddChild(pLightNode)));
+
+    // Create and attach light
+    Gem::TGemPtr<XLight> pLight;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateLight(LightType::Spot, &pLight)));
+    EXPECT_TRUE(Succeeded(pLightNode->BindElement(pLight)));
+
+    // Set different transforms for A and B
+    const float ninety = float(3.14159265358979323846 / 2.0);
+    auto qA = FloatQuaternion::FromEulerXYZ(0.0f, 0.0f, ninety); // Rotate 90° around Z
+    pA->SetLocalRotation(qA);
+    pA->SetLocalTranslation(FloatVector4(5.0f, 0.0f, 0.0f, 1.0f));
+
+    auto qB = FloatQuaternion::FromEulerXYZ(0.0f, ninety, 0.0f); // Rotate 90° around Y
+    pB->SetLocalRotation(qB);
+    pB->SetLocalTranslation(FloatVector4(0.0f, 5.0f, 0.0f, 1.0f));
+
+    pLightNode->SetLocalTranslation(FloatVector4(1.0f, 0.0f, 0.0f, 1.0f));
+
+    // Get initial light world transform (under A)
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
+    auto lightTranslation1 = pLightNode->GetGlobalTranslation();
+    auto lightRotation1 = pLightNode->GetGlobalRotation();
+
+    // Move light node from A to B
+    EXPECT_TRUE(Succeeded(pB->AddChild(pLightNode)));
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
+
+    // Light's world transform should be different (different parent)
+    auto lightTranslation2 = pLightNode->GetGlobalTranslation();
+    auto lightRotation2 = pLightNode->GetGlobalRotation();
+
+    EXPECT_FALSE(AlmostEqual(lightTranslation1, lightTranslation2));
+    EXPECT_FALSE(AlmostEqual(lightRotation1, lightRotation2));
+
+    // Move light to root (no parent transform)
+    EXPECT_TRUE(Succeeded(pRoot->AddChild(pLightNode)));
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
+
+    auto lightTranslation3 = pLightNode->GetGlobalTranslation();
+    auto lightRotation3 = pLightNode->GetGlobalRotation();
+
+    // Under root, light's world transform should equal its local transform
+    auto lightLocalTranslation = pLightNode->GetLocalTranslation();
+    auto lightLocalRotation = pLightNode->GetLocalRotation();
+
+    EXPECT_TRUE(AlmostEqual(lightTranslation3, lightLocalTranslation));
+    EXPECT_TRUE(AlmostEqual(lightRotation3, lightLocalRotation));
+}
+
+TEST(CanvasInterfacesTest, LightTransformPropagation)
+{
+    using namespace Canvas::Math;
+
+    // Create Canvas and Scene
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+    Gem::TGemPtr<XScene> pScene;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
+
+    // Create hierarchy: root -> parent -> lightNode
+    Gem::TGemPtr<XSceneGraphNode> pParent, pLightNode;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pParent)));
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pLightNode)));
+
+    Gem::TGemPtr<XSceneGraphNode> pRoot = pScene->GetRootNode();
+    EXPECT_TRUE(Succeeded(pRoot->AddChild(pParent)));
+    EXPECT_TRUE(Succeeded(pParent->AddChild(pLightNode)));
+
+    // Create and attach light
+    Gem::TGemPtr<XLight> pLight;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateLight(LightType::Directional, &pLight)));
+    EXPECT_TRUE(Succeeded(pLightNode->BindElement(pLight)));
+
+    // Set initial transforms
+    const float ninety = float(3.14159265358979323846 / 2.0);
+    auto qParent = FloatQuaternion::FromEulerXYZ(0.0f, 0.0f, ninety);
+    pParent->SetLocalRotation(qParent);
+    pParent->SetLocalTranslation(FloatVector4(5.0f, 5.0f, 0.0f, 1.0f));
+    pLightNode->SetLocalTranslation(FloatVector4(2.0f, 0.0f, 0.0f, 1.0f));
+
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
+    auto lightTranslation1 = pLightNode->GetGlobalTranslation();
+
+    // Change parent's translation - light should update
+    pParent->SetLocalTranslation(FloatVector4(10.0f, 10.0f, 0.0f, 1.0f));
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
+
+    auto lightTranslation2 = pLightNode->GetGlobalTranslation();
+    EXPECT_FALSE(AlmostEqual(lightTranslation1, lightTranslation2));
+
+    // Verify the light's world transform is computed correctly
+    // Row vectors: world = parent_global * light_local
+    auto parentGlobal = pParent->GetGlobalMatrix();
+    auto lightLocal = pLightNode->GetLocalMatrix();
+    auto expectedLightGlobal = parentGlobal * lightLocal;
+    auto actualLightGlobal = pLightNode->GetGlobalMatrix();
+    EXPECT_TRUE(AlmostEqual(expectedLightGlobal, actualLightGlobal));
+
+    // Change parent's rotation - light should update
+    auto qParentNew = FloatQuaternion::FromEulerXYZ(0.0f, ninety, 0.0f);
+    pParent->SetLocalRotation(qParentNew);
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
+
+    auto lightTranslation3 = pLightNode->GetGlobalTranslation();
+    EXPECT_FALSE(AlmostEqual(lightTranslation2, lightTranslation3));
+
+    // Verify correctness again after rotation change
+    auto parentGlobal2 = pParent->GetGlobalMatrix();
+    auto expectedLightGlobal2 = parentGlobal2 * lightLocal;
+    auto actualLightGlobal2 = pLightNode->GetGlobalMatrix();
+    EXPECT_TRUE(AlmostEqual(expectedLightGlobal2, actualLightGlobal2));
+}
+
+TEST(CanvasInterfacesTest, LightProperties)
+{
+    using namespace Canvas::Math;
+
+    // Create Canvas
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+
+    // Test Point Light
+    Gem::TGemPtr<XLight> pPointLight;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateLight(LightType::Point, &pPointLight)));
+
+    // Verify immutable type
+    EXPECT_TRUE(pPointLight->GetType() == LightType::Point);
+
+    // Test Color
+    FloatVector4 testColor(1.0f, 0.5f, 0.25f, 1.0f);
+    pPointLight->SetColor(testColor);
+    auto retrievedColor = pPointLight->GetColor();
+    EXPECT_TRUE(AlmostEqual(retrievedColor, testColor));
+
+    // Test Intensity
+    pPointLight->SetIntensity(2.5f);
+    EXPECT_EQ(2.5f, pPointLight->GetIntensity());
+
+    // Test Flags
+    pPointLight->SetFlags(LightFlags::CastsShadows | LightFlags::Enabled);
+    EXPECT_EQ((UINT)(LightFlags::CastsShadows | LightFlags::Enabled), pPointLight->GetFlags());
+
+    // Test Range
+    pPointLight->SetRange(500.0f);
+    EXPECT_EQ(500.0f, pPointLight->GetRange());
+
+    // Test Attenuation
+    pPointLight->SetAttenuation(1.0f, 0.09f, 0.032f);
+    float constant = 0.0f, linear = 0.0f, quadratic = 0.0f;
+    pPointLight->GetAttenuation(&constant, &linear, &quadratic);
+    EXPECT_EQ(1.0f, constant);
+    EXPECT_EQ(0.09f, linear);
+    EXPECT_EQ(0.032f, quadratic);
+
+    // Test Spot Light
+    Gem::TGemPtr<XLight> pSpotLight;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateLight(LightType::Spot, &pSpotLight)));
+
+    // Verify type
+    EXPECT_TRUE(pSpotLight->GetType() == LightType::Spot);
+
+    // Test Spot Angles
+    const float innerAngle = 0.523599f; // 30 degrees
+    const float outerAngle = 0.785398f; // 45 degrees
+    pSpotLight->SetSpotAngles(innerAngle, outerAngle);
+    float retrievedInner = 0.0f, retrievedOuter = 0.0f;
+    pSpotLight->GetSpotAngles(&retrievedInner, &retrievedOuter);
+    EXPECT_EQ(innerAngle, retrievedInner);
+    EXPECT_EQ(outerAngle, retrievedOuter);
+
+    // Test Directional Light
+    Gem::TGemPtr<XLight> pDirectionalLight;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateLight(LightType::Directional, &pDirectionalLight)));
+    EXPECT_TRUE(pDirectionalLight->GetType() == LightType::Directional);
+
+    // Directional lights can still have color and intensity
+    FloatVector4 sunColor(1.0f, 0.95f, 0.8f, 1.0f);
+    pDirectionalLight->SetColor(sunColor);
+    pDirectionalLight->SetIntensity(1.5f);
+    EXPECT_TRUE(AlmostEqual(pDirectionalLight->GetColor(), sunColor));
+    EXPECT_EQ(1.5f, pDirectionalLight->GetIntensity());
+
+    // Test Ambient Light
+    Gem::TGemPtr<XLight> pAmbientLight;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateLight(LightType::Ambient, &pAmbientLight)));
+    EXPECT_TRUE(pAmbientLight->GetType() == LightType::Ambient);
+
+    // Ambient light should support color and intensity
+    FloatVector4 ambientColor(0.2f, 0.2f, 0.3f, 1.0f);
+    pAmbientLight->SetColor(ambientColor);
+    pAmbientLight->SetIntensity(0.5f);
+    EXPECT_TRUE(AlmostEqual(pAmbientLight->GetColor(), ambientColor));
+    EXPECT_EQ(0.5f, pAmbientLight->GetIntensity());
+}
+
+// ============================================================
+// XModel Tests
+// ============================================================
+TEST(CanvasInterfacesTest, ModelCreation)
+{
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+
+    // Create a model
+    Gem::TGemPtr<Canvas::XModel> pModel;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateModel(pDevice, &pModel, "TestModel")));
+    EXPECT_NE(pModel.Get(), nullptr);
+
+    // Model should have a root node
+    Canvas::XSceneGraphNode *pRoot = pModel->GetRootNode();
+    EXPECT_NE(pRoot, nullptr);
+
+    // Device should be accessible
+    EXPECT_TRUE(pModel->GetDevice() == pDevice.Get());
+
+    // Empty model should have no resources
+    EXPECT_EQ(0u, pModel->GetMeshDataCount());
+    EXPECT_EQ(0u, pModel->GetMaterialCount());
+    EXPECT_EQ(0u, pModel->GetTextureCount());
+
+    // Active camera node should be null initially
+    EXPECT_EQ(pModel->GetActiveCameraNode(), nullptr);
+}
+
+TEST(CanvasInterfacesTest, ModelResourceLibrary)
+{
+    using namespace Canvas::Math;
+
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+
+    Gem::TGemPtr<Canvas::XModel> pModel;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateModel(pDevice, &pModel, "ResourceModel")));
+
+    // Create a debug mesh and add it to the model
+    FloatVector4 positions[] = {
+        {0, 0, 0, 1}, {1, 0, 0, 1}, {0, 1, 0, 1}
     };
+    FloatVector4 normals[] = {
+        {0, 0, 1, 0}, {0, 0, 1, 0}, {0, 0, 1, 0}
+    };
+    Gem::TGemPtr<Canvas::XGfxMeshData> pMesh;
+    EXPECT_TRUE(Succeeded(pDevice->CreateDebugMeshData(3, positions, normals, &pMesh, "TriMesh")));
+
+    EXPECT_TRUE(Succeeded(pModel->AddMeshData(pMesh)));
+    EXPECT_EQ(1u, pModel->GetMeshDataCount());
+    EXPECT_TRUE(pModel->GetMeshData(0) == pMesh.Get());
+    EXPECT_EQ(pModel->GetMeshData(1), nullptr); // out of range
+
+    // Create and add a material
+    Gem::TGemPtr<Canvas::XGfxMaterial> pMaterial;
+    EXPECT_TRUE(Succeeded(pDevice->CreateMaterial(&pMaterial)));
+    EXPECT_TRUE(Succeeded(pModel->AddMaterial(pMaterial)));
+    EXPECT_EQ(1u, pModel->GetMaterialCount());
+    EXPECT_TRUE(pModel->GetMaterial(0) == pMaterial.Get());
+
+    // Null arguments should fail
+    EXPECT_TRUE(Gem::Failed(pModel->AddMeshData(nullptr)));
+    EXPECT_TRUE(Gem::Failed(pModel->AddMaterial(nullptr)));
+    EXPECT_TRUE(Gem::Failed(pModel->AddTexture(nullptr)));
+}
+
+TEST(CanvasInterfacesTest, ModelAuthoringAndInstantiation)
+{
+    using namespace Canvas::Math;
+
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+
+    // Build a model with a simple hierarchy:
+    // ModelRoot
+    //   - NodeA (mesh)
+    //   - NodeB
+    //       - NodeC (mesh)
+    Gem::TGemPtr<Canvas::XModel> pModel;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateModel(pDevice, &pModel, "TestModel")));
+
+    FloatVector4 positions[] = {
+        {0, 0, 0, 1}, {1, 0, 0, 1}, {0, 1, 0, 1}
+    };
+    FloatVector4 normals[] = {
+        {0, 0, 1, 0}, {0, 0, 1, 0}, {0, 0, 1, 0}
+    };
+    Gem::TGemPtr<Canvas::XGfxMeshData> pMesh;
+    EXPECT_TRUE(Succeeded(pDevice->CreateDebugMeshData(3, positions, normals, &pMesh, "SharedMesh")));
+    pModel->AddMeshData(pMesh);
+
+    Canvas::XSceneGraphNode *pModelRoot = pModel->GetRootNode();
+
+    // NodeA with mesh
+    Gem::TGemPtr<Canvas::XSceneGraphNode> pNodeA;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pNodeA, "NodeA")));
+    pNodeA->SetLocalTranslation(FloatVector4(1.0f, 0.0f, 0.0f, 1.0f));
+    Gem::TGemPtr<Canvas::XMeshInstance> pMeshA;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateMeshInstance(&pMeshA, "MeshA")));
+    pMeshA->SetMeshData(pMesh);
+    EXPECT_TRUE(Succeeded(pNodeA->BindElement(pMeshA)));
+    EXPECT_TRUE(Succeeded(pModelRoot->AddChild(pNodeA)));
+
+    // NodeB
+    Gem::TGemPtr<Canvas::XSceneGraphNode> pNodeB;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pNodeB, "NodeB")));
+    pNodeB->SetLocalTranslation(FloatVector4(0.0f, 2.0f, 0.0f, 1.0f));
+    EXPECT_TRUE(Succeeded(pModelRoot->AddChild(pNodeB)));
+
+    // NodeC under NodeB with mesh
+    Gem::TGemPtr<Canvas::XSceneGraphNode> pNodeC;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pNodeC, "NodeC")));
+    pNodeC->SetLocalTranslation(FloatVector4(0.0f, 0.0f, 3.0f, 1.0f));
+    Gem::TGemPtr<Canvas::XMeshInstance> pMeshC;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateMeshInstance(&pMeshC, "MeshC")));
+    pMeshC->SetMeshData(pMesh);
+    EXPECT_TRUE(Succeeded(pNodeC->BindElement(pMeshC)));
+    EXPECT_TRUE(Succeeded(pNodeB->AddChild(pNodeC)));
+
+    // Instantiate into a scene
+    Gem::TGemPtr<Canvas::XScene> pScene;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateScene(pDevice, &pScene, "TestScene")));
+
+    Canvas::ModelInstantiateResult result{};
+    EXPECT_TRUE(Succeeded(pModel->Instantiate(pScene->GetRootNode(), &result)));
+
+    // Verify instance root was created
+    EXPECT_NE(result.pInstanceRoot, nullptr);
+    EXPECT_EQ(result.pActiveCamera, nullptr); // no camera in model
+
+    // Instance root should be a child of scene root
+    Canvas::XSceneGraphNode *pSceneRoot = pScene->GetRootNode();
+    EXPECT_TRUE(pSceneRoot->GetFirstChild() == result.pInstanceRoot);
+
+    // Instance root should have 2 children (cloned NodeA and NodeB)
+    Canvas::XSceneGraphNode *pClonedA = result.pInstanceRoot->GetFirstChild();
+    EXPECT_NE(pClonedA, nullptr);
+    Canvas::XSceneGraphNode *pClonedB = result.pInstanceRoot->GetNextChild(pClonedA);
+    EXPECT_NE(pClonedB, nullptr);
+    EXPECT_EQ(result.pInstanceRoot->GetNextChild(pClonedB), nullptr); // no more children
+
+    // Verify transforms were copied
+    EXPECT_TRUE(AlmostEqual(pClonedA->GetLocalTranslation(), FloatVector4(1.0f, 0.0f, 0.0f, 1.0f)));
+    EXPECT_TRUE(AlmostEqual(pClonedB->GetLocalTranslation(), FloatVector4(0.0f, 2.0f, 0.0f, 1.0f)));
+
+    // ClonedB should have one child (cloned NodeC)
+    Canvas::XSceneGraphNode *pClonedC = pClonedB->GetFirstChild();
+    EXPECT_NE(pClonedC, nullptr);
+    EXPECT_TRUE(AlmostEqual(pClonedC->GetLocalTranslation(), FloatVector4(0.0f, 0.0f, 3.0f, 1.0f)));
+
+    // Verify mesh instances share the same GPU mesh data
+    EXPECT_EQ(1u, pClonedA->GetBoundElementCount());
+    Canvas::XSceneGraphElement *pClonedElemA = pClonedA->GetBoundElement(0);
+    Gem::TGemPtr<Canvas::XMeshInstance> pClonedMeshA;
+    EXPECT_TRUE(Succeeded(pClonedElemA->QueryInterface(&pClonedMeshA)));
+    EXPECT_TRUE(pClonedMeshA->GetMeshData() == pMesh.Get()); // shared GPU data
+
+    EXPECT_EQ(1u, pClonedC->GetBoundElementCount());
+    Canvas::XSceneGraphElement *pClonedElemC = pClonedC->GetBoundElement(0);
+    Gem::TGemPtr<Canvas::XMeshInstance> pClonedMeshC;
+    EXPECT_TRUE(Succeeded(pClonedElemC->QueryInterface(&pClonedMeshC)));
+    EXPECT_TRUE(pClonedMeshC->GetMeshData() == pMesh.Get()); // shared GPU data
+}
+
+TEST(CanvasInterfacesTest, ModelInstantiateTransformIndependence)
+{
+    using namespace Canvas::Math;
+
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+
+    Gem::TGemPtr<Canvas::XModel> pModel;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateModel(pDevice, &pModel, "TestModel")));
+
+    Gem::TGemPtr<Canvas::XSceneGraphNode> pNodeA;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pNodeA, "NodeA")));
+    pNodeA->SetLocalTranslation(FloatVector4(1.0f, 0.0f, 0.0f, 1.0f));
+    EXPECT_TRUE(Succeeded(pModel->GetRootNode()->AddChild(pNodeA)));
+
+    // Create scene and instantiate twice
+    Gem::TGemPtr<Canvas::XScene> pScene;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateScene(pDevice, &pScene, "TestScene")));
+
+    Canvas::ModelInstantiateResult result1{}, result2{};
+    EXPECT_TRUE(Succeeded(pModel->Instantiate(pScene->GetRootNode(), &result1)));
+    EXPECT_TRUE(Succeeded(pModel->Instantiate(pScene->GetRootNode(), &result2)));
+
+    // Both instances should exist independently
+    EXPECT_NE(result1.pInstanceRoot, nullptr);
+    EXPECT_NE(result2.pInstanceRoot, nullptr);
+    EXPECT_TRUE(result1.pInstanceRoot != result2.pInstanceRoot);
+
+    // Modify instance 1's child transform
+    Canvas::XSceneGraphNode *pCloned1A = result1.pInstanceRoot->GetFirstChild();
+    Canvas::XSceneGraphNode *pCloned2A = result2.pInstanceRoot->GetFirstChild();
+    EXPECT_NE(pCloned1A, nullptr);
+    EXPECT_NE(pCloned2A, nullptr);
+
+    pCloned1A->SetLocalTranslation(FloatVector4(99.0f, 0.0f, 0.0f, 1.0f));
+
+    // Instance 2 should be unaffected
+    EXPECT_TRUE(AlmostEqual(pCloned2A->GetLocalTranslation(), FloatVector4(1.0f, 0.0f, 0.0f, 1.0f)));
+}
+
+TEST(CanvasInterfacesTest, ModelActiveCameraInstantiation)
+{
+    using namespace Canvas::Math;
+
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+
+    Gem::TGemPtr<Canvas::XModel> pModel;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateModel(pDevice, &pModel, "CameraModel")));
+
+    // Add a camera node to the model
+    Gem::TGemPtr<Canvas::XSceneGraphNode> pCamNode;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pCamNode, "CamNode")));
+    pCamNode->SetLocalTranslation(FloatVector4(0.0f, -5.0f, 2.0f, 1.0f));
+
+    Gem::TGemPtr<Canvas::XCamera> pCamera;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateCamera(&pCamera, "ModelCamera")));
+    pCamera->SetFovAngle(1.2f);
+    pCamera->SetNearClip(0.5f);
+    pCamera->SetFarClip(500.0f);
+    EXPECT_TRUE(Succeeded(pCamNode->BindElement(pCamera)));
+    EXPECT_TRUE(Succeeded(pModel->GetRootNode()->AddChild(pCamNode)));
+
+    // Set as active camera node
+    pModel->SetActiveCameraNode(pCamNode);
+    EXPECT_TRUE(pModel->GetActiveCameraNode() == pCamNode.Get());
+
+    // Instantiate
+    Gem::TGemPtr<Canvas::XScene> pScene;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateScene(pDevice, &pScene, "TestScene")));
+
+    Canvas::ModelInstantiateResult result{};
+    EXPECT_TRUE(Succeeded(pModel->Instantiate(pScene->GetRootNode(), &result)));
+
+    // Active camera should be mapped in result
+    EXPECT_NE(result.pActiveCamera, nullptr);
+
+    // Camera properties should be cloned
+    EXPECT_EQ(1.2f, result.pActiveCamera->GetFovAngle());
+    EXPECT_EQ(0.5f, result.pActiveCamera->GetNearClip());
+    EXPECT_EQ(500.0f, result.pActiveCamera->GetFarClip());
+
+    // Camera should be attached to the cloned node, not the model's node
+    Canvas::XSceneGraphNode *pClonedCamNode = result.pActiveCamera->GetAttachedNode();
+    EXPECT_NE(pClonedCamNode, nullptr);
+    EXPECT_TRUE(pClonedCamNode != pCamNode.Get()); // different node instance
+    EXPECT_TRUE(AlmostEqual(pClonedCamNode->GetLocalTranslation(), FloatVector4(0.0f, -5.0f, 2.0f, 1.0f)));
+}
+
+TEST(CanvasInterfacesTest, ModelLightCloning)
+{
+    using namespace Canvas::Math;
+
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+
+    Gem::TGemPtr<Canvas::XModel> pModel;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateModel(pDevice, &pModel, "LightModel")));
+
+    // Add a light node
+    Gem::TGemPtr<Canvas::XSceneGraphNode> pLightNode;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pLightNode, "LightNode")));
+
+    Gem::TGemPtr<Canvas::XLight> pLight;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateLight(Canvas::LightType::Point, &pLight, "PointLight")));
+    pLight->SetColor(FloatVector4(1.0f, 0.5f, 0.0f, 1.0f));
+    pLight->SetIntensity(3.0f);
+    pLight->SetRange(50.0f);
+    EXPECT_TRUE(Succeeded(pLightNode->BindElement(pLight)));
+    EXPECT_TRUE(Succeeded(pModel->GetRootNode()->AddChild(pLightNode)));
+
+    // Instantiate
+    Gem::TGemPtr<Canvas::XScene> pScene;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateScene(pDevice, &pScene, "TestScene")));
+
+    Canvas::ModelInstantiateResult result{};
+    EXPECT_TRUE(Succeeded(pModel->Instantiate(pScene->GetRootNode(), &result)));
+
+    // Find cloned light
+    Canvas::XSceneGraphNode *pClonedLightNode = result.pInstanceRoot->GetFirstChild();
+    EXPECT_NE(pClonedLightNode, nullptr);
+    EXPECT_EQ(1u, pClonedLightNode->GetBoundElementCount());
+
+    Gem::TGemPtr<Canvas::XLight> pClonedLight;
+    EXPECT_TRUE(Succeeded(pClonedLightNode->GetBoundElement(0)->QueryInterface(&pClonedLight)));
+
+    EXPECT_TRUE(pClonedLight->GetType() == Canvas::LightType::Point);
+    EXPECT_TRUE(AlmostEqual(pClonedLight->GetColor(), FloatVector4(1.0f, 0.5f, 0.0f, 1.0f)));
+    EXPECT_EQ(3.0f, pClonedLight->GetIntensity());
+    EXPECT_EQ(50.0f, pClonedLight->GetRange());
+}
+
+TEST(CanvasInterfacesTest, ModelEmptyInstantiation)
+{
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+
+    // Create empty model (no child nodes)
+    Gem::TGemPtr<Canvas::XModel> pModel;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateModel(pDevice, &pModel, "EmptyModel")));
+
+    Gem::TGemPtr<Canvas::XScene> pScene;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateScene(pDevice, &pScene, "TestScene")));
+
+    Canvas::ModelInstantiateResult result{};
+    EXPECT_TRUE(Succeeded(pModel->Instantiate(pScene->GetRootNode(), &result)));
+
+    // Should still create a synthetic instance root
+    EXPECT_NE(result.pInstanceRoot, nullptr);
+    EXPECT_EQ(result.pActiveCamera, nullptr);
+
+    // Instance root should have no children
+    EXPECT_EQ(result.pInstanceRoot->GetFirstChild(), nullptr);
+}
+
+TEST(CanvasInterfacesTest, ModelInstantiateNullTargetFails)
+{
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<Canvas::XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+
+    Gem::TGemPtr<Canvas::XModel> pModel;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateModel(pDevice, &pModel, "TestModel")));
+
+    // Null target should fail
+    EXPECT_TRUE(Gem::Failed(pModel->Instantiate(nullptr)));
+}
+
 }
 

--- a/src/CanvasUnitTest/CanvasMathTest.cpp
+++ b/src/CanvasUnitTest/CanvasMathTest.cpp
@@ -1128,5 +1128,98 @@ namespace CanvasUnitTest
             Assert::IsTrue(std::abs(cY.X - 0.0f) < 1e-5f);
             Assert::IsTrue(std::abs(cY.Y - (-1.0f)) < 1e-5f);
         }
+
+        // ----------------------------------------------------------------
+        // Frustum extraction + AABB intersection tests.
+        //
+        // Camera view space: LHS, +X right, +Y up, +Z forward.  Tests use
+        // view = identity so the projection matrix alone defines the
+        // frustum, letting us reason about points/AABBs directly in view
+        // coordinates without an extra matrix layer to debug.
+        // ----------------------------------------------------------------
+
+        // Reverse-Z perspective is Canvas's default.  These tests pin the
+        // sign convention of FromViewProjection: points truly inside the
+        // view frustum must produce IntersectsAABB == true; points outside
+        // any single plane must produce false.
+        TEST_METHOD(FrustumReverseZPerspectiveInsideOutside)
+        {
+            const float fovY = float(g_PI * 0.5);  // 90 deg
+            const float aspect = 1.0f;
+            const float nearZ = 1.0f;
+            const float farZ  = 100.0f;
+            FloatMatrix4x4 proj = PerspectiveReverseZ<float>(fovY, aspect, nearZ, farZ);
+            Frustum f = Frustum::FromViewProjection(proj, /*reverseZ*/ true);
+
+            auto pointAABB = [](float x, float y, float z) {
+                FloatVector4 p(x, y, z, 0.0f);
+                return AABB(p, p);
+            };
+
+            // Squarely inside.
+            Assert::IsTrue(f.IntersectsAABB(pointAABB(0.0f, 0.0f, 10.0f)));
+
+            // Behind the near plane (z < nearZ): outside near.
+            Assert::IsFalse(f.IntersectsAABB(pointAABB(0.0f, 0.0f, 0.5f)));
+
+            // Behind the camera entirely.
+            Assert::IsFalse(f.IntersectsAABB(pointAABB(0.0f, 0.0f, -10.0f)));
+
+            // Beyond the far plane.
+            Assert::IsFalse(f.IntersectsAABB(pointAABB(0.0f, 0.0f, 200.0f)));
+
+            // Off to the right past the 90-deg side plane (x > z at z=10).
+            Assert::IsFalse(f.IntersectsAABB(pointAABB(50.0f, 0.0f, 10.0f)));
+
+            // Above the top plane (y > z at z=10 for 90deg fov).
+            Assert::IsFalse(f.IntersectsAABB(pointAABB(0.0f, 50.0f, 10.0f)));
+
+            // AABB straddling the near plane: must overlap.
+            AABB straddleNear(FloatVector4(-0.5f, -0.5f, 0.5f, 0.0f),
+                              FloatVector4( 0.5f,  0.5f, 2.0f, 0.0f));
+            Assert::IsTrue(f.IntersectsAABB(straddleNear));
+
+            // Large AABB enclosing the camera: positive-vertex test is
+            // conservative and accepts this (every plane has SOME corner
+            // on the inside).  Documents the known false-positive regime.
+            AABB enclosing(FloatVector4(-1000.0f, -1000.0f, -1000.0f, 0.0f),
+                           FloatVector4( 1000.0f,  1000.0f,  1000.0f, 0.0f));
+            Assert::IsTrue(f.IntersectsAABB(enclosing));
+
+            // Empty AABB: never intersects.
+            Assert::IsFalse(f.IntersectsAABB(AABB{}));
+        }
+
+        // Forward-Z swap: only Near/Far plane assignment differs.  Same
+        // points should yield the same inside/outside verdicts because
+        // both extractions describe the same world-space frustum.
+        TEST_METHOD(FrustumForwardZPerspectiveAgreesWithReverseZ)
+        {
+            const float fovY = float(g_PI * 0.5);
+            const float aspect = 16.0f / 9.0f;
+            const float nearZ = 0.5f;
+            const float farZ  = 50.0f;
+
+            Frustum fRev = Frustum::FromViewProjection(
+                PerspectiveReverseZ<float>(fovY, aspect, nearZ, farZ), true);
+            Frustum fFwd = Frustum::FromViewProjection(
+                PerspectiveForwardZ<float>(fovY, aspect, nearZ, farZ), false);
+
+            const FloatVector4 inside (0.0f, 0.0f, 10.0f, 0.0f);
+            const FloatVector4 tooNear(0.0f, 0.0f,  0.1f, 0.0f);
+            const FloatVector4 tooFar (0.0f, 0.0f, 99.0f, 0.0f);
+
+            AABB bIn (inside,  inside);
+            AABB bN  (tooNear, tooNear);
+            AABB bF  (tooFar,  tooFar);
+
+            Assert::AreEqual(fRev.IntersectsAABB(bIn), fFwd.IntersectsAABB(bIn));
+            Assert::AreEqual(fRev.IntersectsAABB(bN),  fFwd.IntersectsAABB(bN));
+            Assert::AreEqual(fRev.IntersectsAABB(bF),  fFwd.IntersectsAABB(bF));
+
+            Assert::IsTrue (fRev.IntersectsAABB(bIn));
+            Assert::IsFalse(fRev.IntersectsAABB(bN));
+            Assert::IsFalse(fRev.IntersectsAABB(bF));
+        }
 	};
 }

--- a/src/CanvasUnitTest/CanvasMathTest.cpp
+++ b/src/CanvasUnitTest/CanvasMathTest.cpp
@@ -1,8 +1,4 @@
 #include "pch.h"
-#include "CppUnitTest.h"
-
-using namespace Microsoft::VisualStudio::CppUnitTestFramework;
-
 using namespace Canvas;
 using namespace Canvas::Math;
 
@@ -12,1214 +8,1216 @@ namespace CanvasUnitTest
 
     const double g_PI = 3.1415926535897932384626433832795;
 
-	TEST_CLASS(CanvasMathTest)
-	{
-	public:
-		
-        bool AlmostZero(double n)
-        {
-            return n < DBL_EPSILON;
-        }
+namespace {
 
-        bool AlmostZero(float n)
-        {
-            return n < FLT_EPSILON;
-        }
+bool AlmostZero(double n)
+{
+    return n < DBL_EPSILON;
+}
 
-        template<class _Type, unsigned int _D>
-        bool AlmostEqual(const TVector<_Type, _D> &v0, const TVector<_Type, _D> &v1)
+bool AlmostZero(float n)
+{
+    return n < FLT_EPSILON;
+}
+
+template<class _Type, unsigned int _D>
+bool AlmostEqual(const TVector<_Type, _D> &v0, const TVector<_Type, _D> &v1)
+{
+    TVector<_Type, _D> delta = v1 - v0;
+    _Type lensq = DotProduct(delta, delta);
+    return AlmostZero(lensq);
+}
+
+template<class _Type>
+bool AlmostEqual(const TQuaternion<_Type> &q0, const TQuaternion<_Type> &q1)
+{
+    TQuaternion<_Type> delta = q1 - q0;
+    _Type lensq = DotProduct(delta, delta);
+    return AlmostZero(lensq);
+}
+
+template<class _Type, unsigned int _Rows, unsigned int _Columns>
+bool AlmostEqual(const TMatrix<_Type, _Rows, _Columns> &m0, const TMatrix<_Type, _Rows, _Columns> &m1)
+{
+    for (unsigned int row = 0; row < _Rows; ++row)
+    {
+        if (!AlmostEqual(m0.M[row], m1.M[row]))
         {
-            TVector<_Type, _D> delta = v1 - v0;
-            _Type lensq = DotProduct(delta, delta);
-            return AlmostZero(lensq);
+            return false;
         }
-        template<class _Type>
-        bool AlmostEqual(const TQuaternion<_Type> &q0, const TQuaternion<_Type> &q1)
+    }
+    return true;
+}
+
+__declspec(noinline) FloatVector4 Mul(const FloatVector4 &a, const FloatVector4 &b)
+{
+    return a * b;
+
+}
+
+} // anonymous namespace
+
+TEST(CanvasMathTest, SimpleVectors)
+{
+    TVector<int, 4> V0(1, 2, 3, 4);
+    TVector<int, 4> V1(5, 6, 1, 2);
+    EXPECT_EQ(V0.Dim, 4);
+    EXPECT_EQ(V1[0], 5);
+    EXPECT_EQ(V1[1], 6);
+    EXPECT_EQ(V1[2], 1);
+    EXPECT_EQ(V1[3], 2);
+    auto SubResult = V1 - V0;
+    EXPECT_TRUE((SubResult == TVector<int, 4>(4, 4, -2, -2)));
+    auto AddResult = V1 + V0;
+    EXPECT_TRUE((AddResult == TVector<int, 4>(6, 8, 4, 6)));
+    auto MulResult = V1 * V0;
+    EXPECT_TRUE((MulResult == TVector<int, 4>(5, 12, 3, 8)));
+    int Dot = DotProduct(SubResult, V0);
+    EXPECT_EQ(4 + 8 - 6 - 8, Dot);
+    TVector<int, 3> V2(3, 5, 7);
+    TVector<int, 3> V3(2, 11, 13);
+    auto Cross = CrossProduct(V2, V3);
+    EXPECT_TRUE((TVector<int, 3>(-12, -25, 23) == Cross));
+
+    TVector<int, 2> V4(11, 13);
+    EXPECT_EQ(V4[0], 11);
+    EXPECT_EQ(V4[1], 13);
+
+    TVector<int, 6> V5 = { 1, 1, 2, 3, 5, 8 };
+    TVector<int, 6> V8 = { 2, 2, 4, 6, 10, 16 };
+    auto V6 = 2 * V5;
+    auto V7 = V5 * 2;
+    EXPECT_TRUE(V8 == V7);
+    EXPECT_TRUE(V8 == V6);
+
+    FloatVector4 a(1 * g_mul, 2 * g_mul, 3 * g_mul, 4 * g_mul);
+    FloatVector4 b(.1f * g_mul, .2f * g_mul, .3f * g_mul, .4f * g_mul);
+    FloatVector4 c = Mul(a, b);
+    EXPECT_TRUE(AlmostEqual(c, FloatVector4(.1f, .4f, .9f, 1.6f)));
+}
+
+TEST(CanvasMathTest, SimpleMatrices)
+{
+    TMatrix<int, 3, 4> M0 = {
+        {1, 1, 2, 3},
+        {5, 8, 13, 21},
+        {34, 55, 89, 144}
+    };
+    EXPECT_EQ(M0.Columns, 4);
+    EXPECT_EQ(M0.Rows, 3);
+    TMatrix<int, 4, 4> M1 = {
+        {4, 7, 10, 13 },
+        {5, 8, 11, 14},
+        {6, 9, 12, 15},
+        {7, 10, 13, 16}
+    };
+
+    auto M2 = M0 * M1;
+
+    TMatrix<int, 3, 4> MMulResult = {
+        { 42, 63, 84, 105 },
+        { 285, 426, 567, 708 },
+        { 1953, 2919, 3885, 4851 }
+    };
+
+    EXPECT_TRUE(MMulResult == M2);
+
+    auto T = MatrixTransposeRows(M1);
+    EXPECT_TRUE((T == TMatrix<int, 4, 4>(
+        {4, 5, 6, 7 },
+        {7, 8, 9, 10},
+        {10, 11, 12, 13},
+        {13, 14, 15, 16}
+    )));
+
+    T = MatrixTransposeRows(M1, 2, 2, 1);
+    EXPECT_TRUE((T == TMatrix<int, 4, 4>(
+        {4, 7, 10, 13 },
+        {5, 8, 11, 14},
+        {6, 9, 10, 15},
+        {7, 12, 13, 16}
+    )));
+}
+
+TEST(CanvasMathTest, Normalize)
+{
+    TVector<float, 3> fv[] =
+    {
+        { 1.0f, 0.0f, 0.0f },
+        { 1.0f, 1.0f, 1.0f },
+        { 1.0f, 2.0f, 3.0f }
+    };
+
+    for (unsigned int i = 0; i < _countof(fv); ++i)
+    {
+        auto nv = fv[i].Normalize();
+
+        // Verify the magnitude is nearly 1.0f
+        float magsq = DotProduct(nv, nv);
+        float diff = std::abs(magsq - 1.0f);
+        EXPECT_TRUE(diff < 0.000001f);
+    }
+
+    TVector<double, 4> dv[] =
+    {
+        { 0.0, 1.0, 0.0, 0.0 },
+        { 1.0, 1.0, 1.0, 1.0 },
+        { 0.0, 1.0, 2.0, 3.0 }
+    };
+
+    for (unsigned int i = 0; i < _countof(dv); ++i)
+    {
+        auto nv = dv[i].Normalize();
+
+        // Verify the magnitude is nearly 1.0f
+        double magsq = DotProduct(nv, nv);
+        double diff = std::abs(magsq - 1.0);
+        EXPECT_TRUE(diff < 0.000001);
+    }
+}
+
+TEST(CanvasMathTest, MatrixRotation)
+{
+    using MatrixType = FloatMatrix4x4;
+    using VecType = MatrixType::RowType;
+    using ElementType = MatrixType::ElementType;
+    static const auto Rows = MatrixType::Rows;
+    static const auto Columns = MatrixType::Columns;
+
+    MatrixType rx = XRotationMatrix<ElementType>(float(g_PI) / 2);
+    EXPECT_TRUE(AlmostEqual(rx[0], VecType(1, 0, 0, 0)));
+    EXPECT_TRUE(AlmostEqual(rx[1], VecType(0, 0, -1, 0)));
+    EXPECT_TRUE(AlmostEqual(rx[2], VecType(0, 1, 0, 0)));
+
+    rx = XRotationMatrix<ElementType>(-float(g_PI) / 2);
+    EXPECT_TRUE(AlmostEqual(rx[0], VecType(1, 0, 0, 0)));
+    EXPECT_TRUE(AlmostEqual(rx[1], VecType(0, 0, 1, 0)));
+    EXPECT_TRUE(AlmostEqual(rx[2], VecType(0, -1, 0, 0)));
+
+    MatrixType ry = YRotationMatrix<ElementType>(float(g_PI) / 2);
+    EXPECT_TRUE(AlmostEqual(ry[0], VecType(0, 0, 1, 0)));
+    EXPECT_TRUE(AlmostEqual(ry[1], VecType(0, 1, 0, 0)));
+    EXPECT_TRUE(AlmostEqual(ry[2], VecType(-1, 0, 0, 0)));
+    EXPECT_TRUE(AlmostEqual(ry[3], VecType(0, 0, 0, 1)));
+
+    ry = YRotationMatrix<ElementType>(-float(g_PI) / 2);
+    EXPECT_TRUE(AlmostEqual(ry[0], VecType(0, 0, -1, 0)));
+    EXPECT_TRUE(AlmostEqual(ry[1], VecType(0, 1, 0, 0)));
+    EXPECT_TRUE(AlmostEqual(ry[2], VecType(1, 0, 0, 0)));
+    EXPECT_TRUE(AlmostEqual(ry[3], VecType(0, 0, 0, 1)));
+
+    MatrixType rz = ZRotationMatrix<ElementType>(float(g_PI) / 2);
+    EXPECT_TRUE(AlmostEqual(rz[0], VecType(0, -1, 0, 0)));
+    EXPECT_TRUE(AlmostEqual(rz[1], VecType(1, 0, 0, 0)));
+    EXPECT_TRUE(AlmostEqual(rz[2], VecType(0, 0, 1, 0)));
+    EXPECT_TRUE(AlmostEqual(ry[3], VecType(0, 0, 0, 1)));
+
+    rz = ZRotationMatrix<ElementType>(-float(g_PI) / 2);
+    EXPECT_TRUE(AlmostEqual(rz[0], VecType(0, 1, 0, 0)));
+    EXPECT_TRUE(AlmostEqual(rz[1], VecType(-1, 0, 0, 0)));
+    EXPECT_TRUE(AlmostEqual(rz[2], VecType(0, 0, 1, 0)));
+    EXPECT_TRUE(AlmostEqual(ry[3], VecType(0, 0, 0, 1)));
+}
+
+TEST(CanvasMathTest, LookAt)
+{
+    // ComposePointToBasisVectors is a general utility that works with any coordinate system.
+    // It computes: basisSideVector = WorldUp × ForwardVector, basisUpVector = ForwardVector × basisSideVector
+    // This test verifies the math works correctly regardless of camera conventions.
+
+    auto WorldUp = FloatVector3(0, 0, 1); // World-up is the world Z-axis
+    FloatMatrix3x3 M;
+
+    // Test case 1: Forward vector pointing in -Y direction
+    auto forward1 = FloatVector3(0, -1, 0);
+    ComposePointToBasisVectors(WorldUp, forward1, M[0], M[1]);
+    M[2] = forward1;
+
+    // Expected:
+    // side = WorldUp × forward = (0,0,1) × (0,-1,0) = (1,0,0)
+    // up = forward × side = (0,-1,0) × (1,0,0) = (0,0,1)
+    EXPECT_TRUE(AlmostEqual(M, FloatMatrix3x3(
         {
-            TQuaternion<_Type> delta = q1 - q0;
-            _Type lensq = DotProduct(delta, delta);
-            return AlmostZero(lensq);
+            {1, 0, 0},     // side
+            {0, 0, 1},     // up  
+            {0, -1, 0},    // forward
         }
-        template<class _Type, unsigned int _Rows, unsigned int _Columns>
-        bool AlmostEqual(const TMatrix<_Type, _Rows, _Columns> &m0, const TMatrix<_Type, _Rows, _Columns> &m1)
+    )));
+
+    // Degenerate case 1: Forward vector aligned with world-up
+    auto forward2 = FloatVector3(0, 0, 1);
+    ComposePointToBasisVectors(WorldUp, forward2, M[0], M[1]);
+    M[2] = forward2;
+
+    // When forward is parallel to WorldUp, function picks an arbitrary perpendicular side vector
+    EXPECT_TRUE(AlmostEqual(M, FloatMatrix3x3(
         {
-            for (unsigned int row = 0; row < _Rows; ++row)
+            {1, 0, 0},     // side (arbitrary perpendicular)
+            {0, 1, 0},     // up (perpendicular to forward and side)
+            {0, 0, 1},     // forward
+        }
+    )));
+
+    // Degenerate case 2: Forward vector anti-parallel to world-up
+    auto forward3 = FloatVector3(0, 0, -1);
+    ComposePointToBasisVectors(WorldUp, forward3, M[0], M[1]);
+    M[2] = forward3;
+
+    // When forward is anti-parallel to WorldUp, function picks an arbitrary perpendicular side vector (flipped)
+    // side = (-1, 0, 0) from function's formula: (-localUp[2], localUp[0], -localUp[1])
+    // up = forward × side = (0,0,-1) × (-1,0,0) = (0, 1, 0)
+    EXPECT_TRUE(AlmostEqual(M, FloatMatrix3x3(
+        {
+            {-1, 0, 0},    // side (arbitrary perpendicular, negative)
+            {0, 1, 0},     // up (perpendicular to forward and side)
+            {0, 0, -1},    // forward
+        }
+    )));
+}
+
+TEST(CanvasMathTest, LookAtArbitraryBasis)
+{
+    // Test ComposeArbitraryPointToBasisVectors which automatically selects
+    // a reference up vector based on the forward vector
+    FloatVector3 side, up;
+
+    // Test case 1: Forward pointing in +X direction
+    // Should choose Y or Z as reference (whichever is less aligned)
+    auto forward1 = FloatVector3(1, 0, 0);
+    ComposeArbitraryPointToBasisVectors(forward1, side, up);
+
+    // Verify orthonormality
+    EXPECT_TRUE(AlmostZero(DotProduct(forward1, side)));
+    EXPECT_TRUE(AlmostZero(DotProduct(forward1, up)));
+    EXPECT_TRUE(AlmostZero(DotProduct(side, up)));
+    float len1 = DotProduct(forward1, forward1);
+    EXPECT_TRUE(AlmostZero(len1 - 1.0f));
+    float lenSide1 = DotProduct(side, side);
+    EXPECT_TRUE(AlmostZero(lenSide1 - 1.0f));
+    float lenUp1 = DotProduct(up, up);
+    EXPECT_TRUE(AlmostZero(lenUp1 - 1.0f));
+
+    // Verify right-handedness: forward × side = up
+    auto computedUp = CrossProduct(forward1, side);
+    EXPECT_TRUE(AlmostEqual(computedUp, up));
+
+    // Test case 2: Forward pointing in +Y direction
+    auto forward2 = FloatVector3(0, 1, 0);
+    ComposeArbitraryPointToBasisVectors(forward2, side, up);
+
+    EXPECT_TRUE(AlmostZero(DotProduct(forward2, side)));
+    EXPECT_TRUE(AlmostZero(DotProduct(forward2, up)));
+    EXPECT_TRUE(AlmostZero(DotProduct(side, up)));
+    float lenSide2 = DotProduct(side, side);
+    EXPECT_TRUE(AlmostZero(lenSide2 - 1.0f));
+    float lenUp2 = DotProduct(up, up);
+    EXPECT_TRUE(AlmostZero(lenUp2 - 1.0f));
+    computedUp = CrossProduct(forward2, side);
+    EXPECT_TRUE(AlmostEqual(computedUp, up));
+
+    // Test case 3: Forward pointing in +Z direction
+    auto forward3 = FloatVector3(0, 0, 1);
+    ComposeArbitraryPointToBasisVectors(forward3, side, up);
+
+    EXPECT_TRUE(AlmostZero(DotProduct(forward3, side)));
+    EXPECT_TRUE(AlmostZero(DotProduct(forward3, up)));
+    EXPECT_TRUE(AlmostZero(DotProduct(side, up)));
+    float lenSide3 = DotProduct(side, side);
+    EXPECT_TRUE(AlmostZero(lenSide3 - 1.0f));
+    float lenUp3 = DotProduct(up, up);
+    EXPECT_TRUE(AlmostZero(lenUp3 - 1.0f));
+    computedUp = CrossProduct(forward3, side);
+    EXPECT_TRUE(AlmostEqual(computedUp, up));
+
+    // Test case 4: Forward pointing in -X direction
+    auto forward4 = FloatVector3(-1, 0, 0);
+    ComposeArbitraryPointToBasisVectors(forward4, side, up);
+
+    EXPECT_TRUE(AlmostZero(DotProduct(forward4, side)));
+    EXPECT_TRUE(AlmostZero(DotProduct(forward4, up)));
+    EXPECT_TRUE(AlmostZero(DotProduct(side, up)));
+    float lenSide4 = DotProduct(side, side);
+    EXPECT_TRUE(AlmostZero(lenSide4 - 1.0f));
+    float lenUp4 = DotProduct(up, up);
+    EXPECT_TRUE(AlmostZero(lenUp4 - 1.0f));
+    computedUp = CrossProduct(forward4, side);
+    EXPECT_TRUE(AlmostEqual(computedUp, up));
+
+    // Test case 5: Arbitrary diagonal direction
+    auto forward5 = FloatVector3(1, 1, 1).Normalize();
+    ComposeArbitraryPointToBasisVectors(forward5, side, up);
+
+    EXPECT_TRUE(AlmostZero(DotProduct(forward5, side)));
+    EXPECT_TRUE(AlmostZero(DotProduct(forward5, up)));
+    EXPECT_TRUE(AlmostZero(DotProduct(side, up)));
+    float lenSide5 = DotProduct(side, side);
+    EXPECT_TRUE(AlmostZero(lenSide5 - 1.0f));
+    float lenUp5 = DotProduct(up, up);
+    EXPECT_TRUE(AlmostZero(lenUp5 - 1.0f));
+    computedUp = CrossProduct(forward5, side);
+    EXPECT_TRUE(AlmostEqual(computedUp, up));
+
+    // Test case 6: Another arbitrary direction
+    auto forward6 = FloatVector3(0.6f, -0.8f, 0).Normalize();
+    ComposeArbitraryPointToBasisVectors(forward6, side, up);
+
+    EXPECT_TRUE(AlmostZero(DotProduct(forward6, side)));
+    EXPECT_TRUE(AlmostZero(DotProduct(forward6, up)));
+    EXPECT_TRUE(AlmostZero(DotProduct(side, up)));
+    float lenSide6 = DotProduct(side, side);
+    EXPECT_TRUE(AlmostZero(lenSide6 - 1.0f));
+    float lenUp6 = DotProduct(up, up);
+    EXPECT_TRUE(AlmostZero(lenUp6 - 1.0f));
+    computedUp = CrossProduct(forward6, side);
+    EXPECT_TRUE(AlmostEqual(computedUp, up));
+
+    // Test case 7: Near-axis aligned (stress test)
+    auto forward7 = FloatVector3(0.0001f, 0.9999f, 0).Normalize();
+    ComposeArbitraryPointToBasisVectors(forward7, side, up);
+
+    EXPECT_TRUE(AlmostZero(DotProduct(forward7, side)));
+    EXPECT_TRUE(AlmostZero(DotProduct(forward7, up)));
+    EXPECT_TRUE(AlmostZero(DotProduct(side, up)));
+    float lenSide7 = DotProduct(side, side);
+    EXPECT_TRUE(AlmostZero(lenSide7 - 1.0f));
+    float lenUp7 = DotProduct(up, up);
+    EXPECT_TRUE(AlmostZero(lenUp7 - 1.0f));
+    computedUp = CrossProduct(forward7, side);
+    EXPECT_TRUE(AlmostEqual(computedUp, up));
+}
+
+TEST(CanvasMathTest, BasicQuaternion)
+{
+    auto Q = IdentityQuaternion<double>();
+    EXPECT_TRUE(Q == DoubleQuaternion(0, 0, 0, 1));
+    auto M = IdentityMatrix<double, 4, 4>();
+    auto N = QuaternionToRotationMatrix(Q);
+    EXPECT_TRUE(AlmostEqual(M, N));
+
+    auto R = QuaternionFromAngleAxis(DoubleVector4(1, 0, 0, 0));
+    EXPECT_TRUE(AlmostEqual(Q, R));
+
+    M = TMatrix<double, 4, 4>(
+        {
+            { -1,  0,  0, 0 },
+            {  0, -1,  0, 0 },
+            {  0,  0,  1, 0 },
+            {  0,  0,  0, 1 }
+        }
+    );
+
+    R = QuaternionFromRotationMatrix(M);
+    N = QuaternionToRotationMatrix(R);
+    EXPECT_TRUE(AlmostEqual(M, N));
+
+    for (int i = 0; i < 16; i++)
+    {
+        for (int j = 0; j < 16; j++)
+        {
+            for (int k = 1; k < 16; k++)
             {
-                if (!AlmostEqual(m0.M[row], m1.M[row]))
+                double rotx = i * g_PI / 16.;
+                double roty = j * g_PI / 16.;
+                double rotz = k * g_PI / 16.;
+                M = XRotationMatrix<double>(rotx) * YRotationMatrix<double>(roty) * ZRotationMatrix<double>(rotz);
+                R = QuaternionFromRotationMatrix(M);
+                N = QuaternionToRotationMatrix(R);
+
+                // Verify round-trip conversion from matrix->quaternion->matrix produces the original matrix
+                EXPECT_TRUE(AlmostEqual(M, N));
+
+                // Transform a set of vertices by matrix and by quaternion and verify 
+                // the rotated results match
+
+                TVector<double, 4> Vectors[] =
                 {
-                    return false;
+                    {1., 0., 0., 0},
+                    {-5., 7, 13., 0},
+                    {6, -2, 11, 0},
+                    {6, 22, -11, 0},
+                    {.5, .2, 0., 0},
+                };
+
+                // Transform each vector by matrix and by quaternion
+                // and verify the results match
+                for (auto &V : Vectors)
+                {
+                    // Matrix transform
+                    auto VByM = M * V;
+
+                    auto InvR = Conjugate(R);
+                    auto Ident = R * InvR;
+                    EXPECT_TRUE(AlmostEqual(Ident, DoubleQuaternion(0, 0, 0, 1)));
+
+                    // Quaternion transform - convert vector to quaternion with w=0
+                    DoubleQuaternion VQuat(V.X, V.Y, V.Z, 0);
+                    auto VByQ = R * VQuat * InvR;
+
+                    EXPECT_TRUE(AlmostEqual(VByM, VByQ));
                 }
             }
-            return true;
         }
+    }
+}
+
+TEST(CanvasMathTest, VectorUnaryMinus)
+{
+    IntVector3 v1(1, -2, 3);
+    IntVector3 v2 = -v1;
+    EXPECT_TRUE(v2 == IntVector3(-1, 2, -3));
+
+    FloatVector4 v3(1.5f, -2.5f, 3.5f, -4.5f);
+    FloatVector4 v4 = -v3;
+    EXPECT_TRUE(AlmostEqual(v4, FloatVector4(-1.5f, 2.5f, -3.5f, 4.5f)));
+}
+
+TEST(CanvasMathTest, VectorInequalityAndDivision)
+{
+    IntVector3 v1(1, 2, 3);
+    IntVector3 v2(1, 2, 3);
+    IntVector3 v3(1, 2, 4);
+
+    EXPECT_FALSE(v1 != v2);
+    EXPECT_TRUE(v1 != v3);
+
+    FloatVector4 v4(10.0f, 20.0f, 30.0f, 40.0f);
+    FloatVector4 v5(2.0f, 4.0f, 5.0f, 8.0f);
+    auto v6 = v4 / v5;
+    EXPECT_TRUE(AlmostEqual(v6, FloatVector4(5.0f, 5.0f, 6.0f, 5.0f)));
+}
+
+TEST(CanvasMathTest, VectorSumTest)
+{
+    IntVector4 v1(1, 2, 3, 4);
+    int sum = VectorSum(v1);
+    EXPECT_EQ(10, sum);
+
+    FloatVector3 v2(1.5f, 2.5f, 3.0f);
+    float fsum = VectorSum(v2);
+    EXPECT_TRUE(AlmostZero(fsum - 7.0f));
+}
+
+TEST(CanvasMathTest, MatrixScalarMultiplication)
+{
+    FloatMatrix3x3 m1({
+        {1.0f, 2.0f, 3.0f},
+        {4.0f, 5.0f, 6.0f},
+        {7.0f, 8.0f, 9.0f}
+    });
+
+    auto m2 = m1 * 2.0f;
+    auto m3 = 2.0f * m1;
+
+    FloatMatrix3x3 expected({
+        {2.0f, 4.0f, 6.0f},
+        {8.0f, 10.0f, 12.0f},
+        {14.0f, 16.0f, 18.0f}
+    });
+
+    EXPECT_TRUE(AlmostEqual(m2, expected));
+    EXPECT_TRUE(AlmostEqual(m3, expected));
+}
+
+TEST(CanvasMathTest, AllRotationMatrixOrders)
+{
+    float angleX = float(g_PI) / 6.0f;  // 30 degrees
+    float angleY = float(g_PI) / 4.0f;  // 45 degrees
+    float angleZ = float(g_PI) / 3.0f;  // 60 degrees
+
+    // Test XYZRotationMatrix
+    auto mXYZ = XYZRotationMatrix(angleX, angleY, angleZ);
+    auto mXYZ_manual = ZRotationMatrix(angleZ) * YRotationMatrix(angleY) * XRotationMatrix(angleX);
+    EXPECT_TRUE(AlmostEqual(mXYZ, mXYZ_manual));
+
+    // Test XZYRotationMatrix
+    auto mXZY = XZYRotationMatrix(angleX, angleZ, angleY);
+    auto mXZY_manual = YRotationMatrix(angleY) * ZRotationMatrix(angleZ) * XRotationMatrix(angleX);
+    EXPECT_TRUE(AlmostEqual(mXZY, mXZY_manual));
+
+    // Test YXZRotationMatrix
+    auto mYXZ = YXZRotationMatrix(angleY, angleX, angleZ);
+    auto mYXZ_manual = ZRotationMatrix(angleZ) * XRotationMatrix(angleX) * YRotationMatrix(angleY);
+    EXPECT_TRUE(AlmostEqual(mYXZ, mYXZ_manual));
+
+    // Test YZXRotationMatrix
+    auto mYZX = YZXRotationMatrix(angleY, angleZ, angleX);
+    auto mYZX_manual = XRotationMatrix(angleX) * ZRotationMatrix(angleZ) * YRotationMatrix(angleY);
+    EXPECT_TRUE(AlmostEqual(mYZX, mYZX_manual));
+
+    // Test ZXYRotationMatrix
+    auto mZXY = ZXYRotationMatrix(angleZ, angleX, angleY);
+    auto mZXY_manual = YRotationMatrix(angleY) * XRotationMatrix(angleX) * ZRotationMatrix(angleZ);
+    EXPECT_TRUE(AlmostEqual(mZXY, mZXY_manual));
+
+    // Test ZYXRotationMatrix
+    auto mZYX = ZYXRotationMatrix(angleZ, angleY, angleX);
+    auto mZYX_manual = XRotationMatrix(angleX) * YRotationMatrix(angleY) * ZRotationMatrix(angleZ);
+    EXPECT_TRUE(AlmostEqual(mZYX, mZYX_manual));
+}
+
+TEST(CanvasMathTest, QuaternionFromEulerAngles)
+{
+    float angleX = float(g_PI) / 6.0f;
+    float angleY = float(g_PI) / 4.0f;
+    float angleZ = float(g_PI) / 3.0f;
+
+    // Test FromEulerXYZ
+    auto qXYZ = FloatQuaternion::FromEulerXYZ(angleX, angleY, angleZ);
+    auto mXYZ = XYZRotationMatrix(angleX, angleY, angleZ);
+    auto mFromQuat = QuaternionToRotationMatrix(qXYZ);
+    EXPECT_TRUE(AlmostEqual(mXYZ, mFromQuat));
+
+    // Test FromEulerXZY
+    auto qXZY = FloatQuaternion::FromEulerXZY(angleX, angleZ, angleY);
+    auto mXZY = XZYRotationMatrix(angleX, angleZ, angleY);
+    mFromQuat = QuaternionToRotationMatrix(qXZY);
+    EXPECT_TRUE(AlmostEqual(mXZY, mFromQuat));
+
+    // Test FromEulerYXZ
+    auto qYXZ = FloatQuaternion::FromEulerYXZ(angleY, angleX, angleZ);
+    auto mYXZ = YXZRotationMatrix(angleY, angleX, angleZ);
+    mFromQuat = QuaternionToRotationMatrix(qYXZ);
+    EXPECT_TRUE(AlmostEqual(mYXZ, mFromQuat));
+
+    // Test FromEulerYZX
+    auto qYZX = FloatQuaternion::FromEulerYZX(angleY, angleZ, angleX);
+    auto mYZX = YZXRotationMatrix(angleY, angleZ, angleX);
+    mFromQuat = QuaternionToRotationMatrix(qYZX);
+    EXPECT_TRUE(AlmostEqual(mYZX, mFromQuat));
+
+    // Test FromEulerZXY
+    auto qZXY = FloatQuaternion::FromEulerZXY(angleZ, angleX, angleY);
+    auto mZXY = ZXYRotationMatrix(angleZ, angleX, angleY);
+    mFromQuat = QuaternionToRotationMatrix(qZXY);
+    EXPECT_TRUE(AlmostEqual(mZXY, mFromQuat));
+
+    // Test FromEulerZYX
+    auto qZYX = FloatQuaternion::FromEulerZYX(angleZ, angleY, angleX);
+    auto mZYX = ZYXRotationMatrix(angleZ, angleY, angleX);
+    mFromQuat = QuaternionToRotationMatrix(qZYX);
+    EXPECT_TRUE(AlmostEqual(mZYX, mFromQuat));
+}
+
+TEST(CanvasMathTest, QuaternionScaledAxisAngle)
+{
+    // Test round-trip conversion
+    FloatVector3 axis1(1.0f, 0.0f, 0.0f);
+    float angle1 = float(g_PI) / 4.0f;
+    FloatVector3 scaledAxis1(axis1.X * angle1, axis1.Y * angle1, axis1.Z * angle1);
+
+    auto q1 = FloatQuaternion::FromScaledAxisAngle(scaledAxis1);
+    auto result1 = q1.ToScaledAxisAngle();
+    EXPECT_TRUE(AlmostEqual(scaledAxis1, result1));
+
+    // Test with arbitrary axis
+    FloatVector3 axis2(1.0f, 2.0f, 3.0f);
+    float angle2 = float(g_PI) / 3.0f;
+    float len = std::sqrt(axis2.X * axis2.X + axis2.Y * axis2.Y + axis2.Z * axis2.Z);
+    axis2 = axis2 * (1.0f / len); // normalize
+    FloatVector3 scaledAxis2(axis2.X * angle2, axis2.Y * angle2, axis2.Z * angle2);
+
+    auto q2 = FloatQuaternion::FromScaledAxisAngle(scaledAxis2);
+    auto result2 = q2.ToScaledAxisAngle();
+    EXPECT_TRUE(AlmostEqual(scaledAxis2, result2));
+
+    // Test zero rotation
+    FloatVector3 scaledAxis3(0.0f, 0.0f, 0.0f);
+    auto q3 = FloatQuaternion::FromScaledAxisAngle(scaledAxis3);
+    EXPECT_TRUE(AlmostEqual(q3, IdentityQuaternion<float>()));
+}
+
+TEST(CanvasMathTest, QuaternionMultiplication)
+{
+    // Test that quaternion multiplication follows the expected composition
+    float angle1 = float(g_PI) / 4.0f;
+    float angle2 = float(g_PI) / 3.0f;
+
+    auto qX = FloatQuaternion::FromEulerXYZ(angle1, 0.0f, 0.0f);
+    auto qY = FloatQuaternion::FromEulerXYZ(0.0f, angle2, 0.0f);
+
+    // Quaternion multiplication
+    auto qResult = qY * qX;
+
+    // Equivalent matrix multiplication
+    auto mX = XRotationMatrix(angle1);
+    auto mY = YRotationMatrix(angle2);
+    auto mResult = mY * mX;
+
+    // Convert quaternion result to matrix
+    auto mFromQuat = QuaternionToRotationMatrix(qResult);
+
+    EXPECT_TRUE(AlmostEqual(mResult, mFromQuat));
+
+    // Test identity property
+    auto qIdentity = IdentityQuaternion<float>();
+    auto qTest = FloatQuaternion::FromEulerXYZ(0.1f, 0.2f, 0.3f);
+    auto qResult1 = qIdentity * qTest;
+    auto qResult2 = qTest * qIdentity;
+    EXPECT_TRUE(AlmostEqual(qTest, qResult1));
+    EXPECT_TRUE(AlmostEqual(qTest, qResult2));
+}
+
+TEST(CanvasMathTest, QuaternionRotateVector)
+{
+    // Create a 90-degree rotation about the Z-axis
+    float angle = float(g_PI) / 2.0f;
+    auto qZ = FloatQuaternion::FromEulerXYZ(0.0f, 0.0f, angle);
+
+    // Rotate a vector using quaternion multiplication: q * v * q*
+    FloatVector4 v1(1.0f, 0.0f, 0.0f, 0.0f);
+    FloatQuaternion vQuat1(v1.X, v1.Y, v1.Z, 0.0f);
+    auto qConj = Conjugate(qZ);
+    auto rotated = qZ * vQuat1 * qConj;
+
+    // Should point along Y-axis
+    EXPECT_TRUE(AlmostEqual(rotated, FloatVector4(0.0f, 1.0f, 0.0f, 0.0f)));
+
+    // Test 90-degree rotation about X-axis
+    auto qX = FloatQuaternion::FromEulerXYZ(angle, 0.0f, 0.0f);
+    FloatVector4 v2(0.0f, 1.0f, 0.0f, 0.0f);
+    FloatQuaternion vQuat2(v2.X, v2.Y, v2.Z, 0.0f);
+    auto qConjX = Conjugate(qX);
+    auto rotated2 = qX * vQuat2 * qConjX;
+
+    // Should point along Z-axis
+    EXPECT_TRUE(AlmostEqual(rotated2, FloatVector4(0.0f, 0.0f, 1.0f, 0.0f)));
+}
+
+TEST(CanvasMathTest, CrossProductFloatVector4)
+{
+    // Test the specialized FloatVector4 cross product
+    FloatVector4 a(1.0f, 0.0f, 0.0f, 0.0f);
+    FloatVector4 b(0.0f, 1.0f, 0.0f, 0.0f);
+
+    auto c = CrossProduct(a, b);
+    EXPECT_TRUE(AlmostEqual(c, FloatVector4(0.0f, 0.0f, 1.0f, 0.0f)));
+
+    // Test arbitrary vectors
+    FloatVector4 v1(2.0f, 3.0f, 4.0f, 0.0f);
+    FloatVector4 v2(5.0f, 6.0f, 7.0f, 0.0f);
+    auto v3 = CrossProduct(v1, v2);
+
+    // Cross product formula: (a.y*b.z - a.z*b.y, a.z*b.x - a.x*b.z, a.x*b.y - a.y*b.x)
+    FloatVector4 expected(3.0f*7.0f - 4.0f*6.0f, 4.0f*5.0f - 2.0f*7.0f, 2.0f*6.0f - 3.0f*5.0f, 0.0f);
+    EXPECT_TRUE(AlmostEqual(v3, expected));
+}
+
+TEST(CanvasMathTest, AABBTests)
+{
+    // Default-constructed AABB is the canonical empty (FLT_MAX
+    // inside-out sentinel) used as the aggregation starting point.
+    AABB box1;
+    EXPECT_TRUE(box1.IsEmpty());
+    EXPECT_TRUE(box1.IsValid());   // empty is intentional, not malformed
+
+    // A constructor with explicit min<=max produces a non-empty,
+    // valid box.
+    AABB box2(FloatVector4(0.0f, 0.0f, 0.0f, 0.0f), FloatVector4(1.0f, 1.0f, 1.0f, 0.0f));
+    EXPECT_FALSE(box2.IsEmpty());
+    EXPECT_TRUE(box2.IsValid());
+
+    // Test center and extents
+    auto center = box2.GetCenter();
+    auto extents = box2.GetExtents();
+    EXPECT_TRUE(AlmostEqual(center, FloatVector4(0.5f, 0.5f, 0.5f, 0.0f)));
+    EXPECT_TRUE(AlmostEqual(extents, FloatVector4(0.5f, 0.5f, 0.5f, 0.0f)));
+
+    // Single-point ExpandToInclude on an empty AABB collapses to a
+    // degenerate (zero-volume) AABB at that point -- non-empty,
+    // and well-formed because min == max.
+    AABB box3;
+    box3.ExpandToInclude(FloatVector4(1.0f, 2.0f, 3.0f, 0.0f));
+    EXPECT_FALSE(box3.IsEmpty());
+    EXPECT_TRUE(box3.IsValid());
+    EXPECT_TRUE(AlmostEqual(box3.Min, FloatVector4(1.0f, 2.0f, 3.0f, 0.0f)));
+    EXPECT_TRUE(AlmostEqual(box3.Max, FloatVector4(1.0f, 2.0f, 3.0f, 0.0f)));
+    box3.ExpandToInclude(FloatVector4(4.0f, 5.0f, 6.0f, 0.0f));
+    EXPECT_TRUE(AlmostEqual(box3.Min, FloatVector4(1.0f, 2.0f, 3.0f, 0.0f)));
+    EXPECT_TRUE(AlmostEqual(box3.Max, FloatVector4(4.0f, 5.0f, 6.0f, 0.0f)));
+
+    // Test ExpandToInclude with another AABB
+    AABB box4(FloatVector4(0.0f, 0.0f, 0.0f, 0.0f), FloatVector4(2.0f, 2.0f, 2.0f, 0.0f));
+    AABB box5(FloatVector4(1.0f, 1.0f, 1.0f, 0.0f), FloatVector4(3.0f, 3.0f, 3.0f, 0.0f));
+    box4.ExpandToInclude(box5);
+    EXPECT_TRUE(AlmostEqual(box4.Min, FloatVector4(0.0f, 0.0f, 0.0f, 0.0f)));
+    EXPECT_TRUE(AlmostEqual(box4.Max, FloatVector4(3.0f, 3.0f, 3.0f, 0.0f)));
+
+    // Reset restores the canonical empty sentinel.
+    box4.Reset();
+    EXPECT_TRUE(box4.IsEmpty());
+    EXPECT_TRUE(box4.IsValid());
+}
+
+TEST(CanvasMathTest, AABBInsideOutNonSentinelIsInvalidNotEmpty)
+{
+    // An AABB that is inside-out in some axis but is NOT the
+    // canonical FLT_MAX sentinel is INVALID -- not empty.
+    // Treating it as empty would mask a construction-side bug
+    // and cause aggregation to silently skip it.
+    AABB box(FloatVector4(0.0f, 5.0f, 0.0f, 0.0f),
+             FloatVector4(10.0f, 2.0f, 10.0f, 0.0f));  // Y inside-out
+    EXPECT_FALSE(box.IsEmpty());
+    EXPECT_FALSE(box.IsValid());
+
+    // Mixed: partially sentinel values are still not the canonical
+    // empty.  Only the exact FLT_MAX sentinel counts as empty.
+    AABB partial(FloatVector4(FLT_MAX, 0.0f, FLT_MAX, 0.0f),
+                 FloatVector4(-FLT_MAX, 1.0f, -FLT_MAX, 0.0f));
+    EXPECT_FALSE(partial.IsEmpty());
+    EXPECT_FALSE(partial.IsValid());
+}
+
+TEST(CanvasMathTest, AABBTransformIdentity)
+{
+    // Identity matrix leaves the AABB unchanged.
+    AABB box(FloatVector4(-1.0f, -2.0f, -3.0f, 0.0f),
+             FloatVector4( 1.0f,  2.0f,  3.0f, 0.0f));
+    auto result = box.Transform(FloatMatrix4x4::Identity());
+    EXPECT_TRUE(AlmostEqual(result.Min, box.Min));
+    EXPECT_TRUE(AlmostEqual(result.Max, box.Max));
+}
+
+TEST(CanvasMathTest, AABBTransformTranslation)
+{
+    // Pure translation shifts both Min and Max equally.
+    AABB box(FloatVector4(-1.0f, -1.0f, -1.0f, 0.0f),
+             FloatVector4( 1.0f,  1.0f,  1.0f, 0.0f));
+    FloatMatrix4x4 m = FloatMatrix4x4::Identity();
+    m[3][0] = 10.0f;
+    m[3][1] = 20.0f;
+    m[3][2] = 30.0f;
+    auto result = box.Transform(m);
+    EXPECT_TRUE(AlmostEqual(result.Min, FloatVector4( 9.0f, 19.0f, 29.0f, 0.0f)));
+    EXPECT_TRUE(AlmostEqual(result.Max, FloatVector4(11.0f, 21.0f, 31.0f, 0.0f)));
+}
+
+TEST(CanvasMathTest, AABBTransformRotation)
+{
+    // 90-degree rotation around Z (row-vector convention: row 0 ->
+    // becomes +Y, row 1 -> becomes -X) of a non-square box.
+    // After rotation:  X extent <- old Y extent, Y extent <- old X extent.
+    AABB box(FloatVector4(-2.0f, -1.0f, -0.5f, 0.0f),
+             FloatVector4( 2.0f,  1.0f,  0.5f, 0.0f));
+    FloatMatrix4x4 m = FloatMatrix4x4::Identity();
+    m[0][0] =  0.0f; m[0][1] =  1.0f;
+    m[1][0] = -1.0f; m[1][1] =  0.0f;
+    auto result = box.Transform(m);
+    EXPECT_TRUE(AlmostEqual(result.Min, FloatVector4(-1.0f, -2.0f, -0.5f, 0.0f)));
+    EXPECT_TRUE(AlmostEqual(result.Max, FloatVector4( 1.0f,  2.0f,  0.5f, 0.0f)));
+}
+
+TEST(CanvasMathTest, AABBTransformEmptyPropagates)
+{
+    // Transforming an empty AABB returns the same empty AABB.
+    AABB box;
+    EXPECT_TRUE(box.IsEmpty());
+    auto result = box.Transform(FloatMatrix4x4::Identity());
+    EXPECT_TRUE(result.IsEmpty());
+}
+
+TEST(CanvasMathTest, QuaternionNormalize)
+{
+    // Test that normalize works correctly
+    FloatQuaternion q1(0.5f, 0.5f, 0.5f, 0.5f);
+    auto qn = q1.Normalize();
+
+    // Should be unit length
+    float len = DotProduct(qn, qn);
+    EXPECT_TRUE(AlmostZero(len - 1.0f));
+
+    // Test already normalized quaternion
+    auto qIdentity = IdentityQuaternion<float>();
+    auto qIdentityNorm = qIdentity.Normalize();
+    EXPECT_TRUE(AlmostEqual(qIdentity, qIdentityNorm));
+}
+
+TEST(CanvasMathTest, QuaternionConjugate)
+{
+    FloatQuaternion q(0.1f, 0.2f, 0.3f, 0.9f);
+    auto qConj = Conjugate(q);
+
+    EXPECT_TRUE(AlmostEqual(qConj, FloatQuaternion(-0.1f, -0.2f, -0.3f, 0.9f)));
+
+    // Test that q * conjugate(q) = identity for unit quaternions
+    auto qNorm = q.Normalize();
+    auto qConjNorm = Conjugate(qNorm);
+    auto result = qNorm * qConjNorm;
+    EXPECT_TRUE(AlmostEqual(result, IdentityQuaternion<float>()));
+}
+
+TEST(CanvasMathTest, VectorMatrixMultiplication)
+{
+    // Test vector * matrix (row vector)
+    FloatVector3 v(1.0f, 2.0f, 3.0f);
+    FloatMatrix3x3 m({
+        {1.0f, 0.0f, 0.0f},
+        {0.0f, 2.0f, 0.0f},
+        {0.0f, 0.0f, 3.0f}
+    });
+
+    auto result = v * m;
+    EXPECT_TRUE(AlmostEqual(result, FloatVector3(1.0f, 4.0f, 9.0f)));
+
+    // Test matrix * vector (column vector)
+    auto result2 = m * v;
+    EXPECT_TRUE(AlmostEqual(result2, FloatVector3(1.0f, 4.0f, 9.0f)));
+}
+
+TEST(CanvasMathTest, MatrixIdentity)
+{
+    // Test static Identity() method
+    auto m2 = FloatMatrix2x2::Identity();
+    EXPECT_EQ(1.0f, m2[0][0]);
+    EXPECT_EQ(0.0f, m2[0][1]);
+    EXPECT_EQ(0.0f, m2[1][0]);
+    EXPECT_EQ(1.0f, m2[1][1]);
+
+    auto m3 = FloatMatrix3x3::Identity();
+    EXPECT_TRUE(AlmostEqual(m3, IdentityMatrix<float, 3, 3>()));
+
+    auto m4 = FloatMatrix4x4::Identity();
+    EXPECT_TRUE(AlmostEqual(m4, IdentityMatrix<float, 4, 4>()));
+}
+
+TEST(CanvasMathTest, PerspectiveReverseZBasic)
+{
+    // Test basic reverse-Z perspective matrix properties.
+    // View space: +X=right, +Y=up, +Z=forward (D3D LHS, standard).
+    // Row-vector layout: [x_v, y_v, z_v, 1] * M = [x_c, y_c, z_c, w_c].
+    float fovY = static_cast<float>(g_PI / 4.0);  // 45 degrees
+    float aspect = 16.0f / 9.0f;
+    float nearPlane = 0.1f;
+    float farPlane = 1000.0f;
+
+    auto proj = PerspectiveReverseZ(fovY, aspect, nearPlane, farPlane);
+
+    // Non-zero elements per the canonical D3D LHS perspective layout.
+    EXPECT_TRUE(proj[0][0] != 0.0f);  // X(right)   -> X_clip scaling (f/aspect)
+    EXPECT_TRUE(proj[1][1] != 0.0f);  // Y(up)      -> Y_clip scaling (f)
+    EXPECT_TRUE(proj[2][2] != 0.0f);  // Z(forward) -> Z_clip depth
+    EXPECT_TRUE(proj[2][3] == 1.0f);  // Z(forward) -> W_clip (perspective divide)
+
+    // Verify f = cot(fovY/2)
+    float f = 1.0f / std::tan(fovY * 0.5f);
+    EXPECT_TRUE(std::abs(proj[0][0] - (f / aspect)) < FLT_EPSILON);
+    EXPECT_TRUE(std::abs(proj[1][1] - f) < FLT_EPSILON);
+}
+
+TEST(CanvasMathTest, PerspectiveReverseZDepthMapping)
+{
+    // Test reverse-Z perspective matrix generates correct depth coefficients.
+    // View space: +X=right, +Y=up, +Z=forward.
+    float fovY = static_cast<float>(g_PI / 4.0);
+    float aspect = 16.0f / 9.0f;
+    float nearPlane = 0.1f;
+    float farPlane = 1000.0f;
+
+    auto proj = PerspectiveReverseZ(fovY, aspect, nearPlane, farPlane);
+
+    // Row-vector: M[2][2] = A (forward -> z_clip), M[3][2] = B (depth bias).
+    EXPECT_TRUE(proj[2][2] != 0.0f);
+    EXPECT_TRUE(proj[3][2] != 0.0f);
+
+    // A = nearPlane / (nearPlane - farPlane)
+    // B = -(nearPlane * farPlane) / (nearPlane - farPlane)
+    float rangeInv = 1.0f / (nearPlane - farPlane);
+    EXPECT_TRUE(std::abs(proj[2][2] - nearPlane * rangeInv) < FLT_EPSILON);
+    EXPECT_TRUE(std::abs(proj[3][2] - (-(nearPlane * farPlane * rangeInv))) < FLT_EPSILON);
+
+    // Verify depth mapping: ndc_z = (A*z + B) / z where z = forward distance.
+    // At near plane (z=near): ndc_z should be 1.0
+    float A = proj[2][2];
+    float B = proj[3][2];
+    float ndc_near = (A * nearPlane + B) / nearPlane;
+    EXPECT_TRUE(std::abs(ndc_near - 1.0f) < 1e-5f);
+    // At far plane (z=far): ndc_z should be 0.0
+    float ndc_far = (A * farPlane + B) / farPlane;
+    EXPECT_TRUE(std::abs(ndc_far - 0.0f) < 1e-5f);
+}
+
+TEST(CanvasMathTest, PerspectiveReverseZCoordinateTransform)
+{
+    // Test coordinate system transformation: X_v(right)->X_clip,
+    // Y_v(up)->Y_clip, Z_v(forward)->Z_clip + W_clip.
+    float fovY = static_cast<float>(g_PI / 4.0);
+    float aspect = 1.0f;
+    float nearPlane = 1.0f;
+    float farPlane = 10.0f;
+
+    auto proj = PerspectiveReverseZ(fovY, aspect, nearPlane, farPlane);
+
+    float f = 1.0f / std::tan(fovY * 0.5f);
+
+    // Row-vector: M[0][0] = f/a (right -> x_clip), M[1][1] = f (up -> y_clip).
+    EXPECT_TRUE(std::abs(proj[0][0] - f) < 1e-5f);  // aspect=1
+    EXPECT_TRUE(std::abs(proj[1][1] - f) < 1e-5f);
+
+    // Perspective divide: M[2][3] = 1 (forward -> w_clip), M[3][3] = 0.
+    EXPECT_TRUE(std::abs(proj[2][3] - 1.0f) < 1e-5f);  // w_clip = z_view
+    EXPECT_TRUE(std::abs(proj[3][3] - 0.0f) < 1e-5f);
+}
+
+TEST(CanvasMathTest, PerspectiveForwardZBasic)
+{
+    // Test basic forward-Z perspective matrix properties.
+    // View space: +X=right, +Y=up, +Z=forward.
+    float fovY = static_cast<float>(g_PI / 4.0);
+    float aspect = 16.0f / 9.0f;
+    float nearPlane = 0.1f;
+    float farPlane = 1000.0f;
+
+    auto proj = PerspectiveForwardZ(fovY, aspect, nearPlane, farPlane);
+
+    // Row-vector: M[i][j] maps input axis i to output axis j.
+    EXPECT_TRUE(proj[0][0] != 0.0f);  // X(right)   -> X_clip
+    EXPECT_TRUE(proj[1][1] != 0.0f);  // Y(up)      -> Y_clip
+    EXPECT_TRUE(proj[2][2] != 0.0f);  // Z(forward) -> Z_clip
+    EXPECT_TRUE(proj[2][3] == 1.0f);  // Z(forward) -> W_clip
+
+    // Verify f = cot(fovY/2)
+    float f = 1.0f / std::tan(fovY * 0.5f);
+    EXPECT_TRUE(std::abs(proj[0][0] - (f / aspect)) < FLT_EPSILON);
+    EXPECT_TRUE(std::abs(proj[1][1] - f) < FLT_EPSILON);
+}
+
+TEST(CanvasMathTest, PerspectiveForwardZDepthMapping)
+{
+    // Test forward-Z perspective matrix generates correct depth coefficients.
+    float fovY = static_cast<float>(g_PI / 4.0);
+    float aspect = 16.0f / 9.0f;
+    float nearPlane = 0.1f;
+    float farPlane = 1000.0f;
+
+    auto proj = PerspectiveForwardZ(fovY, aspect, nearPlane, farPlane);
+
+    // Row-vector: M[2][2] = A (forward -> z_clip), M[3][2] = B (depth bias).
+    EXPECT_TRUE(proj[2][2] != 0.0f);
+    EXPECT_TRUE(proj[3][2] != 0.0f);
+
+    // A = farPlane / (farPlane - nearPlane)
+    // B = -(nearPlane * farPlane) / (farPlane - nearPlane)
+    float rangeInv = 1.0f / (farPlane - nearPlane);
+    EXPECT_TRUE(std::abs(proj[2][2] - farPlane * rangeInv) < FLT_EPSILON);
+    EXPECT_TRUE(std::abs(proj[3][2] + nearPlane * farPlane * rangeInv) < FLT_EPSILON);
+
+    // Verify depth mapping: ndc_z = (A*z + B) / z.
+    // At near plane: ndc_z should be 0.0
+    float A = proj[2][2];
+    float B = proj[3][2];
+    float ndc_near = (A * nearPlane + B) / nearPlane;
+    EXPECT_TRUE(std::abs(ndc_near - 0.0f) < 1e-5f);
+    // At far plane: ndc_z should be 1.0
+    float ndc_far = (A * farPlane + B) / farPlane;
+    EXPECT_TRUE(std::abs(ndc_far - 1.0f) < 1e-5f);
+}
+
+TEST(CanvasMathTest, PerspectiveForwardZCoordinateTransform)
+{
+    // Test coordinate system transformation for forward-Z.
+    // X_v(right)->X_clip, Y_v(up)->Y_clip, Z_v(forward)->Z/W_clip.
+    float fovY = static_cast<float>(g_PI / 4.0);
+    float aspect = 1.0f;
+    float nearPlane = 1.0f;
+    float farPlane = 10.0f;
+
+    auto proj = PerspectiveForwardZ(fovY, aspect, nearPlane, farPlane);
+
+    float f = 1.0f / std::tan(fovY * 0.5f);
+
+    // Row-vector: M[0][0] = f/a (right -> x_clip), M[1][1] = f (up -> y_clip).
+    EXPECT_TRUE(std::abs(proj[0][0] - f) < 1e-5f);
+    EXPECT_TRUE(std::abs(proj[1][1] - f) < 1e-5f);
+
+    // Perspective divide: M[2][3] = 1 (forward -> w_clip).
+    EXPECT_TRUE(std::abs(proj[2][3] - 1.0f) < 1e-5f);  // w_clip = z_view
+    EXPECT_TRUE(std::abs(proj[3][3] - 0.0f) < 1e-5f);  // no constant contribution to w_clip
+}
+
+TEST(CanvasMathTest, PerspectiveReverseZVsForwardZDifference)
+{
+    // Verify both reverse-Z and forward-Z functions create valid projection matrices.
+    // View space: +X=right, +Y=up, +Z=forward.
+    float fovY = static_cast<float>(g_PI / 4.0);
+    float aspect = 1.0f;
+    float nearPlane = 1.0f;
+    float farPlane = 10.0f;
+
+    auto projRZ = PerspectiveReverseZ(fovY, aspect, nearPlane, farPlane);
+    auto projFZ = PerspectiveForwardZ(fovY, aspect, nearPlane, farPlane);
+
+    float f = 1.0f / std::tan(fovY * 0.5f);
+
+    // Both should have identical FOV and perspective setup (row-vector layout).
+    EXPECT_TRUE(std::abs(projRZ[0][0] - f) < 1e-5f);  // X(right) -> X_clip
+    EXPECT_TRUE(std::abs(projRZ[1][1] - f) < 1e-5f);  // Y(up)    -> Y_clip
+    EXPECT_TRUE(std::abs(projFZ[0][0] - f) < 1e-5f);
+    EXPECT_TRUE(std::abs(projFZ[1][1] - f) < 1e-5f);
+
+    // Verify perspective divide is correctly set for both.
+    EXPECT_TRUE(std::abs(projRZ[2][3] - 1.0f) < 1e-5f);  // w_clip = z_view
+    EXPECT_TRUE(std::abs(projFZ[2][3] - 1.0f) < 1e-5f);
+    EXPECT_TRUE(std::abs(projRZ[3][3] - 0.0f) < 1e-5f);
+    EXPECT_TRUE(projFZ[3][3] == 0.0f);
+
+    // Depth coefficients differ: reverse-Z and forward-Z must produce
+    // different A and B values (otherwise they are the same mapping).
+    EXPECT_TRUE(std::abs(projRZ[2][2] - projFZ[2][2]) > 1e-5f);
+    EXPECT_TRUE(std::abs(projRZ[3][2] - projFZ[3][2]) > 1e-5f);
+}
+
+TEST(CanvasMathTest, OrthoReverseZDepthMapping)
+{
+    // Verify that the reverse-Z ortho helper maps zNear -> 1 and
+    // zFar -> 0 in clip space, matching the engine's reverse-Z
+    // convention used by perspective projections and the
+    // GREATER_EQUAL depth test.  View-space convention is LHS
+    // (X=right, Y=up, Z=forward); row vectors throughout.
+    const float halfW   = 100.0f;
+    const float halfH   = 50.0f;
+    const float zNear   = 1.0f;
+    const float zFar    = 200.0f;
+
+    auto proj = OrthoReverseZ(halfW, halfH, zNear, zFar);
+
+    // Ortho has no perspective divide: row 3 column 3 is the
+    // identity-affine 1, row 2 column 3 must be 0 so w_clip
+    // equals 1 for every input.
+    EXPECT_TRUE(std::abs(proj[3][3] - 1.0f) < FLT_EPSILON);
+    EXPECT_TRUE(std::abs(proj[2][3] - 0.0f) < FLT_EPSILON);
+
+    // XY scaling: 1/halfWidth, 1/halfHeight.
+    EXPECT_TRUE(std::abs(proj[0][0] - (1.0f / halfW)) < FLT_EPSILON);
+    EXPECT_TRUE(std::abs(proj[1][1] - (1.0f / halfH)) < FLT_EPSILON);
+
+    // Pump a point at the near plane through the matrix and
+    // verify ndc_z = 1.0.  At z=zNear: clip_z = -zNear/(zFar-zNear)
+    // + zFar/(zFar-zNear) = (zFar - zNear) / (zFar - zNear) = 1.
+    FloatVector4 ptNear(0.0f, 0.0f, zNear, 1.0f);
+    FloatVector4 clipNear = ptNear * proj;
+    EXPECT_TRUE(std::abs(clipNear.W - 1.0f) < 1e-5f);
+    EXPECT_TRUE(std::abs(clipNear.Z / clipNear.W - 1.0f) < 1e-5f);
+
+    // Same at the far plane: ndc_z = 0.
+    FloatVector4 ptFar(0.0f, 0.0f, zFar, 1.0f);
+    FloatVector4 clipFar = ptFar * proj;
+    EXPECT_TRUE(std::abs(clipFar.W - 1.0f) < 1e-5f);
+    EXPECT_TRUE(std::abs(clipFar.Z / clipFar.W - 0.0f) < 1e-5f);
+}
+
+TEST(CanvasMathTest, OrthoReverseZXYExtents)
+{
+    // Verify points at the +/- box extents map to +/- 1 in NDC.
+    const float halfW = 20.0f;
+    const float halfH = 10.0f;
+    const float zNear = 0.5f;
+    const float zFar  = 100.0f;
+
+    auto proj = OrthoReverseZ(halfW, halfH, zNear, zFar);
+
+    // +halfWidth on x -> +1 in NDC x.
+    FloatVector4 pX(halfW, 0.0f, zNear, 1.0f);
+    FloatVector4 cX = pX * proj;
+    EXPECT_TRUE(std::abs(cX.X - 1.0f) < 1e-5f);
+    EXPECT_TRUE(std::abs(cX.Y - 0.0f) < 1e-5f);
+
+    // -halfHeight on y -> -1 in NDC y.
+    FloatVector4 pY(0.0f, -halfH, zFar, 1.0f);
+    FloatVector4 cY = pY * proj;
+    EXPECT_TRUE(std::abs(cY.X - 0.0f) < 1e-5f);
+    EXPECT_TRUE(std::abs(cY.Y - (-1.0f)) < 1e-5f);
+}
+
+// ----------------------------------------------------------------
+// Frustum extraction + AABB intersection tests.
+//
+// Camera view space: LHS, +X right, +Y up, +Z forward.  Tests use
+// view = identity so the projection matrix alone defines the
+// frustum, letting us reason about points/AABBs directly in view
+// coordinates without an extra matrix layer to debug.
+// ----------------------------------------------------------------
+
+// Reverse-Z perspective is Canvas's default.  These tests pin the
+// sign convention of FromViewProjection: points truly inside the
+// view frustum must produce IntersectsAABB == true; points outside
+// any single plane must produce false.
+TEST(CanvasMathTest, FrustumReverseZPerspectiveInsideOutside)
+{
+    const float fovY = float(g_PI * 0.5);  // 90 deg
+    const float aspect = 1.0f;
+    const float nearZ = 1.0f;
+    const float farZ  = 100.0f;
+    FloatMatrix4x4 proj = PerspectiveReverseZ<float>(fovY, aspect, nearZ, farZ);
+    Frustum f = Frustum::FromViewProjection(proj, /*reverseZ*/ true);
+
+    auto pointAABB = [](float x, float y, float z) {
+        FloatVector4 p(x, y, z, 0.0f);
+        return AABB(p, p);
+    };
+
+    // Squarely inside.
+    EXPECT_TRUE(f.IntersectsAABB(pointAABB(0.0f, 0.0f, 10.0f)));
+
+    // Behind the near plane (z < nearZ): outside near.
+    EXPECT_FALSE(f.IntersectsAABB(pointAABB(0.0f, 0.0f, 0.5f)));
+
+    // Behind the camera entirely.
+    EXPECT_FALSE(f.IntersectsAABB(pointAABB(0.0f, 0.0f, -10.0f)));
+
+    // Beyond the far plane.
+    EXPECT_FALSE(f.IntersectsAABB(pointAABB(0.0f, 0.0f, 200.0f)));
+
+    // Off to the right past the 90-deg side plane (x > z at z=10).
+    EXPECT_FALSE(f.IntersectsAABB(pointAABB(50.0f, 0.0f, 10.0f)));
+
+    // Above the top plane (y > z at z=10 for 90deg fov).
+    EXPECT_FALSE(f.IntersectsAABB(pointAABB(0.0f, 50.0f, 10.0f)));
+
+    // AABB straddling the near plane: must overlap.
+    AABB straddleNear(FloatVector4(-0.5f, -0.5f, 0.5f, 0.0f),
+                      FloatVector4( 0.5f,  0.5f, 2.0f, 0.0f));
+    EXPECT_TRUE(f.IntersectsAABB(straddleNear));
+
+    // Large AABB enclosing the camera: positive-vertex test is
+    // conservative and accepts this (every plane has SOME corner
+    // on the inside).  Documents the known false-positive regime.
+    AABB enclosing(FloatVector4(-1000.0f, -1000.0f, -1000.0f, 0.0f),
+                   FloatVector4( 1000.0f,  1000.0f,  1000.0f, 0.0f));
+    EXPECT_TRUE(f.IntersectsAABB(enclosing));
+
+    // Empty AABB: never intersects.
+    EXPECT_FALSE(f.IntersectsAABB(AABB{}));
+}
+
+// Forward-Z swap: only Near/Far plane assignment differs.  Same
+// points should yield the same inside/outside verdicts because
+// both extractions describe the same world-space frustum.
+TEST(CanvasMathTest, FrustumForwardZPerspectiveAgreesWithReverseZ)
+{
+    const float fovY = float(g_PI * 0.5);
+    const float aspect = 16.0f / 9.0f;
+    const float nearZ = 0.5f;
+    const float farZ  = 50.0f;
+
+    Frustum fRev = Frustum::FromViewProjection(
+        PerspectiveReverseZ<float>(fovY, aspect, nearZ, farZ), true);
+    Frustum fFwd = Frustum::FromViewProjection(
+        PerspectiveForwardZ<float>(fovY, aspect, nearZ, farZ), false);
+
+    const FloatVector4 inside (0.0f, 0.0f, 10.0f, 0.0f);
+    const FloatVector4 tooNear(0.0f, 0.0f,  0.1f, 0.0f);
+    const FloatVector4 tooFar (0.0f, 0.0f, 99.0f, 0.0f);
+
+    AABB bIn (inside,  inside);
+    AABB bN  (tooNear, tooNear);
+    AABB bF  (tooFar,  tooFar);
+
+    EXPECT_EQ(fRev.IntersectsAABB(bIn), fFwd.IntersectsAABB(bIn));
+    EXPECT_EQ(fRev.IntersectsAABB(bN), fFwd.IntersectsAABB(bN));
+    EXPECT_EQ(fRev.IntersectsAABB(bF), fFwd.IntersectsAABB(bF));
+
+    EXPECT_TRUE(fRev.IntersectsAABB(bIn));
+    EXPECT_FALSE(fRev.IntersectsAABB(bN));
+    EXPECT_FALSE(fRev.IntersectsAABB(bF));
+}
 
-        __declspec(noinline) FloatVector4 Mul(const FloatVector4 &a, const FloatVector4 &b)
-        {
-            return a * b;
-
-        }
-		TEST_METHOD(SimpleVectors)
-		{
-            TVector<int, 4> V0(1, 2, 3, 4);
-            TVector<int, 4> V1(5, 6, 1, 2);
-            Assert::AreEqual(V0.Dim, 4);
-            Assert::AreEqual(V1[0], 5);
-            Assert::AreEqual(V1[1], 6);
-            Assert::AreEqual(V1[2], 1);
-            Assert::AreEqual(V1[3], 2);
-            auto SubResult = V1 - V0;
-            Assert::IsTrue(SubResult == TVector<int, 4>(4, 4, -2, -2));
-            auto AddResult = V1 + V0;
-            Assert::IsTrue(AddResult == TVector<int, 4>(6, 8, 4, 6));
-            auto MulResult = V1 * V0;
-            Assert::IsTrue(MulResult == TVector<int, 4>(5, 12, 3, 8));
-            int Dot = DotProduct(SubResult, V0);
-            Assert::AreEqual(4 + 8 - 6 - 8, Dot);
-            TVector<int, 3> V2(3, 5, 7);
-            TVector<int, 3> V3(2, 11, 13);
-            auto Cross = CrossProduct(V2, V3);
-            Assert::IsTrue(TVector<int, 3>(-12, -25, 23) == Cross);
-
-            TVector<int, 2> V4(11, 13);
-            Assert::AreEqual(V4[0], 11);
-            Assert::AreEqual(V4[1], 13);
-
-            TVector<int, 6> V5 = { 1, 1, 2, 3, 5, 8 };
-            TVector<int, 6> V8 = { 2, 2, 4, 6, 10, 16 };
-            auto V6 = 2 * V5;
-            auto V7 = V5 * 2;
-            Assert::IsTrue(V8 == V7);
-            Assert::IsTrue(V8 == V6);
-
-            FloatVector4 a(1 * g_mul, 2 * g_mul, 3 * g_mul, 4 * g_mul);
-            FloatVector4 b(.1f * g_mul, .2f * g_mul, .3f * g_mul, .4f * g_mul);
-            FloatVector4 c = Mul(a, b);
-            Assert::IsTrue(AlmostEqual(c, FloatVector4(.1f, .4f, .9f, 1.6f)));
-        }
-
-        TEST_METHOD(SimpleMatrices)
-        {
-            TMatrix<int, 3, 4> M0 = {
-                {1, 1, 2, 3},
-                {5, 8, 13, 21},
-                {34, 55, 89, 144}
-            };
-            Assert::AreEqual(M0.Columns, 4);
-            Assert::AreEqual(M0.Rows, 3);
-            TMatrix<int, 4, 4> M1 = {
-                {4, 7, 10, 13 },
-                {5, 8, 11, 14},
-                {6, 9, 12, 15},
-                {7, 10, 13, 16}
-            };
-
-            auto M2 = M0 * M1;
-
-            TMatrix<int, 3, 4> MMulResult = {
-                { 42, 63, 84, 105 },
-                { 285, 426, 567, 708 },
-                { 1953, 2919, 3885, 4851 }
-            };
-
-            Assert::IsTrue(MMulResult == M2);
-
-            auto T = MatrixTransposeRows(M1);
-            Assert::IsTrue(T == TMatrix<int, 4, 4>(
-                {4, 5, 6, 7 },
-                {7, 8, 9, 10},
-                {10, 11, 12, 13},
-                {13, 14, 15, 16}
-            ));
-
-            T = MatrixTransposeRows(M1, 2, 2, 1);
-            Assert::IsTrue(T == TMatrix<int, 4, 4>(
-                {4, 7, 10, 13 },
-                {5, 8, 11, 14},
-                {6, 9, 10, 15},
-                {7, 12, 13, 16}
-            ));
-        }
-
-        TEST_METHOD(Normalize)
-        {
-            TVector<float, 3> fv[] =
-            {
-                { 1.0f, 0.0f, 0.0f },
-                { 1.0f, 1.0f, 1.0f },
-                { 1.0f, 2.0f, 3.0f }
-            };
-
-            for (unsigned int i = 0; i < _countof(fv); ++i)
-            {
-                auto nv = fv[i].Normalize();
-            
-                // Verify the magnitude is nearly 1.0f
-                float magsq = DotProduct(nv, nv);
-                float diff = std::abs(magsq - 1.0f);
-                Assert::IsTrue(diff < 0.000001f);
-            }
-
-            TVector<double, 4> dv[] =
-            {
-                { 0.0, 1.0, 0.0, 0.0 },
-                { 1.0, 1.0, 1.0, 1.0 },
-                { 0.0, 1.0, 2.0, 3.0 }
-            };
-
-            for (unsigned int i = 0; i < _countof(dv); ++i)
-            {
-                auto nv = dv[i].Normalize();
-            
-                // Verify the magnitude is nearly 1.0f
-                double magsq = DotProduct(nv, nv);
-                double diff = std::abs(magsq - 1.0);
-                Assert::IsTrue(diff < 0.000001);
-            }
-        }
-
-        TEST_METHOD(MatrixRotation)
-        {
-            using MatrixType = FloatMatrix4x4;
-            using VecType = MatrixType::RowType;
-            using ElementType = MatrixType::ElementType;
-            static const auto Rows = MatrixType::Rows;
-            static const auto Columns = MatrixType::Columns;
-
-            MatrixType rx = XRotationMatrix<ElementType>(float(g_PI) / 2);
-            Assert::IsTrue(AlmostEqual(rx[0], VecType(1, 0, 0, 0)));
-            Assert::IsTrue(AlmostEqual(rx[1], VecType(0, 0, -1, 0)));
-            Assert::IsTrue(AlmostEqual(rx[2], VecType(0, 1, 0, 0)));
-
-            rx = XRotationMatrix<ElementType>(-float(g_PI) / 2);
-            Assert::IsTrue(AlmostEqual(rx[0], VecType(1, 0, 0, 0)));
-            Assert::IsTrue(AlmostEqual(rx[1], VecType(0, 0, 1, 0)));
-            Assert::IsTrue(AlmostEqual(rx[2], VecType(0, -1, 0, 0)));
-
-            MatrixType ry = YRotationMatrix<ElementType>(float(g_PI) / 2);
-            Assert::IsTrue(AlmostEqual(ry[0], VecType(0, 0, 1, 0)));
-            Assert::IsTrue(AlmostEqual(ry[1], VecType(0, 1, 0, 0)));
-            Assert::IsTrue(AlmostEqual(ry[2], VecType(-1, 0, 0, 0)));
-            Assert::IsTrue(AlmostEqual(ry[3], VecType(0, 0, 0, 1)));
-
-            ry = YRotationMatrix<ElementType>(-float(g_PI) / 2);
-            Assert::IsTrue(AlmostEqual(ry[0], VecType(0, 0, -1, 0)));
-            Assert::IsTrue(AlmostEqual(ry[1], VecType(0, 1, 0, 0)));
-            Assert::IsTrue(AlmostEqual(ry[2], VecType(1, 0, 0, 0)));
-            Assert::IsTrue(AlmostEqual(ry[3], VecType(0, 0, 0, 1)));
-
-            MatrixType rz = ZRotationMatrix<ElementType>(float(g_PI) / 2);
-            Assert::IsTrue(AlmostEqual(rz[0], VecType(0, -1, 0, 0)));
-            Assert::IsTrue(AlmostEqual(rz[1], VecType(1, 0, 0, 0)));
-            Assert::IsTrue(AlmostEqual(rz[2], VecType(0, 0, 1, 0)));
-            Assert::IsTrue(AlmostEqual(ry[3], VecType(0, 0, 0, 1)));
-
-            rz = ZRotationMatrix<ElementType>(-float(g_PI) / 2);
-            Assert::IsTrue(AlmostEqual(rz[0], VecType(0, 1, 0, 0)));
-            Assert::IsTrue(AlmostEqual(rz[1], VecType(-1, 0, 0, 0)));
-            Assert::IsTrue(AlmostEqual(rz[2], VecType(0, 0, 1, 0)));
-            Assert::IsTrue(AlmostEqual(ry[3], VecType(0, 0, 0, 1)));
-        }
-
-        TEST_METHOD(LookAt)
-        {
-            // ComposePointToBasisVectors is a general utility that works with any coordinate system.
-            // It computes: basisSideVector = WorldUp × ForwardVector, basisUpVector = ForwardVector × basisSideVector
-            // This test verifies the math works correctly regardless of camera conventions.
-            
-            auto WorldUp = FloatVector3(0, 0, 1); // World-up is the world Z-axis
-            FloatMatrix3x3 M;
-            
-            // Test case 1: Forward vector pointing in -Y direction
-            auto forward1 = FloatVector3(0, -1, 0);
-            ComposePointToBasisVectors(WorldUp, forward1, M[0], M[1]);
-            M[2] = forward1;
-
-            // Expected:
-            // side = WorldUp × forward = (0,0,1) × (0,-1,0) = (1,0,0)
-            // up = forward × side = (0,-1,0) × (1,0,0) = (0,0,1)
-            Assert::IsTrue(AlmostEqual(M, FloatMatrix3x3(
-                {
-                    {1, 0, 0},     // side
-                    {0, 0, 1},     // up  
-                    {0, -1, 0},    // forward
-                }
-            )));
-
-            
-            // Degenerate case 1: Forward vector aligned with world-up
-            auto forward2 = FloatVector3(0, 0, 1);
-            ComposePointToBasisVectors(WorldUp, forward2, M[0], M[1]);
-            M[2] = forward2;
-
-            // When forward is parallel to WorldUp, function picks an arbitrary perpendicular side vector
-            Assert::IsTrue(AlmostEqual(M, FloatMatrix3x3(
-                {
-                    {1, 0, 0},     // side (arbitrary perpendicular)
-                    {0, 1, 0},     // up (perpendicular to forward and side)
-                    {0, 0, 1},     // forward
-                }
-            )));
-
-            // Degenerate case 2: Forward vector anti-parallel to world-up
-            auto forward3 = FloatVector3(0, 0, -1);
-            ComposePointToBasisVectors(WorldUp, forward3, M[0], M[1]);
-            M[2] = forward3;
-
-            // When forward is anti-parallel to WorldUp, function picks an arbitrary perpendicular side vector (flipped)
-            // side = (-1, 0, 0) from function's formula: (-localUp[2], localUp[0], -localUp[1])
-            // up = forward × side = (0,0,-1) × (-1,0,0) = (0, 1, 0)
-            Assert::IsTrue(AlmostEqual(M, FloatMatrix3x3(
-                {
-                    {-1, 0, 0},    // side (arbitrary perpendicular, negative)
-                    {0, 1, 0},     // up (perpendicular to forward and side)
-                    {0, 0, -1},    // forward
-                }
-            )));
-        }
-
-        TEST_METHOD(LookAtArbitraryBasis)
-        {
-            // Test ComposeArbitraryPointToBasisVectors which automatically selects
-            // a reference up vector based on the forward vector
-            FloatVector3 side, up;
-            
-            // Test case 1: Forward pointing in +X direction
-            // Should choose Y or Z as reference (whichever is less aligned)
-            auto forward1 = FloatVector3(1, 0, 0);
-            ComposeArbitraryPointToBasisVectors(forward1, side, up);
-            
-            // Verify orthonormality
-            Assert::IsTrue(AlmostZero(DotProduct(forward1, side)));
-            Assert::IsTrue(AlmostZero(DotProduct(forward1, up)));
-            Assert::IsTrue(AlmostZero(DotProduct(side, up)));
-            float len1 = DotProduct(forward1, forward1);
-            Assert::IsTrue(AlmostZero(len1 - 1.0f));
-            float lenSide1 = DotProduct(side, side);
-            Assert::IsTrue(AlmostZero(lenSide1 - 1.0f));
-            float lenUp1 = DotProduct(up, up);
-            Assert::IsTrue(AlmostZero(lenUp1 - 1.0f));
-            
-            // Verify right-handedness: forward × side = up
-            auto computedUp = CrossProduct(forward1, side);
-            Assert::IsTrue(AlmostEqual(computedUp, up));
-            
-            // Test case 2: Forward pointing in +Y direction
-            auto forward2 = FloatVector3(0, 1, 0);
-            ComposeArbitraryPointToBasisVectors(forward2, side, up);
-            
-            Assert::IsTrue(AlmostZero(DotProduct(forward2, side)));
-            Assert::IsTrue(AlmostZero(DotProduct(forward2, up)));
-            Assert::IsTrue(AlmostZero(DotProduct(side, up)));
-            float lenSide2 = DotProduct(side, side);
-            Assert::IsTrue(AlmostZero(lenSide2 - 1.0f));
-            float lenUp2 = DotProduct(up, up);
-            Assert::IsTrue(AlmostZero(lenUp2 - 1.0f));
-            computedUp = CrossProduct(forward2, side);
-            Assert::IsTrue(AlmostEqual(computedUp, up));
-            
-            // Test case 3: Forward pointing in +Z direction
-            auto forward3 = FloatVector3(0, 0, 1);
-            ComposeArbitraryPointToBasisVectors(forward3, side, up);
-            
-            Assert::IsTrue(AlmostZero(DotProduct(forward3, side)));
-            Assert::IsTrue(AlmostZero(DotProduct(forward3, up)));
-            Assert::IsTrue(AlmostZero(DotProduct(side, up)));
-            float lenSide3 = DotProduct(side, side);
-            Assert::IsTrue(AlmostZero(lenSide3 - 1.0f));
-            float lenUp3 = DotProduct(up, up);
-            Assert::IsTrue(AlmostZero(lenUp3 - 1.0f));
-            computedUp = CrossProduct(forward3, side);
-            Assert::IsTrue(AlmostEqual(computedUp, up));
-            
-            // Test case 4: Forward pointing in -X direction
-            auto forward4 = FloatVector3(-1, 0, 0);
-            ComposeArbitraryPointToBasisVectors(forward4, side, up);
-            
-            Assert::IsTrue(AlmostZero(DotProduct(forward4, side)));
-            Assert::IsTrue(AlmostZero(DotProduct(forward4, up)));
-            Assert::IsTrue(AlmostZero(DotProduct(side, up)));
-            float lenSide4 = DotProduct(side, side);
-            Assert::IsTrue(AlmostZero(lenSide4 - 1.0f));
-            float lenUp4 = DotProduct(up, up);
-            Assert::IsTrue(AlmostZero(lenUp4 - 1.0f));
-            computedUp = CrossProduct(forward4, side);
-            Assert::IsTrue(AlmostEqual(computedUp, up));
-            
-            // Test case 5: Arbitrary diagonal direction
-            auto forward5 = FloatVector3(1, 1, 1).Normalize();
-            ComposeArbitraryPointToBasisVectors(forward5, side, up);
-            
-            Assert::IsTrue(AlmostZero(DotProduct(forward5, side)));
-            Assert::IsTrue(AlmostZero(DotProduct(forward5, up)));
-            Assert::IsTrue(AlmostZero(DotProduct(side, up)));
-            float lenSide5 = DotProduct(side, side);
-            Assert::IsTrue(AlmostZero(lenSide5 - 1.0f));
-            float lenUp5 = DotProduct(up, up);
-            Assert::IsTrue(AlmostZero(lenUp5 - 1.0f));
-            computedUp = CrossProduct(forward5, side);
-            Assert::IsTrue(AlmostEqual(computedUp, up));
-            
-            // Test case 6: Another arbitrary direction
-            auto forward6 = FloatVector3(0.6f, -0.8f, 0).Normalize();
-            ComposeArbitraryPointToBasisVectors(forward6, side, up);
-            
-            Assert::IsTrue(AlmostZero(DotProduct(forward6, side)));
-            Assert::IsTrue(AlmostZero(DotProduct(forward6, up)));
-            Assert::IsTrue(AlmostZero(DotProduct(side, up)));
-            float lenSide6 = DotProduct(side, side);
-            Assert::IsTrue(AlmostZero(lenSide6 - 1.0f));
-            float lenUp6 = DotProduct(up, up);
-            Assert::IsTrue(AlmostZero(lenUp6 - 1.0f));
-            computedUp = CrossProduct(forward6, side);
-            Assert::IsTrue(AlmostEqual(computedUp, up));
-            
-            // Test case 7: Near-axis aligned (stress test)
-            auto forward7 = FloatVector3(0.0001f, 0.9999f, 0).Normalize();
-            ComposeArbitraryPointToBasisVectors(forward7, side, up);
-            
-            Assert::IsTrue(AlmostZero(DotProduct(forward7, side)));
-            Assert::IsTrue(AlmostZero(DotProduct(forward7, up)));
-            Assert::IsTrue(AlmostZero(DotProduct(side, up)));
-            float lenSide7 = DotProduct(side, side);
-            Assert::IsTrue(AlmostZero(lenSide7 - 1.0f));
-            float lenUp7 = DotProduct(up, up);
-            Assert::IsTrue(AlmostZero(lenUp7 - 1.0f));
-            computedUp = CrossProduct(forward7, side);
-            Assert::IsTrue(AlmostEqual(computedUp, up));
-        }
-
-        TEST_METHOD(BasicQuaternion)
-        {
-            auto Q = IdentityQuaternion<double>();
-            Assert::IsTrue(Q == DoubleQuaternion(0, 0, 0, 1));
-            auto M = IdentityMatrix<double, 4, 4>();
-            auto N = QuaternionToRotationMatrix(Q);
-            Assert::IsTrue(AlmostEqual(M, N));
-
-            auto R = QuaternionFromAngleAxis(DoubleVector4(1, 0, 0, 0));
-            Assert::IsTrue(AlmostEqual(Q, R));
-
-            M = TMatrix<double, 4, 4>(
-                {
-                    { -1,  0,  0, 0 },
-                    {  0, -1,  0, 0 },
-                    {  0,  0,  1, 0 },
-                    {  0,  0,  0, 1 }
-                }
-            );
-
-            R = QuaternionFromRotationMatrix(M);
-            N = QuaternionToRotationMatrix(R);
-            Assert::IsTrue(AlmostEqual(M, N));
-
-            for (int i = 0; i < 16; i++)
-            {
-                for (int j = 0; j < 16; j++)
-                {
-                    for (int k = 1; k < 16; k++)
-                    {
-                        double rotx = i * g_PI / 16.;
-                        double roty = j * g_PI / 16.;
-                        double rotz = k * g_PI / 16.;
-                        M = XRotationMatrix<double>(rotx) * YRotationMatrix<double>(roty) * ZRotationMatrix<double>(rotz);
-                        R = QuaternionFromRotationMatrix(M);
-                        N = QuaternionToRotationMatrix(R);
-
-                        // Verify round-trip conversion from matrix->quaternion->matrix produces the original matrix
-                        Assert::IsTrue(AlmostEqual(M, N));
-
-                        // Transform a set of vertices by matrix and by quaternion and verify 
-                        // the rotated results match
-
-                        TVector<double, 4> Vectors[] =
-                        {
-                            {1., 0., 0., 0},
-                            {-5., 7, 13., 0},
-                            {6, -2, 11, 0},
-                            {6, 22, -11, 0},
-                            {.5, .2, 0., 0},
-                        };
-
-                        // Transform each vector by matrix and by quaternion
-                        // and verify the results match
-                        for (auto &V : Vectors)
-                        {
-                            // Matrix transform
-                            auto VByM = M * V;
-
-                            auto InvR = Conjugate(R);
-                            auto Ident = R * InvR;
-                            Assert::IsTrue(AlmostEqual(Ident, DoubleQuaternion(0, 0, 0, 1)));
-
-                            // Quaternion transform - convert vector to quaternion with w=0
-                            DoubleQuaternion VQuat(V.X, V.Y, V.Z, 0);
-                            auto VByQ = R * VQuat * InvR;
-
-                            Assert::IsTrue(AlmostEqual(VByM, VByQ));
-                        }
-                    }
-                }
-            }
-        }
-
-        TEST_METHOD(VectorUnaryMinus)
-        {
-            IntVector3 v1(1, -2, 3);
-            IntVector3 v2 = -v1;
-            Assert::IsTrue(v2 == IntVector3(-1, 2, -3));
-
-            FloatVector4 v3(1.5f, -2.5f, 3.5f, -4.5f);
-            FloatVector4 v4 = -v3;
-            Assert::IsTrue(AlmostEqual(v4, FloatVector4(-1.5f, 2.5f, -3.5f, 4.5f)));
-        }
-
-        TEST_METHOD(VectorInequalityAndDivision)
-        {
-            IntVector3 v1(1, 2, 3);
-            IntVector3 v2(1, 2, 3);
-            IntVector3 v3(1, 2, 4);
-            
-            Assert::IsFalse(v1 != v2);
-            Assert::IsTrue(v1 != v3);
-
-            FloatVector4 v4(10.0f, 20.0f, 30.0f, 40.0f);
-            FloatVector4 v5(2.0f, 4.0f, 5.0f, 8.0f);
-            auto v6 = v4 / v5;
-            Assert::IsTrue(AlmostEqual(v6, FloatVector4(5.0f, 5.0f, 6.0f, 5.0f)));
-        }
-
-        TEST_METHOD(VectorSumTest)
-        {
-            IntVector4 v1(1, 2, 3, 4);
-            int sum = VectorSum(v1);
-            Assert::AreEqual(10, sum);
-
-            FloatVector3 v2(1.5f, 2.5f, 3.0f);
-            float fsum = VectorSum(v2);
-            Assert::IsTrue(AlmostZero(fsum - 7.0f));
-        }
-
-        TEST_METHOD(MatrixScalarMultiplication)
-        {
-            FloatMatrix3x3 m1({
-                {1.0f, 2.0f, 3.0f},
-                {4.0f, 5.0f, 6.0f},
-                {7.0f, 8.0f, 9.0f}
-            });
-
-            auto m2 = m1 * 2.0f;
-            auto m3 = 2.0f * m1;
-            
-            FloatMatrix3x3 expected({
-                {2.0f, 4.0f, 6.0f},
-                {8.0f, 10.0f, 12.0f},
-                {14.0f, 16.0f, 18.0f}
-            });
-
-            Assert::IsTrue(AlmostEqual(m2, expected));
-            Assert::IsTrue(AlmostEqual(m3, expected));
-        }
-
-        TEST_METHOD(AllRotationMatrixOrders)
-        {
-            float angleX = float(g_PI) / 6.0f;  // 30 degrees
-            float angleY = float(g_PI) / 4.0f;  // 45 degrees
-            float angleZ = float(g_PI) / 3.0f;  // 60 degrees
-
-            // Test XYZRotationMatrix
-            auto mXYZ = XYZRotationMatrix(angleX, angleY, angleZ);
-            auto mXYZ_manual = ZRotationMatrix(angleZ) * YRotationMatrix(angleY) * XRotationMatrix(angleX);
-            Assert::IsTrue(AlmostEqual(mXYZ, mXYZ_manual));
-
-            // Test XZYRotationMatrix
-            auto mXZY = XZYRotationMatrix(angleX, angleZ, angleY);
-            auto mXZY_manual = YRotationMatrix(angleY) * ZRotationMatrix(angleZ) * XRotationMatrix(angleX);
-            Assert::IsTrue(AlmostEqual(mXZY, mXZY_manual));
-
-            // Test YXZRotationMatrix
-            auto mYXZ = YXZRotationMatrix(angleY, angleX, angleZ);
-            auto mYXZ_manual = ZRotationMatrix(angleZ) * XRotationMatrix(angleX) * YRotationMatrix(angleY);
-            Assert::IsTrue(AlmostEqual(mYXZ, mYXZ_manual));
-
-            // Test YZXRotationMatrix
-            auto mYZX = YZXRotationMatrix(angleY, angleZ, angleX);
-            auto mYZX_manual = XRotationMatrix(angleX) * ZRotationMatrix(angleZ) * YRotationMatrix(angleY);
-            Assert::IsTrue(AlmostEqual(mYZX, mYZX_manual));
-
-            // Test ZXYRotationMatrix
-            auto mZXY = ZXYRotationMatrix(angleZ, angleX, angleY);
-            auto mZXY_manual = YRotationMatrix(angleY) * XRotationMatrix(angleX) * ZRotationMatrix(angleZ);
-            Assert::IsTrue(AlmostEqual(mZXY, mZXY_manual));
-
-            // Test ZYXRotationMatrix
-            auto mZYX = ZYXRotationMatrix(angleZ, angleY, angleX);
-            auto mZYX_manual = XRotationMatrix(angleX) * YRotationMatrix(angleY) * ZRotationMatrix(angleZ);
-            Assert::IsTrue(AlmostEqual(mZYX, mZYX_manual));
-        }
-
-        TEST_METHOD(QuaternionFromEulerAngles)
-        {
-            float angleX = float(g_PI) / 6.0f;
-            float angleY = float(g_PI) / 4.0f;
-            float angleZ = float(g_PI) / 3.0f;
-
-            // Test FromEulerXYZ
-            auto qXYZ = FloatQuaternion::FromEulerXYZ(angleX, angleY, angleZ);
-            auto mXYZ = XYZRotationMatrix(angleX, angleY, angleZ);
-            auto mFromQuat = QuaternionToRotationMatrix(qXYZ);
-            Assert::IsTrue(AlmostEqual(mXYZ, mFromQuat));
-
-            // Test FromEulerXZY
-            auto qXZY = FloatQuaternion::FromEulerXZY(angleX, angleZ, angleY);
-            auto mXZY = XZYRotationMatrix(angleX, angleZ, angleY);
-            mFromQuat = QuaternionToRotationMatrix(qXZY);
-            Assert::IsTrue(AlmostEqual(mXZY, mFromQuat));
-
-            // Test FromEulerYXZ
-            auto qYXZ = FloatQuaternion::FromEulerYXZ(angleY, angleX, angleZ);
-            auto mYXZ = YXZRotationMatrix(angleY, angleX, angleZ);
-            mFromQuat = QuaternionToRotationMatrix(qYXZ);
-            Assert::IsTrue(AlmostEqual(mYXZ, mFromQuat));
-
-            // Test FromEulerYZX
-            auto qYZX = FloatQuaternion::FromEulerYZX(angleY, angleZ, angleX);
-            auto mYZX = YZXRotationMatrix(angleY, angleZ, angleX);
-            mFromQuat = QuaternionToRotationMatrix(qYZX);
-            Assert::IsTrue(AlmostEqual(mYZX, mFromQuat));
-
-            // Test FromEulerZXY
-            auto qZXY = FloatQuaternion::FromEulerZXY(angleZ, angleX, angleY);
-            auto mZXY = ZXYRotationMatrix(angleZ, angleX, angleY);
-            mFromQuat = QuaternionToRotationMatrix(qZXY);
-            Assert::IsTrue(AlmostEqual(mZXY, mFromQuat));
-
-            // Test FromEulerZYX
-            auto qZYX = FloatQuaternion::FromEulerZYX(angleZ, angleY, angleX);
-            auto mZYX = ZYXRotationMatrix(angleZ, angleY, angleX);
-            mFromQuat = QuaternionToRotationMatrix(qZYX);
-            Assert::IsTrue(AlmostEqual(mZYX, mFromQuat));
-        }
-
-        TEST_METHOD(QuaternionScaledAxisAngle)
-        {
-            // Test round-trip conversion
-            FloatVector3 axis1(1.0f, 0.0f, 0.0f);
-            float angle1 = float(g_PI) / 4.0f;
-            FloatVector3 scaledAxis1(axis1.X * angle1, axis1.Y * angle1, axis1.Z * angle1);
-            
-            auto q1 = FloatQuaternion::FromScaledAxisAngle(scaledAxis1);
-            auto result1 = q1.ToScaledAxisAngle();
-            Assert::IsTrue(AlmostEqual(scaledAxis1, result1));
-
-            // Test with arbitrary axis
-            FloatVector3 axis2(1.0f, 2.0f, 3.0f);
-            float angle2 = float(g_PI) / 3.0f;
-            float len = std::sqrt(axis2.X * axis2.X + axis2.Y * axis2.Y + axis2.Z * axis2.Z);
-            axis2 = axis2 * (1.0f / len); // normalize
-            FloatVector3 scaledAxis2(axis2.X * angle2, axis2.Y * angle2, axis2.Z * angle2);
-            
-            auto q2 = FloatQuaternion::FromScaledAxisAngle(scaledAxis2);
-            auto result2 = q2.ToScaledAxisAngle();
-            Assert::IsTrue(AlmostEqual(scaledAxis2, result2));
-
-            // Test zero rotation
-            FloatVector3 scaledAxis3(0.0f, 0.0f, 0.0f);
-            auto q3 = FloatQuaternion::FromScaledAxisAngle(scaledAxis3);
-            Assert::IsTrue(AlmostEqual(q3, IdentityQuaternion<float>()));
-        }
-
-        TEST_METHOD(QuaternionMultiplication)
-        {
-            // Test that quaternion multiplication follows the expected composition
-            float angle1 = float(g_PI) / 4.0f;
-            float angle2 = float(g_PI) / 3.0f;
-            
-            auto qX = FloatQuaternion::FromEulerXYZ(angle1, 0.0f, 0.0f);
-            auto qY = FloatQuaternion::FromEulerXYZ(0.0f, angle2, 0.0f);
-            
-            // Quaternion multiplication
-            auto qResult = qY * qX;
-            
-            // Equivalent matrix multiplication
-            auto mX = XRotationMatrix(angle1);
-            auto mY = YRotationMatrix(angle2);
-            auto mResult = mY * mX;
-            
-            // Convert quaternion result to matrix
-            auto mFromQuat = QuaternionToRotationMatrix(qResult);
-            
-            Assert::IsTrue(AlmostEqual(mResult, mFromQuat));
-
-            // Test identity property
-            auto qIdentity = IdentityQuaternion<float>();
-            auto qTest = FloatQuaternion::FromEulerXYZ(0.1f, 0.2f, 0.3f);
-            auto qResult1 = qIdentity * qTest;
-            auto qResult2 = qTest * qIdentity;
-            Assert::IsTrue(AlmostEqual(qTest, qResult1));
-            Assert::IsTrue(AlmostEqual(qTest, qResult2));
-        }
-
-        TEST_METHOD(QuaternionRotateVector)
-        {
-            // Create a 90-degree rotation about the Z-axis
-            float angle = float(g_PI) / 2.0f;
-            auto qZ = FloatQuaternion::FromEulerXYZ(0.0f, 0.0f, angle);
-            
-            // Rotate a vector using quaternion multiplication: q * v * q*
-            FloatVector4 v1(1.0f, 0.0f, 0.0f, 0.0f);
-            FloatQuaternion vQuat1(v1.X, v1.Y, v1.Z, 0.0f);
-            auto qConj = Conjugate(qZ);
-            auto rotated = qZ * vQuat1 * qConj;
-            
-            // Should point along Y-axis
-            Assert::IsTrue(AlmostEqual(rotated, FloatVector4(0.0f, 1.0f, 0.0f, 0.0f)));
-
-            // Test 90-degree rotation about X-axis
-            auto qX = FloatQuaternion::FromEulerXYZ(angle, 0.0f, 0.0f);
-            FloatVector4 v2(0.0f, 1.0f, 0.0f, 0.0f);
-            FloatQuaternion vQuat2(v2.X, v2.Y, v2.Z, 0.0f);
-            auto qConjX = Conjugate(qX);
-            auto rotated2 = qX * vQuat2 * qConjX;
-            
-            // Should point along Z-axis
-            Assert::IsTrue(AlmostEqual(rotated2, FloatVector4(0.0f, 0.0f, 1.0f, 0.0f)));
-        }
-
-        TEST_METHOD(CrossProductFloatVector4)
-        {
-            // Test the specialized FloatVector4 cross product
-            FloatVector4 a(1.0f, 0.0f, 0.0f, 0.0f);
-            FloatVector4 b(0.0f, 1.0f, 0.0f, 0.0f);
-            
-            auto c = CrossProduct(a, b);
-            Assert::IsTrue(AlmostEqual(c, FloatVector4(0.0f, 0.0f, 1.0f, 0.0f)));
-
-            // Test arbitrary vectors
-            FloatVector4 v1(2.0f, 3.0f, 4.0f, 0.0f);
-            FloatVector4 v2(5.0f, 6.0f, 7.0f, 0.0f);
-            auto v3 = CrossProduct(v1, v2);
-            
-            // Cross product formula: (a.y*b.z - a.z*b.y, a.z*b.x - a.x*b.z, a.x*b.y - a.y*b.x)
-            FloatVector4 expected(3.0f*7.0f - 4.0f*6.0f, 4.0f*5.0f - 2.0f*7.0f, 2.0f*6.0f - 3.0f*5.0f, 0.0f);
-            Assert::IsTrue(AlmostEqual(v3, expected));
-        }
-
-        TEST_METHOD(AABBTests)
-        {
-            // Default-constructed AABB is the canonical empty (FLT_MAX
-            // inside-out sentinel) used as the aggregation starting point.
-            AABB box1;
-            Assert::IsTrue(box1.IsEmpty());
-            Assert::IsTrue(box1.IsValid());   // empty is intentional, not malformed
-
-            // A constructor with explicit min<=max produces a non-empty,
-            // valid box.
-            AABB box2(FloatVector4(0.0f, 0.0f, 0.0f, 0.0f), FloatVector4(1.0f, 1.0f, 1.0f, 0.0f));
-            Assert::IsFalse(box2.IsEmpty());
-            Assert::IsTrue(box2.IsValid());
-
-            // Test center and extents
-            auto center = box2.GetCenter();
-            auto extents = box2.GetExtents();
-            Assert::IsTrue(AlmostEqual(center, FloatVector4(0.5f, 0.5f, 0.5f, 0.0f)));
-            Assert::IsTrue(AlmostEqual(extents, FloatVector4(0.5f, 0.5f, 0.5f, 0.0f)));
-
-            // Single-point ExpandToInclude on an empty AABB collapses to a
-            // degenerate (zero-volume) AABB at that point -- non-empty,
-            // and well-formed because min == max.
-            AABB box3;
-            box3.ExpandToInclude(FloatVector4(1.0f, 2.0f, 3.0f, 0.0f));
-            Assert::IsFalse(box3.IsEmpty());
-            Assert::IsTrue(box3.IsValid());
-            Assert::IsTrue(AlmostEqual(box3.Min, FloatVector4(1.0f, 2.0f, 3.0f, 0.0f)));
-            Assert::IsTrue(AlmostEqual(box3.Max, FloatVector4(1.0f, 2.0f, 3.0f, 0.0f)));
-            box3.ExpandToInclude(FloatVector4(4.0f, 5.0f, 6.0f, 0.0f));
-            Assert::IsTrue(AlmostEqual(box3.Min, FloatVector4(1.0f, 2.0f, 3.0f, 0.0f)));
-            Assert::IsTrue(AlmostEqual(box3.Max, FloatVector4(4.0f, 5.0f, 6.0f, 0.0f)));
-
-            // Test ExpandToInclude with another AABB
-            AABB box4(FloatVector4(0.0f, 0.0f, 0.0f, 0.0f), FloatVector4(2.0f, 2.0f, 2.0f, 0.0f));
-            AABB box5(FloatVector4(1.0f, 1.0f, 1.0f, 0.0f), FloatVector4(3.0f, 3.0f, 3.0f, 0.0f));
-            box4.ExpandToInclude(box5);
-            Assert::IsTrue(AlmostEqual(box4.Min, FloatVector4(0.0f, 0.0f, 0.0f, 0.0f)));
-            Assert::IsTrue(AlmostEqual(box4.Max, FloatVector4(3.0f, 3.0f, 3.0f, 0.0f)));
-
-            // Reset restores the canonical empty sentinel.
-            box4.Reset();
-            Assert::IsTrue(box4.IsEmpty());
-            Assert::IsTrue(box4.IsValid());
-        }
-
-        TEST_METHOD(AABBInsideOutNonSentinelIsInvalidNotEmpty)
-        {
-            // An AABB that is inside-out in some axis but is NOT the
-            // canonical FLT_MAX sentinel is INVALID -- not empty.
-            // Treating it as empty would mask a construction-side bug
-            // and cause aggregation to silently skip it.
-            AABB box(FloatVector4(0.0f, 5.0f, 0.0f, 0.0f),
-                     FloatVector4(10.0f, 2.0f, 10.0f, 0.0f));  // Y inside-out
-            Assert::IsFalse(box.IsEmpty());
-            Assert::IsFalse(box.IsValid());
-
-            // Mixed: partially sentinel values are still not the canonical
-            // empty.  Only the exact FLT_MAX sentinel counts as empty.
-            AABB partial(FloatVector4(FLT_MAX, 0.0f, FLT_MAX, 0.0f),
-                         FloatVector4(-FLT_MAX, 1.0f, -FLT_MAX, 0.0f));
-            Assert::IsFalse(partial.IsEmpty());
-            Assert::IsFalse(partial.IsValid());
-        }
-
-        TEST_METHOD(AABBTransformIdentity)
-        {
-            // Identity matrix leaves the AABB unchanged.
-            AABB box(FloatVector4(-1.0f, -2.0f, -3.0f, 0.0f),
-                     FloatVector4( 1.0f,  2.0f,  3.0f, 0.0f));
-            auto result = box.Transform(FloatMatrix4x4::Identity());
-            Assert::IsTrue(AlmostEqual(result.Min, box.Min));
-            Assert::IsTrue(AlmostEqual(result.Max, box.Max));
-        }
-
-        TEST_METHOD(AABBTransformTranslation)
-        {
-            // Pure translation shifts both Min and Max equally.
-            AABB box(FloatVector4(-1.0f, -1.0f, -1.0f, 0.0f),
-                     FloatVector4( 1.0f,  1.0f,  1.0f, 0.0f));
-            FloatMatrix4x4 m = FloatMatrix4x4::Identity();
-            m[3][0] = 10.0f;
-            m[3][1] = 20.0f;
-            m[3][2] = 30.0f;
-            auto result = box.Transform(m);
-            Assert::IsTrue(AlmostEqual(result.Min, FloatVector4( 9.0f, 19.0f, 29.0f, 0.0f)));
-            Assert::IsTrue(AlmostEqual(result.Max, FloatVector4(11.0f, 21.0f, 31.0f, 0.0f)));
-        }
-
-        TEST_METHOD(AABBTransformRotation)
-        {
-            // 90-degree rotation around Z (row-vector convention: row 0 ->
-            // becomes +Y, row 1 -> becomes -X) of a non-square box.
-            // After rotation:  X extent <- old Y extent, Y extent <- old X extent.
-            AABB box(FloatVector4(-2.0f, -1.0f, -0.5f, 0.0f),
-                     FloatVector4( 2.0f,  1.0f,  0.5f, 0.0f));
-            FloatMatrix4x4 m = FloatMatrix4x4::Identity();
-            m[0][0] =  0.0f; m[0][1] =  1.0f;
-            m[1][0] = -1.0f; m[1][1] =  0.0f;
-            auto result = box.Transform(m);
-            Assert::IsTrue(AlmostEqual(result.Min, FloatVector4(-1.0f, -2.0f, -0.5f, 0.0f)));
-            Assert::IsTrue(AlmostEqual(result.Max, FloatVector4( 1.0f,  2.0f,  0.5f, 0.0f)));
-        }
-
-        TEST_METHOD(AABBTransformEmptyPropagates)
-        {
-            // Transforming an empty AABB returns the same empty AABB.
-            AABB box;
-            Assert::IsTrue(box.IsEmpty());
-            auto result = box.Transform(FloatMatrix4x4::Identity());
-            Assert::IsTrue(result.IsEmpty());
-        }
-
-        TEST_METHOD(QuaternionNormalize)
-        {
-            // Test that normalize works correctly
-            FloatQuaternion q1(0.5f, 0.5f, 0.5f, 0.5f);
-            auto qn = q1.Normalize();
-            
-            // Should be unit length
-            float len = DotProduct(qn, qn);
-            Assert::IsTrue(AlmostZero(len - 1.0f));
-
-            // Test already normalized quaternion
-            auto qIdentity = IdentityQuaternion<float>();
-            auto qIdentityNorm = qIdentity.Normalize();
-            Assert::IsTrue(AlmostEqual(qIdentity, qIdentityNorm));
-        }
-
-        TEST_METHOD(QuaternionConjugate)
-        {
-            FloatQuaternion q(0.1f, 0.2f, 0.3f, 0.9f);
-            auto qConj = Conjugate(q);
-            
-            Assert::IsTrue(AlmostEqual(qConj, FloatQuaternion(-0.1f, -0.2f, -0.3f, 0.9f)));
-
-            // Test that q * conjugate(q) = identity for unit quaternions
-            auto qNorm = q.Normalize();
-            auto qConjNorm = Conjugate(qNorm);
-            auto result = qNorm * qConjNorm;
-            Assert::IsTrue(AlmostEqual(result, IdentityQuaternion<float>()));
-        }
-
-        TEST_METHOD(VectorMatrixMultiplication)
-        {
-            // Test vector * matrix (row vector)
-            FloatVector3 v(1.0f, 2.0f, 3.0f);
-            FloatMatrix3x3 m({
-                {1.0f, 0.0f, 0.0f},
-                {0.0f, 2.0f, 0.0f},
-                {0.0f, 0.0f, 3.0f}
-            });
-            
-            auto result = v * m;
-            Assert::IsTrue(AlmostEqual(result, FloatVector3(1.0f, 4.0f, 9.0f)));
-
-            // Test matrix * vector (column vector)
-            auto result2 = m * v;
-            Assert::IsTrue(AlmostEqual(result2, FloatVector3(1.0f, 4.0f, 9.0f)));
-        }
-
-        TEST_METHOD(MatrixIdentity)
-        {
-            // Test static Identity() method
-            auto m2 = FloatMatrix2x2::Identity();
-            Assert::AreEqual(1.0f, m2[0][0]);
-            Assert::AreEqual(0.0f, m2[0][1]);
-            Assert::AreEqual(0.0f, m2[1][0]);
-            Assert::AreEqual(1.0f, m2[1][1]);
-
-            auto m3 = FloatMatrix3x3::Identity();
-            Assert::IsTrue(AlmostEqual(m3, IdentityMatrix<float, 3, 3>()));
-
-            auto m4 = FloatMatrix4x4::Identity();
-            Assert::IsTrue(AlmostEqual(m4, IdentityMatrix<float, 4, 4>()));
-        }
-
-        TEST_METHOD(PerspectiveReverseZBasic)
-        {
-            // Test basic reverse-Z perspective matrix properties.
-            // View space: +X=right, +Y=up, +Z=forward (D3D LHS, standard).
-            // Row-vector layout: [x_v, y_v, z_v, 1] * M = [x_c, y_c, z_c, w_c].
-            float fovY = static_cast<float>(g_PI / 4.0);  // 45 degrees
-            float aspect = 16.0f / 9.0f;
-            float nearPlane = 0.1f;
-            float farPlane = 1000.0f;
-
-            auto proj = PerspectiveReverseZ(fovY, aspect, nearPlane, farPlane);
-
-            // Non-zero elements per the canonical D3D LHS perspective layout.
-            Assert::IsTrue(proj[0][0] != 0.0f);  // X(right)   -> X_clip scaling (f/aspect)
-            Assert::IsTrue(proj[1][1] != 0.0f);  // Y(up)      -> Y_clip scaling (f)
-            Assert::IsTrue(proj[2][2] != 0.0f);  // Z(forward) -> Z_clip depth
-            Assert::IsTrue(proj[2][3] == 1.0f);  // Z(forward) -> W_clip (perspective divide)
-
-            // Verify f = cot(fovY/2)
-            float f = 1.0f / std::tan(fovY * 0.5f);
-            Assert::IsTrue(std::abs(proj[0][0] - (f / aspect)) < FLT_EPSILON);
-            Assert::IsTrue(std::abs(proj[1][1] - f) < FLT_EPSILON);
-        }
-
-        TEST_METHOD(PerspectiveReverseZDepthMapping)
-        {
-            // Test reverse-Z perspective matrix generates correct depth coefficients.
-            // View space: +X=right, +Y=up, +Z=forward.
-            float fovY = static_cast<float>(g_PI / 4.0);
-            float aspect = 16.0f / 9.0f;
-            float nearPlane = 0.1f;
-            float farPlane = 1000.0f;
-
-            auto proj = PerspectiveReverseZ(fovY, aspect, nearPlane, farPlane);
-
-            // Row-vector: M[2][2] = A (forward -> z_clip), M[3][2] = B (depth bias).
-            Assert::IsTrue(proj[2][2] != 0.0f);
-            Assert::IsTrue(proj[3][2] != 0.0f);
-
-            // A = nearPlane / (nearPlane - farPlane)
-            // B = -(nearPlane * farPlane) / (nearPlane - farPlane)
-            float rangeInv = 1.0f / (nearPlane - farPlane);
-            Assert::IsTrue(std::abs(proj[2][2] - nearPlane * rangeInv) < FLT_EPSILON);
-            Assert::IsTrue(std::abs(proj[3][2] - (-(nearPlane * farPlane * rangeInv))) < FLT_EPSILON);
-
-            // Verify depth mapping: ndc_z = (A*z + B) / z where z = forward distance.
-            // At near plane (z=near): ndc_z should be 1.0
-            float A = proj[2][2];
-            float B = proj[3][2];
-            float ndc_near = (A * nearPlane + B) / nearPlane;
-            Assert::IsTrue(std::abs(ndc_near - 1.0f) < 1e-5f);
-            // At far plane (z=far): ndc_z should be 0.0
-            float ndc_far = (A * farPlane + B) / farPlane;
-            Assert::IsTrue(std::abs(ndc_far - 0.0f) < 1e-5f);
-        }
-
-        TEST_METHOD(PerspectiveReverseZCoordinateTransform)
-        {
-            // Test coordinate system transformation: X_v(right)->X_clip,
-            // Y_v(up)->Y_clip, Z_v(forward)->Z_clip + W_clip.
-            float fovY = static_cast<float>(g_PI / 4.0);
-            float aspect = 1.0f;
-            float nearPlane = 1.0f;
-            float farPlane = 10.0f;
-
-            auto proj = PerspectiveReverseZ(fovY, aspect, nearPlane, farPlane);
-
-            float f = 1.0f / std::tan(fovY * 0.5f);
-
-            // Row-vector: M[0][0] = f/a (right -> x_clip), M[1][1] = f (up -> y_clip).
-            Assert::IsTrue(std::abs(proj[0][0] - f) < 1e-5f);  // aspect=1
-            Assert::IsTrue(std::abs(proj[1][1] - f) < 1e-5f);
-
-            // Perspective divide: M[2][3] = 1 (forward -> w_clip), M[3][3] = 0.
-            Assert::IsTrue(std::abs(proj[2][3] - 1.0f) < 1e-5f);  // w_clip = z_view
-            Assert::IsTrue(std::abs(proj[3][3] - 0.0f) < 1e-5f);
-        }
-
-        TEST_METHOD(PerspectiveForwardZBasic)
-        {
-            // Test basic forward-Z perspective matrix properties.
-            // View space: +X=right, +Y=up, +Z=forward.
-            float fovY = static_cast<float>(g_PI / 4.0);
-            float aspect = 16.0f / 9.0f;
-            float nearPlane = 0.1f;
-            float farPlane = 1000.0f;
-
-            auto proj = PerspectiveForwardZ(fovY, aspect, nearPlane, farPlane);
-
-            // Row-vector: M[i][j] maps input axis i to output axis j.
-            Assert::IsTrue(proj[0][0] != 0.0f);  // X(right)   -> X_clip
-            Assert::IsTrue(proj[1][1] != 0.0f);  // Y(up)      -> Y_clip
-            Assert::IsTrue(proj[2][2] != 0.0f);  // Z(forward) -> Z_clip
-            Assert::IsTrue(proj[2][3] == 1.0f);  // Z(forward) -> W_clip
-
-            // Verify f = cot(fovY/2)
-            float f = 1.0f / std::tan(fovY * 0.5f);
-            Assert::IsTrue(std::abs(proj[0][0] - (f / aspect)) < FLT_EPSILON);
-            Assert::IsTrue(std::abs(proj[1][1] - f) < FLT_EPSILON);
-        }
-
-        TEST_METHOD(PerspectiveForwardZDepthMapping)
-        {
-            // Test forward-Z perspective matrix generates correct depth coefficients.
-            float fovY = static_cast<float>(g_PI / 4.0);
-            float aspect = 16.0f / 9.0f;
-            float nearPlane = 0.1f;
-            float farPlane = 1000.0f;
-
-            auto proj = PerspectiveForwardZ(fovY, aspect, nearPlane, farPlane);
-
-            // Row-vector: M[2][2] = A (forward -> z_clip), M[3][2] = B (depth bias).
-            Assert::IsTrue(proj[2][2] != 0.0f);
-            Assert::IsTrue(proj[3][2] != 0.0f);
-
-            // A = farPlane / (farPlane - nearPlane)
-            // B = -(nearPlane * farPlane) / (farPlane - nearPlane)
-            float rangeInv = 1.0f / (farPlane - nearPlane);
-            Assert::IsTrue(std::abs(proj[2][2] - farPlane * rangeInv) < FLT_EPSILON);
-            Assert::IsTrue(std::abs(proj[3][2] + nearPlane * farPlane * rangeInv) < FLT_EPSILON);
-
-            // Verify depth mapping: ndc_z = (A*z + B) / z.
-            // At near plane: ndc_z should be 0.0
-            float A = proj[2][2];
-            float B = proj[3][2];
-            float ndc_near = (A * nearPlane + B) / nearPlane;
-            Assert::IsTrue(std::abs(ndc_near - 0.0f) < 1e-5f);
-            // At far plane: ndc_z should be 1.0
-            float ndc_far = (A * farPlane + B) / farPlane;
-            Assert::IsTrue(std::abs(ndc_far - 1.0f) < 1e-5f);
-        }
-
-        TEST_METHOD(PerspectiveForwardZCoordinateTransform)
-        {
-            // Test coordinate system transformation for forward-Z.
-            // X_v(right)->X_clip, Y_v(up)->Y_clip, Z_v(forward)->Z/W_clip.
-            float fovY = static_cast<float>(g_PI / 4.0);
-            float aspect = 1.0f;
-            float nearPlane = 1.0f;
-            float farPlane = 10.0f;
-
-            auto proj = PerspectiveForwardZ(fovY, aspect, nearPlane, farPlane);
-
-            float f = 1.0f / std::tan(fovY * 0.5f);
-
-            // Row-vector: M[0][0] = f/a (right -> x_clip), M[1][1] = f (up -> y_clip).
-            Assert::IsTrue(std::abs(proj[0][0] - f) < 1e-5f);
-            Assert::IsTrue(std::abs(proj[1][1] - f) < 1e-5f);
-
-            // Perspective divide: M[2][3] = 1 (forward -> w_clip).
-            Assert::IsTrue(std::abs(proj[2][3] - 1.0f) < 1e-5f);  // w_clip = z_view
-            Assert::IsTrue(std::abs(proj[3][3] - 0.0f) < 1e-5f);  // no constant contribution to w_clip
-        }
-
-        TEST_METHOD(PerspectiveReverseZVsForwardZDifference)
-        {
-            // Verify both reverse-Z and forward-Z functions create valid projection matrices.
-            // View space: +X=right, +Y=up, +Z=forward.
-            float fovY = static_cast<float>(g_PI / 4.0);
-            float aspect = 1.0f;
-            float nearPlane = 1.0f;
-            float farPlane = 10.0f;
-
-            auto projRZ = PerspectiveReverseZ(fovY, aspect, nearPlane, farPlane);
-            auto projFZ = PerspectiveForwardZ(fovY, aspect, nearPlane, farPlane);
-
-            float f = 1.0f / std::tan(fovY * 0.5f);
-
-            // Both should have identical FOV and perspective setup (row-vector layout).
-            Assert::IsTrue(std::abs(projRZ[0][0] - f) < 1e-5f);  // X(right) -> X_clip
-            Assert::IsTrue(std::abs(projRZ[1][1] - f) < 1e-5f);  // Y(up)    -> Y_clip
-            Assert::IsTrue(std::abs(projFZ[0][0] - f) < 1e-5f);
-            Assert::IsTrue(std::abs(projFZ[1][1] - f) < 1e-5f);
-
-            // Verify perspective divide is correctly set for both.
-            Assert::IsTrue(std::abs(projRZ[2][3] - 1.0f) < 1e-5f);  // w_clip = z_view
-            Assert::IsTrue(std::abs(projFZ[2][3] - 1.0f) < 1e-5f);
-            Assert::IsTrue(std::abs(projRZ[3][3] - 0.0f) < 1e-5f);
-            Assert::IsTrue(projFZ[3][3] == 0.0f);
-
-            // Depth coefficients differ: reverse-Z and forward-Z must produce
-            // different A and B values (otherwise they are the same mapping).
-            Assert::IsTrue(std::abs(projRZ[2][2] - projFZ[2][2]) > 1e-5f);
-            Assert::IsTrue(std::abs(projRZ[3][2] - projFZ[3][2]) > 1e-5f);
-        }
-
-        TEST_METHOD(OrthoReverseZDepthMapping)
-        {
-            // Verify that the reverse-Z ortho helper maps zNear -> 1 and
-            // zFar -> 0 in clip space, matching the engine's reverse-Z
-            // convention used by perspective projections and the
-            // GREATER_EQUAL depth test.  View-space convention is LHS
-            // (X=right, Y=up, Z=forward); row vectors throughout.
-            const float halfW   = 100.0f;
-            const float halfH   = 50.0f;
-            const float zNear   = 1.0f;
-            const float zFar    = 200.0f;
-
-            auto proj = OrthoReverseZ(halfW, halfH, zNear, zFar);
-
-            // Ortho has no perspective divide: row 3 column 3 is the
-            // identity-affine 1, row 2 column 3 must be 0 so w_clip
-            // equals 1 for every input.
-            Assert::IsTrue(std::abs(proj[3][3] - 1.0f) < FLT_EPSILON);
-            Assert::IsTrue(std::abs(proj[2][3] - 0.0f) < FLT_EPSILON);
-
-            // XY scaling: 1/halfWidth, 1/halfHeight.
-            Assert::IsTrue(std::abs(proj[0][0] - (1.0f / halfW)) < FLT_EPSILON);
-            Assert::IsTrue(std::abs(proj[1][1] - (1.0f / halfH)) < FLT_EPSILON);
-
-            // Pump a point at the near plane through the matrix and
-            // verify ndc_z = 1.0.  At z=zNear: clip_z = -zNear/(zFar-zNear)
-            // + zFar/(zFar-zNear) = (zFar - zNear) / (zFar - zNear) = 1.
-            FloatVector4 ptNear(0.0f, 0.0f, zNear, 1.0f);
-            FloatVector4 clipNear = ptNear * proj;
-            Assert::IsTrue(std::abs(clipNear.W - 1.0f) < 1e-5f);
-            Assert::IsTrue(std::abs(clipNear.Z / clipNear.W - 1.0f) < 1e-5f);
-
-            // Same at the far plane: ndc_z = 0.
-            FloatVector4 ptFar(0.0f, 0.0f, zFar, 1.0f);
-            FloatVector4 clipFar = ptFar * proj;
-            Assert::IsTrue(std::abs(clipFar.W - 1.0f) < 1e-5f);
-            Assert::IsTrue(std::abs(clipFar.Z / clipFar.W - 0.0f) < 1e-5f);
-        }
-
-        TEST_METHOD(OrthoReverseZXYExtents)
-        {
-            // Verify points at the +/- box extents map to +/- 1 in NDC.
-            const float halfW = 20.0f;
-            const float halfH = 10.0f;
-            const float zNear = 0.5f;
-            const float zFar  = 100.0f;
-
-            auto proj = OrthoReverseZ(halfW, halfH, zNear, zFar);
-
-            // +halfWidth on x -> +1 in NDC x.
-            FloatVector4 pX(halfW, 0.0f, zNear, 1.0f);
-            FloatVector4 cX = pX * proj;
-            Assert::IsTrue(std::abs(cX.X - 1.0f) < 1e-5f);
-            Assert::IsTrue(std::abs(cX.Y - 0.0f) < 1e-5f);
-
-            // -halfHeight on y -> -1 in NDC y.
-            FloatVector4 pY(0.0f, -halfH, zFar, 1.0f);
-            FloatVector4 cY = pY * proj;
-            Assert::IsTrue(std::abs(cY.X - 0.0f) < 1e-5f);
-            Assert::IsTrue(std::abs(cY.Y - (-1.0f)) < 1e-5f);
-        }
-
-        // ----------------------------------------------------------------
-        // Frustum extraction + AABB intersection tests.
-        //
-        // Camera view space: LHS, +X right, +Y up, +Z forward.  Tests use
-        // view = identity so the projection matrix alone defines the
-        // frustum, letting us reason about points/AABBs directly in view
-        // coordinates without an extra matrix layer to debug.
-        // ----------------------------------------------------------------
-
-        // Reverse-Z perspective is Canvas's default.  These tests pin the
-        // sign convention of FromViewProjection: points truly inside the
-        // view frustum must produce IntersectsAABB == true; points outside
-        // any single plane must produce false.
-        TEST_METHOD(FrustumReverseZPerspectiveInsideOutside)
-        {
-            const float fovY = float(g_PI * 0.5);  // 90 deg
-            const float aspect = 1.0f;
-            const float nearZ = 1.0f;
-            const float farZ  = 100.0f;
-            FloatMatrix4x4 proj = PerspectiveReverseZ<float>(fovY, aspect, nearZ, farZ);
-            Frustum f = Frustum::FromViewProjection(proj, /*reverseZ*/ true);
-
-            auto pointAABB = [](float x, float y, float z) {
-                FloatVector4 p(x, y, z, 0.0f);
-                return AABB(p, p);
-            };
-
-            // Squarely inside.
-            Assert::IsTrue(f.IntersectsAABB(pointAABB(0.0f, 0.0f, 10.0f)));
-
-            // Behind the near plane (z < nearZ): outside near.
-            Assert::IsFalse(f.IntersectsAABB(pointAABB(0.0f, 0.0f, 0.5f)));
-
-            // Behind the camera entirely.
-            Assert::IsFalse(f.IntersectsAABB(pointAABB(0.0f, 0.0f, -10.0f)));
-
-            // Beyond the far plane.
-            Assert::IsFalse(f.IntersectsAABB(pointAABB(0.0f, 0.0f, 200.0f)));
-
-            // Off to the right past the 90-deg side plane (x > z at z=10).
-            Assert::IsFalse(f.IntersectsAABB(pointAABB(50.0f, 0.0f, 10.0f)));
-
-            // Above the top plane (y > z at z=10 for 90deg fov).
-            Assert::IsFalse(f.IntersectsAABB(pointAABB(0.0f, 50.0f, 10.0f)));
-
-            // AABB straddling the near plane: must overlap.
-            AABB straddleNear(FloatVector4(-0.5f, -0.5f, 0.5f, 0.0f),
-                              FloatVector4( 0.5f,  0.5f, 2.0f, 0.0f));
-            Assert::IsTrue(f.IntersectsAABB(straddleNear));
-
-            // Large AABB enclosing the camera: positive-vertex test is
-            // conservative and accepts this (every plane has SOME corner
-            // on the inside).  Documents the known false-positive regime.
-            AABB enclosing(FloatVector4(-1000.0f, -1000.0f, -1000.0f, 0.0f),
-                           FloatVector4( 1000.0f,  1000.0f,  1000.0f, 0.0f));
-            Assert::IsTrue(f.IntersectsAABB(enclosing));
-
-            // Empty AABB: never intersects.
-            Assert::IsFalse(f.IntersectsAABB(AABB{}));
-        }
-
-        // Forward-Z swap: only Near/Far plane assignment differs.  Same
-        // points should yield the same inside/outside verdicts because
-        // both extractions describe the same world-space frustum.
-        TEST_METHOD(FrustumForwardZPerspectiveAgreesWithReverseZ)
-        {
-            const float fovY = float(g_PI * 0.5);
-            const float aspect = 16.0f / 9.0f;
-            const float nearZ = 0.5f;
-            const float farZ  = 50.0f;
-
-            Frustum fRev = Frustum::FromViewProjection(
-                PerspectiveReverseZ<float>(fovY, aspect, nearZ, farZ), true);
-            Frustum fFwd = Frustum::FromViewProjection(
-                PerspectiveForwardZ<float>(fovY, aspect, nearZ, farZ), false);
-
-            const FloatVector4 inside (0.0f, 0.0f, 10.0f, 0.0f);
-            const FloatVector4 tooNear(0.0f, 0.0f,  0.1f, 0.0f);
-            const FloatVector4 tooFar (0.0f, 0.0f, 99.0f, 0.0f);
-
-            AABB bIn (inside,  inside);
-            AABB bN  (tooNear, tooNear);
-            AABB bF  (tooFar,  tooFar);
-
-            Assert::AreEqual(fRev.IntersectsAABB(bIn), fFwd.IntersectsAABB(bIn));
-            Assert::AreEqual(fRev.IntersectsAABB(bN),  fFwd.IntersectsAABB(bN));
-            Assert::AreEqual(fRev.IntersectsAABB(bF),  fFwd.IntersectsAABB(bF));
-
-            Assert::IsTrue (fRev.IntersectsAABB(bIn));
-            Assert::IsFalse(fRev.IntersectsAABB(bN));
-            Assert::IsFalse(fRev.IntersectsAABB(bF));
-        }
-	};
 }

--- a/src/CanvasUnitTest/CanvasTextTest.cpp
+++ b/src/CanvasUnitTest/CanvasTextTest.cpp
@@ -7,8 +7,6 @@
 //================================================================================================
 
 #include "pch.h"
-#include "CppUnitTest.h"
-
 // Internal CanvasText headers (unit tests are allowed to use these)
 #include <fstream>
 #include "Font.h"
@@ -21,7 +19,6 @@
 // Must match the font the app actually loads (segoeui.ttf, with arial.ttf as fallback).
 static constexpr const wchar_t* kSystemFontPath = L"C:\\Windows\\Fonts\\segoeui.ttf";
 
-using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 using namespace Canvas;
 
 namespace CanvasUnitTest
@@ -63,440 +60,412 @@ static GlyphOutline MakeSquareOutline(float side = 500.0f)
 }
 
 //================================================================================================
-TEST_CLASS(TextUTF8DecodeTest)
+TEST(TextUTF8DecodeTest, EmptyString)
 {
-public:
+    std::vector<uint32_t> codepoints;
+    EXPECT_TRUE(Succeeded(CTextLayout::DecodeUtf8("", codepoints)));
+    EXPECT_EQ((size_t)0, codepoints.size());
+}
 
-    TEST_METHOD(EmptyString)
-    {
-        std::vector<uint32_t> codepoints;
-        Assert::IsTrue(Succeeded(CTextLayout::DecodeUtf8("", codepoints)));
-        Assert::AreEqual((size_t)0, codepoints.size());
-    }
+TEST(TextUTF8DecodeTest, PlainASCII)
+{
+    std::vector<uint32_t> codepoints;
+    EXPECT_TRUE(Succeeded(CTextLayout::DecodeUtf8("Hello", codepoints)));
+    EXPECT_EQ((size_t)5, codepoints.size());
+    EXPECT_EQ((uint32_t)'H', codepoints[0]);
+    EXPECT_EQ((uint32_t)'e', codepoints[1]);
+    EXPECT_EQ((uint32_t)'o', codepoints[4]);
+}
 
-    TEST_METHOD(PlainASCII)
-    {
-        std::vector<uint32_t> codepoints;
-        Assert::IsTrue(Succeeded(CTextLayout::DecodeUtf8("Hello", codepoints)));
-        Assert::AreEqual((size_t)5, codepoints.size());
-        Assert::AreEqual((uint32_t)'H', codepoints[0]);
-        Assert::AreEqual((uint32_t)'e', codepoints[1]);
-        Assert::AreEqual((uint32_t)'o', codepoints[4]);
-    }
+TEST(TextUTF8DecodeTest, SpacePreserved)
+{
+    // Space (0x20) must survive decoding – it was the root cause of the blank-screen bug
+    std::vector<uint32_t> codepoints;
+    EXPECT_TRUE(Succeeded(CTextLayout::DecodeUtf8("A B", codepoints)));
+    EXPECT_EQ((size_t)3, codepoints.size());
+    EXPECT_EQ((uint32_t)' ', codepoints[1]);
+}
 
-    TEST_METHOD(SpacePreserved)
-    {
-        // Space (0x20) must survive decoding – it was the root cause of the blank-screen bug
-        std::vector<uint32_t> codepoints;
-        Assert::IsTrue(Succeeded(CTextLayout::DecodeUtf8("A B", codepoints)));
-        Assert::AreEqual((size_t)3, codepoints.size());
-        Assert::AreEqual((uint32_t)' ', codepoints[1]);
-    }
+TEST(TextUTF8DecodeTest, Newline)
+{
+    std::vector<uint32_t> codepoints;
+    EXPECT_TRUE(Succeeded(CTextLayout::DecodeUtf8("a\nb", codepoints)));
+    EXPECT_EQ((size_t)3, codepoints.size());
+    EXPECT_EQ((uint32_t)'\n', codepoints[1]);
+}
 
-    TEST_METHOD(Newline)
-    {
-        std::vector<uint32_t> codepoints;
-        Assert::IsTrue(Succeeded(CTextLayout::DecodeUtf8("a\nb", codepoints)));
-        Assert::AreEqual((size_t)3, codepoints.size());
-        Assert::AreEqual((uint32_t)'\n', codepoints[1]);
-    }
+TEST(TextUTF8DecodeTest, TwoByteUTF8)
+{
+    // U+00E9 LATIN SMALL LETTER E WITH ACUTE: 0xC3 0xA9
+    const char utf8[] = { '\xC3', '\xA9', '\0' };
+    std::vector<uint32_t> codepoints;
+    EXPECT_TRUE(Succeeded(CTextLayout::DecodeUtf8(utf8, codepoints)));
+    EXPECT_EQ((size_t)1, codepoints.size());
+    EXPECT_EQ((uint32_t)0x00E9u, codepoints[0]);
+}
 
-    TEST_METHOD(TwoByteUTF8)
-    {
-        // U+00E9 LATIN SMALL LETTER E WITH ACUTE: 0xC3 0xA9
-        const char utf8[] = { '\xC3', '\xA9', '\0' };
-        std::vector<uint32_t> codepoints;
-        Assert::IsTrue(Succeeded(CTextLayout::DecodeUtf8(utf8, codepoints)));
-        Assert::AreEqual((size_t)1, codepoints.size());
-        Assert::AreEqual((uint32_t)0x00E9u, codepoints[0]);
-    }
+TEST(TextUTF8DecodeTest, ThreeByteUTF8)
+{
+    // U+4E16 CJK: 0xE4 0xB8 0x96
+    const char utf8[] = { '\xE4', '\xB8', '\x96', '\0' };
+    std::vector<uint32_t> codepoints;
+    EXPECT_TRUE(Succeeded(CTextLayout::DecodeUtf8(utf8, codepoints)));
+    EXPECT_EQ((size_t)1, codepoints.size());
+    EXPECT_EQ((uint32_t)0x4E16u, codepoints[0]);
+}
 
-    TEST_METHOD(ThreeByteUTF8)
-    {
-        // U+4E16 CJK: 0xE4 0xB8 0x96
-        const char utf8[] = { '\xE4', '\xB8', '\x96', '\0' };
-        std::vector<uint32_t> codepoints;
-        Assert::IsTrue(Succeeded(CTextLayout::DecodeUtf8(utf8, codepoints)));
-        Assert::AreEqual((size_t)1, codepoints.size());
-        Assert::AreEqual((uint32_t)0x4E16u, codepoints[0]);
-    }
-
-    TEST_METHOD(MixedASCIIAndMultibyte)
-    {
-        // "Hi" + U+00E9 + "!" → 4 codepoints
-        const char utf8[] = { 'H', 'i', '\xC3', '\xA9', '!', '\0' };
-        std::vector<uint32_t> codepoints;
-        Assert::IsTrue(Succeeded(CTextLayout::DecodeUtf8(utf8, codepoints)));
-        Assert::AreEqual((size_t)4, codepoints.size());
-        Assert::AreEqual((uint32_t)'H',    codepoints[0]);
-        Assert::AreEqual((uint32_t)0x00E9u, codepoints[2]);
-        Assert::AreEqual((uint32_t)'!',    codepoints[3]);
-    }
-};
+TEST(TextUTF8DecodeTest, MixedASCIIAndMultibyte)
+{
+    // "Hi" + U+00E9 + "!" → 4 codepoints
+    const char utf8[] = { 'H', 'i', '\xC3', '\xA9', '!', '\0' };
+    std::vector<uint32_t> codepoints;
+    EXPECT_TRUE(Succeeded(CTextLayout::DecodeUtf8(utf8, codepoints)));
+    EXPECT_EQ((size_t)4, codepoints.size());
+    EXPECT_EQ((uint32_t)'H', codepoints[0]);
+    EXPECT_EQ((uint32_t)0x00E9u, codepoints[2]);
+    EXPECT_EQ((uint32_t)'!', codepoints[3]);
+}
 
 //================================================================================================
-TEST_CLASS(TextLayoutGlyphTest)
+namespace {
+
+// Fabricate an atlas entry for a 40x48 pixel glyph at a known atlas location
+
+static GlyphAtlasEntry MakeEntry(float bw = 40.0f, float bh = 48.0f)
 {
-    // Fabricate an atlas entry for a 40x48 pixel glyph at a known atlas location
-    static GlyphAtlasEntry MakeEntry(float bw = 40.0f, float bh = 48.0f)
+    GlyphAtlasEntry e;
+    e.AdvanceWidth  = 0.5f;   // Normalized (0.5 em)
+    e.LeftBearing   = 2.0f;
+    e.TopBearing    = 4.0f;
+    e.BitmapWidth   = bw;
+    e.BitmapHeight  = bh;
+    e.AtlasU0       = 0.1f;  e.AtlasV0 = 0.2f;
+    e.AtlasU1       = 0.3f;  e.AtlasV1 = 0.4f;
+    return e;
+}
+
+} // anonymous namespace
+
+TEST(TextLayoutGlyphTest, NormalGlyphProduces6Vertices)
+{
+    GlyphAtlasEntry entry = MakeEntry();
+    Math::FloatVector3 pos(10.0f, 20.0f, 0.0f);
+    std::vector<TextVertex> verts;
+
+    CTextLayout::LayoutGlyph(0x41, CTrueTypeFont{}, entry, pos, Math::FloatVector4(1.0f, 1.0f, 1.0f, 1.0f), 1.0f, verts);
+
+    EXPECT_EQ((size_t)6, verts.size());
+}
+
+TEST(TextLayoutGlyphTest, ZeroSizeGlyphProducesNoVertices)
+{
+    // BitmapWidth/Height == 0 → whitespace glyph, no quad should be emitted
+    GlyphAtlasEntry entry = MakeEntry(0.0f, 0.0f);
+    Math::FloatVector3 pos(0.0f, 0.0f, 0.0f);
+    std::vector<TextVertex> verts;
+
+    CTextLayout::LayoutGlyph(' ', CTrueTypeFont{}, entry, pos, Math::FloatVector4(1.0f, 1.0f, 1.0f, 1.0f), 1.0f, verts);
+
+    EXPECT_EQ((size_t)0, verts.size());
+}
+
+TEST(TextLayoutGlyphTest, ZeroSizeGlyphReturnsAdvance)
+{
+    GlyphAtlasEntry entry = MakeEntry(0.0f, 0.0f);
+    entry.AdvanceWidth = 0.35f;
+    Math::FloatVector3 pos(0.0f, 0.0f, 0.0f);
+    std::vector<TextVertex> verts;
+
+    float adv = CTextLayout::LayoutGlyph(' ', CTrueTypeFont{}, entry, pos, Math::FloatVector4(1.0f, 1.0f, 1.0f, 1.0f), 1.0f, verts);
+
+    EXPECT_EQ(0.35f, adv) << "Advance must be returned even for zero-size (whitespace) glyph";
+}
+
+TEST(TextLayoutGlyphTest, VertexPositionsMatchExpected)
+{
+    GlyphAtlasEntry entry = MakeEntry(40.0f, 48.0f);
+    entry.LeftBearing = 0.0f;
+    entry.TopBearing  = 0.0f;
+    Math::FloatVector3 pos(100.0f, 200.0f, 0.5f);
+    std::vector<TextVertex> verts;
+
+    CTextLayout::LayoutGlyph(0x41, CTrueTypeFont{}, entry, pos, Math::FloatVector4(0.0f, 0.0f, 1.0f, 1.0f), 1.0f, verts);
+
+    EXPECT_EQ(6u, (unsigned)verts.size());
+
+    // Top-left of quad (fontSize=1.0 so em fractions == pixels directly)
+    float x0 = 100.0f, y0 = 200.0f, x1 = 140.0f, y1 = 248.0f;
+
+    // All 6 vertices must have X in [x0, x1] and Y in [y0, y1]
+    for (const auto& v : verts)
     {
-        GlyphAtlasEntry e;
-        e.AdvanceWidth  = 0.5f;   // Normalized (0.5 em)
-        e.LeftBearing   = 2.0f;
-        e.TopBearing    = 4.0f;
-        e.BitmapWidth   = bw;
-        e.BitmapHeight  = bh;
-        e.AtlasU0       = 0.1f;  e.AtlasV0 = 0.2f;
-        e.AtlasU1       = 0.3f;  e.AtlasV1 = 0.4f;
-        return e;
+        EXPECT_TRUE(v.Position.X >= x0 && v.Position.X <= x1);
+        EXPECT_TRUE(v.Position.Y >= y0 && v.Position.Y <= y1);
+        EXPECT_NEAR(0.5f, v.Position.Z, 1e-6f);
     }
+}
 
-public:
+TEST(TextLayoutGlyphTest, TexCoordsMatchAtlasEntry)
+{
+    GlyphAtlasEntry entry = MakeEntry();
+    Math::FloatVector3 pos(0.0f, 0.0f, 0.0f);
+    std::vector<TextVertex> verts;
 
-    TEST_METHOD(NormalGlyphProduces6Vertices)
+    CTextLayout::LayoutGlyph(0x41, CTrueTypeFont{}, entry, pos, Math::FloatVector4(1.0f, 1.0f, 1.0f, 1.0f), 1.0f, verts);
+
+    // All UVs must lie within the atlas entry's UV bounds
+    for (const auto& v : verts)
     {
-        GlyphAtlasEntry entry = MakeEntry();
-        Math::FloatVector3 pos(10.0f, 20.0f, 0.0f);
-        std::vector<TextVertex> verts;
-
-        CTextLayout::LayoutGlyph(0x41, CTrueTypeFont{}, entry, pos, Math::FloatVector4(1.0f, 1.0f, 1.0f, 1.0f), 1.0f, verts);
-
-        Assert::AreEqual((size_t)6, verts.size());
+        EXPECT_TRUE(v.TexCoord.X >= entry.AtlasU0 - 1e-5f && v.TexCoord.X <= entry.AtlasU1 + 1e-5f);
+        EXPECT_TRUE(v.TexCoord.Y >= entry.AtlasV0 - 1e-5f && v.TexCoord.Y <= entry.AtlasV1 + 1e-5f);
     }
+}
 
-    TEST_METHOD(ZeroSizeGlyphProducesNoVertices)
+TEST(TextLayoutGlyphTest, ColorIsStoredInVertices)
+{
+    GlyphAtlasEntry entry = MakeEntry();
+    Math::FloatVector3 pos(0.0f, 0.0f, 0.0f);
+    std::vector<TextVertex> verts;
+    Math::FloatVector4 color(0.87f, 0.68f, 0.93f, 0.49f);
+
+    CTextLayout::LayoutGlyph(0x41, CTrueTypeFont{}, entry, pos, color, 1.0f, verts);
+
+    for (const auto& v : verts)
     {
-        // BitmapWidth/Height == 0 → whitespace glyph, no quad should be emitted
-        GlyphAtlasEntry entry = MakeEntry(0.0f, 0.0f);
-        Math::FloatVector3 pos(0.0f, 0.0f, 0.0f);
-        std::vector<TextVertex> verts;
-
-        CTextLayout::LayoutGlyph(' ', CTrueTypeFont{}, entry, pos, Math::FloatVector4(1.0f, 1.0f, 1.0f, 1.0f), 1.0f, verts);
-
-        Assert::AreEqual((size_t)0, verts.size());
+        EXPECT_NEAR(color.X, v.Color[0], 1e-6f);
+        EXPECT_NEAR(color.Y, v.Color[1], 1e-6f);
+        EXPECT_NEAR(color.Z, v.Color[2], 1e-6f);
+        EXPECT_NEAR(color.W, v.Color[3], 1e-6f);
     }
-
-    TEST_METHOD(ZeroSizeGlyphReturnsAdvance)
-    {
-        GlyphAtlasEntry entry = MakeEntry(0.0f, 0.0f);
-        entry.AdvanceWidth = 0.35f;
-        Math::FloatVector3 pos(0.0f, 0.0f, 0.0f);
-        std::vector<TextVertex> verts;
-
-        float adv = CTextLayout::LayoutGlyph(' ', CTrueTypeFont{}, entry, pos, Math::FloatVector4(1.0f, 1.0f, 1.0f, 1.0f), 1.0f, verts);
-
-        Assert::AreEqual(0.35f, adv, L"Advance must be returned even for zero-size (whitespace) glyph");
-    }
-
-    TEST_METHOD(VertexPositionsMatchExpected)
-    {
-        GlyphAtlasEntry entry = MakeEntry(40.0f, 48.0f);
-        entry.LeftBearing = 0.0f;
-        entry.TopBearing  = 0.0f;
-        Math::FloatVector3 pos(100.0f, 200.0f, 0.5f);
-        std::vector<TextVertex> verts;
-
-        CTextLayout::LayoutGlyph(0x41, CTrueTypeFont{}, entry, pos, Math::FloatVector4(0.0f, 0.0f, 1.0f, 1.0f), 1.0f, verts);
-
-        Assert::AreEqual(6u, (unsigned)verts.size());
-
-        // Top-left of quad (fontSize=1.0 so em fractions == pixels directly)
-        float x0 = 100.0f, y0 = 200.0f, x1 = 140.0f, y1 = 248.0f;
-
-        // All 6 vertices must have X in [x0, x1] and Y in [y0, y1]
-        for (const auto& v : verts)
-        {
-            Assert::IsTrue(v.Position.X >= x0 && v.Position.X <= x1);
-            Assert::IsTrue(v.Position.Y >= y0 && v.Position.Y <= y1);
-            Assert::AreEqual(0.5f, v.Position.Z, 1e-6f);
-        }
-    }
-
-    TEST_METHOD(TexCoordsMatchAtlasEntry)
-    {
-        GlyphAtlasEntry entry = MakeEntry();
-        Math::FloatVector3 pos(0.0f, 0.0f, 0.0f);
-        std::vector<TextVertex> verts;
-
-        CTextLayout::LayoutGlyph(0x41, CTrueTypeFont{}, entry, pos, Math::FloatVector4(1.0f, 1.0f, 1.0f, 1.0f), 1.0f, verts);
-
-        // All UVs must lie within the atlas entry's UV bounds
-        for (const auto& v : verts)
-        {
-            Assert::IsTrue(v.TexCoord.X >= entry.AtlasU0 - 1e-5f && v.TexCoord.X <= entry.AtlasU1 + 1e-5f);
-            Assert::IsTrue(v.TexCoord.Y >= entry.AtlasV0 - 1e-5f && v.TexCoord.Y <= entry.AtlasV1 + 1e-5f);
-        }
-    }
-
-    TEST_METHOD(ColorIsStoredInVertices)
-    {
-        GlyphAtlasEntry entry = MakeEntry();
-        Math::FloatVector3 pos(0.0f, 0.0f, 0.0f);
-        std::vector<TextVertex> verts;
-        Math::FloatVector4 color(0.87f, 0.68f, 0.93f, 0.49f);
-
-        CTextLayout::LayoutGlyph(0x41, CTrueTypeFont{}, entry, pos, color, 1.0f, verts);
-
-        for (const auto& v : verts)
-        {
-            Assert::AreEqual(color.X, v.Color[0], 1e-6f);
-            Assert::AreEqual(color.Y, v.Color[1], 1e-6f);
-            Assert::AreEqual(color.Z, v.Color[2], 1e-6f);
-            Assert::AreEqual(color.W, v.Color[3], 1e-6f);
-        }
-    }
-};
+}
 
 //================================================================================================
-TEST_CLASS(TextRectanglePackerTest)
+TEST(TextRectanglePackerTest, SingleAllocation)
 {
-public:
+    CRectanglePacker packer(512, 512);
+    CRectanglePacker::Rect r;
+    EXPECT_TRUE(packer.Allocate(64, 64, r));
+    EXPECT_EQ(0u, r.X);
+    EXPECT_EQ(0u, r.Y);
+    EXPECT_EQ(64u, r.Width);
+    EXPECT_EQ(64u, r.Height);
+}
 
-    TEST_METHOD(SingleAllocation)
+TEST(TextRectanglePackerTest, TwoNonOverlappingAllocations)
+{
+    CRectanglePacker packer(512, 512);
+    CRectanglePacker::Rect r0, r1;
+    EXPECT_TRUE(packer.Allocate(64, 64, r0));
+    EXPECT_TRUE(packer.Allocate(64, 64, r1));
+
+    // Rectangles must not overlap
+    bool xSep = r0.X + r0.Width <= r1.X || r1.X + r1.Width <= r0.X;
+    bool ySep = r0.Y + r0.Height <= r1.Y || r1.Y + r1.Height <= r0.Y;
+    EXPECT_TRUE(xSep || ySep) << "Allocated rectangles must not overlap";
+}
+
+TEST(TextRectanglePackerTest, AllRectsStayWithinBounds)
+{
+    CRectanglePacker packer(128, 128);
+    for (int i = 0; i < 4; ++i)
     {
-        CRectanglePacker packer(512, 512);
         CRectanglePacker::Rect r;
-        Assert::IsTrue(packer.Allocate(64, 64, r));
-        Assert::AreEqual(0u, r.X);
-        Assert::AreEqual(0u, r.Y);
-        Assert::AreEqual(64u, r.Width);
-        Assert::AreEqual(64u, r.Height);
+        if (!packer.Allocate(64, 64, r))
+            break;
+        EXPECT_TRUE(r.X + r.Width  <= 128u);
+        EXPECT_TRUE(r.Y + r.Height <= 128u);
     }
+}
 
-    TEST_METHOD(TwoNonOverlappingAllocations)
-    {
-        CRectanglePacker packer(512, 512);
-        CRectanglePacker::Rect r0, r1;
-        Assert::IsTrue(packer.Allocate(64, 64, r0));
-        Assert::IsTrue(packer.Allocate(64, 64, r1));
+TEST(TextRectanglePackerTest, OverflowReturnsFalse)
+{
+    CRectanglePacker packer(64, 64);
+    CRectanglePacker::Rect r;
+    EXPECT_TRUE(packer.Allocate(64, 64, r));
+    // Atlas is full — next allocation must fail
+    EXPECT_FALSE(packer.Allocate(1, 1, r)) << "Allocation must fail when atlas is full";
+}
 
-        // Rectangles must not overlap
-        bool xSep = r0.X + r0.Width <= r1.X || r1.X + r1.Width <= r0.X;
-        bool ySep = r0.Y + r0.Height <= r1.Y || r1.Y + r1.Height <= r0.Y;
-        Assert::IsTrue(xSep || ySep, L"Allocated rectangles must not overlap");
-    }
-
-    TEST_METHOD(AllRectsStayWithinBounds)
-    {
-        CRectanglePacker packer(128, 128);
-        for (int i = 0; i < 4; ++i)
-        {
-            CRectanglePacker::Rect r;
-            if (!packer.Allocate(64, 64, r))
-                break;
-            Assert::IsTrue(r.X + r.Width  <= 128u);
-            Assert::IsTrue(r.Y + r.Height <= 128u);
-        }
-    }
-
-    TEST_METHOD(OverflowReturnsFalse)
-    {
-        CRectanglePacker packer(64, 64);
-        CRectanglePacker::Rect r;
-        Assert::IsTrue(packer.Allocate(64, 64, r));
-        // Atlas is full — next allocation must fail
-        Assert::IsFalse(packer.Allocate(1, 1, r), L"Allocation must fail when atlas is full");
-    }
-
-    TEST_METHOD(OversizeAllocationReturnsFalse)
-    {
-        CRectanglePacker packer(64, 64);
-        CRectanglePacker::Rect r;
-        Assert::IsFalse(packer.Allocate(128, 128, r), L"Allocation larger than atlas must fail");
-    }
-};
+TEST(TextRectanglePackerTest, OversizeAllocationReturnsFalse)
+{
+    CRectanglePacker packer(64, 64);
+    CRectanglePacker::Rect r;
+    EXPECT_FALSE(packer.Allocate(128, 128, r)) << "Allocation larger than atlas must fail";
+}
 
 //================================================================================================
-TEST_CLASS(TextSDFGeneratorTest)
+TEST(TextSDFGeneratorTest, EmptyOutlineReturnsFalse)
 {
-public:
+    // This is the space-character case that caused the blank-screen bug:
+    // CacheGlyph passed an empty outline to Generate, which must return false,
+    // allowing CacheGlyph to fall back to a metrics-only entry.
+    GlyphOutline outline; // IsEmpty() == true
+    CTrueTypeFont font;
+    CSDFGenerator gen;
+    CSDFGenerator::Config cfg;
+    SDFBitmap bmp;
+    EXPECT_FALSE(gen.Generate(outline, font, cfg, bmp)) << "Generate must return false for an empty (outline-less) glyph";
+}
 
-    TEST_METHOD(EmptyOutlineReturnsFalse)
+TEST(TextSDFGeneratorTest, ValidOutlineReturnsTrue)
+{
+    CTrueTypeFont font; // metrics not needed for SDF pixel loop
+    GlyphOutline outline = MakeSquareOutline(500.0f);
+    CSDFGenerator gen;
+    CSDFGenerator::Config cfg;
+    cfg.TextureSize = 16;
+    SDFBitmap bmp;
+    EXPECT_TRUE(gen.Generate(outline, font, cfg, bmp)) << "Generate must succeed for a valid outline";
+}
+
+TEST(TextSDFGeneratorTest, OutputBitmapDimensionsMatchConfig)
+{
+    CTrueTypeFont font;
+    GlyphOutline outline = MakeSquareOutline();
+    CSDFGenerator gen;
+    CSDFGenerator::Config cfg;
+    cfg.TextureSize = 32;
+    SDFBitmap bmp;
+    gen.Generate(outline, font, cfg, bmp);
+    EXPECT_EQ(32u, bmp.Width);
+    EXPECT_EQ(32u, bmp.Height);
+}
+
+TEST(TextSDFGeneratorTest, OutputDataSizeMatchesBitmap)
+{
+    CTrueTypeFont font;
+    GlyphOutline outline = MakeSquareOutline();
+    CSDFGenerator gen;
+    CSDFGenerator::Config cfg;
+    cfg.TextureSize  = 16;
+    cfg.GenerateMSDF = false;
+    SDFBitmap bmp;
+    gen.Generate(outline, font, cfg, bmp);
+    size_t expected = (size_t)bmp.Width * bmp.Height * bmp.BytesPerPixel;
+    EXPECT_EQ(expected, bmp.Data.size());
+}
+
+TEST(TextSDFGeneratorTest, SingleChannelSDFBytesPerPixelIsOne)
+{
+    CTrueTypeFont font;
+    GlyphOutline outline = MakeSquareOutline();
+    CSDFGenerator gen;
+    CSDFGenerator::Config cfg;
+    cfg.GenerateMSDF = false;
+    SDFBitmap bmp;
+    gen.Generate(outline, font, cfg, bmp);
+    EXPECT_EQ(1u, bmp.BytesPerPixel);
+}
+
+TEST(TextSDFGeneratorTest, AdvanceWidthNormalizedByUnitsPerEm)
+{
+    // AdvanceWidth must be normalised (outline.AdvanceWidth / UnitsPerEm).
+    // With a synthetic outline, font.UnitsPerEm defaults to 0 which would
+    // divide-by-zero, so we use a real font for this check.
+    CTrueTypeFont font;
+    if (!LoadSystemFont(font))
     {
-        // This is the space-character case that caused the blank-screen bug:
-        // CacheGlyph passed an empty outline to Generate, which must return false,
-        // allowing CacheGlyph to fall back to a metrics-only entry.
-        GlyphOutline outline; // IsEmpty() == true
-        CTrueTypeFont font;
-        CSDFGenerator gen;
-        CSDFGenerator::Config cfg;
-        SDFBitmap bmp;
-        Assert::IsFalse(gen.Generate(outline, font, cfg, bmp),
-            L"Generate must return false for an empty (outline-less) glyph");
+        std::cerr << "Skipped: system font not available" << std::endl;
+        return;
     }
 
-    TEST_METHOD(ValidOutlineReturnsTrue)
-    {
-        CTrueTypeFont font; // metrics not needed for SDF pixel loop
-        GlyphOutline outline = MakeSquareOutline(500.0f);
-        CSDFGenerator gen;
-        CSDFGenerator::Config cfg;
-        cfg.TextureSize = 16;
-        SDFBitmap bmp;
-        Assert::IsTrue(gen.Generate(outline, font, cfg, bmp),
-            L"Generate must succeed for a valid outline");
-    }
+    uint16_t idx = font.GetGlyphIndex('A');
+    GlyphOutline outline;
+    EXPECT_TRUE(font.GetGlyphOutline(idx, outline));
 
-    TEST_METHOD(OutputBitmapDimensionsMatchConfig)
-    {
-        CTrueTypeFont font;
-        GlyphOutline outline = MakeSquareOutline();
-        CSDFGenerator gen;
-        CSDFGenerator::Config cfg;
-        cfg.TextureSize = 32;
-        SDFBitmap bmp;
-        gen.Generate(outline, font, cfg, bmp);
-        Assert::AreEqual(32u, bmp.Width);
-        Assert::AreEqual(32u, bmp.Height);
-    }
+    CSDFGenerator gen;
+    CSDFGenerator::Config cfg;
+    cfg.TextureSize = 16;
+    SDFBitmap bmp;
+    EXPECT_TRUE(gen.Generate(outline, font, cfg, bmp));
 
-    TEST_METHOD(OutputDataSizeMatchesBitmap)
-    {
-        CTrueTypeFont font;
-        GlyphOutline outline = MakeSquareOutline();
-        CSDFGenerator gen;
-        CSDFGenerator::Config cfg;
-        cfg.TextureSize  = 16;
-        cfg.GenerateMSDF = false;
-        SDFBitmap bmp;
-        gen.Generate(outline, font, cfg, bmp);
-        size_t expected = (size_t)bmp.Width * bmp.Height * bmp.BytesPerPixel;
-        Assert::AreEqual(expected, bmp.Data.size());
-    }
-
-    TEST_METHOD(SingleChannelSDFBytesPerPixelIsOne)
-    {
-        CTrueTypeFont font;
-        GlyphOutline outline = MakeSquareOutline();
-        CSDFGenerator gen;
-        CSDFGenerator::Config cfg;
-        cfg.GenerateMSDF = false;
-        SDFBitmap bmp;
-        gen.Generate(outline, font, cfg, bmp);
-        Assert::AreEqual(1u, bmp.BytesPerPixel);
-    }
-
-    TEST_METHOD(AdvanceWidthNormalizedByUnitsPerEm)
-    {
-        // AdvanceWidth must be normalised (outline.AdvanceWidth / UnitsPerEm).
-        // With a synthetic outline, font.UnitsPerEm defaults to 0 which would
-        // divide-by-zero, so we use a real font for this check.
-        CTrueTypeFont font;
-        if (!LoadSystemFont(font))
-        {
-            Logger::WriteMessage("Skipped: system font not available");
-            return;
-        }
-
-        uint16_t idx = font.GetGlyphIndex('A');
-        GlyphOutline outline;
-        Assert::IsTrue(font.GetGlyphOutline(idx, outline));
-
-        CSDFGenerator gen;
-        CSDFGenerator::Config cfg;
-        cfg.TextureSize = 16;
-        SDFBitmap bmp;
-        Assert::IsTrue(gen.Generate(outline, font, cfg, bmp));
-
-        // AdvanceWidth from SDF is NormalizeX(outline.AdvanceWidth) = fontUnits / UnitsPerEm
-        // It must be in (0, 3] for any real font (most advances are 0.3-0.7 em)
-        Assert::IsTrue(bmp.AdvanceWidth > 0.0f && bmp.AdvanceWidth <= 3.0f,
-            L"AdvanceWidth from SDF must be a normalised em fraction");
-    }
-};
+    // AdvanceWidth from SDF is NormalizeX(outline.AdvanceWidth) = fontUnits / UnitsPerEm
+    // It must be in (0, 3] for any real font (most advances are 0.3-0.7 em)
+    EXPECT_TRUE(bmp.AdvanceWidth > 0.0f && bmp.AdvanceWidth <= 3.0f) << "AdvanceWidth from SDF must be a normalised em fraction";
+}
 
 //================================================================================================
-TEST_CLASS(TextFontLoadTest)
+TEST(TextFontLoadTest, LoadFromBuffer_Success)
 {
-public:
-
-    TEST_METHOD(LoadFromBuffer_Success)
+    CTrueTypeFont font;
+    if (!LoadSystemFont(font))
     {
-        CTrueTypeFont font;
-        if (!LoadSystemFont(font))
-        {
-            Logger::WriteMessage("Skipped: system font not available");
-            return;
-        }
-        // Basic sanity: UnitsPerEm should be a common value (1000 or 2048)
-        uint16_t upm = font.GetUnitsPerEm();
-        Assert::IsTrue(upm >= 256 && upm <= 4096, L"UnitsPerEm out of expected range");
+        std::cerr << "Skipped: system font not available" << std::endl;
+        return;
+    }
+    // Basic sanity: UnitsPerEm should be a common value (1000 or 2048)
+    uint16_t upm = font.GetUnitsPerEm();
+    EXPECT_TRUE(upm >= 256 && upm <= 4096) << "UnitsPerEm out of expected range";
+}
+
+TEST(TextFontLoadTest, SpaceGlyphHasEmptyOutline)
+{
+    // This is the key regression test for the blank-screen bug.
+    // The space character (U+0020) has no contours; its outline must be empty
+    // so SDFGenerator::Generate returns false and CacheGlyph can create a
+    // metrics-only (no-quad) entry rather than failing entirely.
+    CTrueTypeFont font;
+    if (!LoadSystemFont(font))
+    {
+        std::cerr << "Skipped: system font not available" << std::endl;
+        return;
     }
 
-    TEST_METHOD(SpaceGlyphHasEmptyOutline)
-    {
-        // This is the key regression test for the blank-screen bug.
-        // The space character (U+0020) has no contours; its outline must be empty
-        // so SDFGenerator::Generate returns false and CacheGlyph can create a
-        // metrics-only (no-quad) entry rather than failing entirely.
-        CTrueTypeFont font;
-        if (!LoadSystemFont(font))
-        {
-            Logger::WriteMessage("Skipped: system font not available");
-            return;
-        }
+    uint16_t spaceIdx = font.GetGlyphIndex(' ');
+    GlyphOutline outline;
+    // GetGlyphOutline returns true even for space (metrics-only glyph)
+    EXPECT_TRUE(font.GetGlyphOutline(spaceIdx, outline)) << "GetGlyphOutline must succeed for space";
+    EXPECT_TRUE(outline.IsEmpty()) << "Space glyph must have an empty outline (no contours)";
+    // But it must still carry a non-zero advance width
+    EXPECT_TRUE(outline.AdvanceWidth > 0.0f) << "Space glyph must have a positive advance width";
+}
 
-        uint16_t spaceIdx = font.GetGlyphIndex(' ');
+TEST(TextFontLoadTest, RegularGlyphHasNonEmptyOutline)
+{
+    CTrueTypeFont font;
+    if (!LoadSystemFont(font))
+    {
+        std::cerr << "Skipped: system font not available" << std::endl;
+        return;
+    }
+
+    uint16_t idx = font.GetGlyphIndex('A');
+    GlyphOutline outline;
+    EXPECT_TRUE(font.GetGlyphOutline(idx, outline));
+    EXPECT_FALSE(outline.IsEmpty()) << "'A' glyph must have at least one contour";
+    EXPECT_TRUE(!outline.Contours.empty() && !outline.Contours[0].Points.empty());
+}
+
+TEST(TextFontLoadTest, AdvanceWidthPositiveForPrintableGlyphs)
+{
+    CTrueTypeFont font;
+    if (!LoadSystemFont(font))
+    {
+        std::cerr << "Skipped: system font not available" << std::endl;
+        return;
+    }
+
+    for (char ch : std::string("Hello Canvas"))
+    {
+        uint16_t idx = font.GetGlyphIndex((uint32_t)(uint8_t)ch);
         GlyphOutline outline;
-        // GetGlyphOutline returns true even for space (metrics-only glyph)
-        Assert::IsTrue(font.GetGlyphOutline(spaceIdx, outline),
-            L"GetGlyphOutline must succeed for space");
-        Assert::IsTrue(outline.IsEmpty(),
-            L"Space glyph must have an empty outline (no contours)");
-        // But it must still carry a non-zero advance width
-        Assert::IsTrue(outline.AdvanceWidth > 0.0f,
-            L"Space glyph must have a positive advance width");
+        font.GetGlyphOutline(idx, outline);
+        EXPECT_TRUE(outline.AdvanceWidth > 0.0f) << "Every printable glyph must have a positive advance width";
     }
+}
 
-    TEST_METHOD(RegularGlyphHasNonEmptyOutline)
+TEST(TextFontLoadTest, NormalizeXDividesUnitsPerEm)
+{
+    CTrueTypeFont font;
+    if (!LoadSystemFont(font))
     {
-        CTrueTypeFont font;
-        if (!LoadSystemFont(font))
-        {
-            Logger::WriteMessage("Skipped: system font not available");
-            return;
-        }
-
-        uint16_t idx = font.GetGlyphIndex('A');
-        GlyphOutline outline;
-        Assert::IsTrue(font.GetGlyphOutline(idx, outline));
-        Assert::IsFalse(outline.IsEmpty(), L"'A' glyph must have at least one contour");
-        Assert::IsTrue(!outline.Contours.empty() && !outline.Contours[0].Points.empty());
+        std::cerr << "Skipped: system font not available" << std::endl;
+        return;
     }
 
-    TEST_METHOD(AdvanceWidthPositiveForPrintableGlyphs)
-    {
-        CTrueTypeFont font;
-        if (!LoadSystemFont(font))
-        {
-            Logger::WriteMessage("Skipped: system font not available");
-            return;
-        }
-
-        for (char ch : std::string("Hello Canvas"))
-        {
-            uint16_t idx = font.GetGlyphIndex((uint32_t)(uint8_t)ch);
-            GlyphOutline outline;
-            font.GetGlyphOutline(idx, outline);
-            Assert::IsTrue(outline.AdvanceWidth > 0.0f,
-                L"Every printable glyph must have a positive advance width");
-        }
-    }
-
-    TEST_METHOD(NormalizeXDividesUnitsPerEm)
-    {
-        CTrueTypeFont font;
-        if (!LoadSystemFont(font))
-        {
-            Logger::WriteMessage("Skipped: system font not available");
-            return;
-        }
-
-        uint16_t upm = font.GetUnitsPerEm();
-        float normalized = font.NormalizeX(static_cast<float>(upm));
-        Assert::AreEqual(1.0f, normalized, 1e-5f,
-            L"NormalizeX(UnitsPerEm) must equal 1.0");
-    }
-};
+    uint16_t upm = font.GetUnitsPerEm();
+    float normalized = font.NormalizeX(static_cast<float>(upm));
+    EXPECT_NEAR(1.0f, normalized, 1e-5f) << "NormalizeX(UnitsPerEm) must equal 1.0";
+}
 
 } // namespace CanvasUnitTest

--- a/src/CanvasUnitTest/D3D12ResourceUtilsTest.cpp
+++ b/src/CanvasUnitTest/D3D12ResourceUtilsTest.cpp
@@ -1,170 +1,163 @@
 #include "pch.h"
-#include "CppUnitTest.h"
 #include "D3D12ResourceUtils.h"
-
-using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 using namespace Canvas;
 
 namespace CanvasUnitTest
 {
-    TEST_CLASS(D3D12ResourceUtilsTest)
+TEST(D3D12ResourceUtilsTest, SubresourceLayout_UniformInit)
+{
+    SubresourceLayout layout(D3D12_BARRIER_LAYOUT_COMMON, 4);
+    EXPECT_TRUE(layout.m_AllSame);
+    EXPECT_TRUE(layout.GetLayout(0) == D3D12_BARRIER_LAYOUT_COMMON);
+    EXPECT_TRUE(layout.GetLayout(3) == D3D12_BARRIER_LAYOUT_COMMON);
+}
+
+TEST(D3D12ResourceUtilsTest, SubresourceLayout_ExpandToPerSubresource)
+{
+    SubresourceLayout layout(D3D12_BARRIER_LAYOUT_RENDER_TARGET, 4);
+    layout.ExpandToPerSubresource(4);
+
+    EXPECT_FALSE(layout.m_AllSame);
+    EXPECT_EQ(size_t(4), layout.m_PerSubresource.size());
+    for (UINT i = 0; i < 4; ++i)
+        EXPECT_TRUE(layout.m_PerSubresource[i] == D3D12_BARRIER_LAYOUT_RENDER_TARGET);
+}
+
+TEST(D3D12ResourceUtilsTest, SubresourceLayout_PerSubresourceModify)
+{
+    SubresourceLayout layout(D3D12_BARRIER_LAYOUT_SHADER_RESOURCE, 4);
+    layout.ExpandToPerSubresource(4);
+
+    layout.m_PerSubresource[1] = D3D12_BARRIER_LAYOUT_COPY_SOURCE;
+    layout.m_PerSubresource[3] = D3D12_BARRIER_LAYOUT_COPY_SOURCE;
+
+    EXPECT_TRUE(layout.GetLayout(0) == D3D12_BARRIER_LAYOUT_SHADER_RESOURCE);
+    EXPECT_TRUE(layout.GetLayout(1) == D3D12_BARRIER_LAYOUT_COPY_SOURCE);
+    EXPECT_TRUE(layout.GetLayout(2) == D3D12_BARRIER_LAYOUT_SHADER_RESOURCE);
+    EXPECT_TRUE(layout.GetLayout(3) == D3D12_BARRIER_LAYOUT_COPY_SOURCE);
+}
+
+TEST(D3D12ResourceUtilsTest, SubresourceLayout_AssignUniform)
+{
+    // Assigning a uniform layout after per-subresource expansion should work
+    SubresourceLayout layout(D3D12_BARRIER_LAYOUT_COMMON, 4);
+    layout.ExpandToPerSubresource(4);
+    EXPECT_FALSE(layout.m_AllSame);
+
+    // Overwrite with a uniform layout
+    layout = SubresourceLayout(D3D12_BARRIER_LAYOUT_RENDER_TARGET, 4);
+    EXPECT_TRUE(layout.m_AllSame);
+    EXPECT_TRUE(layout.GetLayout(0) == D3D12_BARRIER_LAYOUT_RENDER_TARGET);
+}
+
+TEST(D3D12ResourceUtilsTest, SubresourceLayout_SetLayout_AllSubresources)
+{
+    SubresourceLayout layout(D3D12_BARRIER_LAYOUT_COMMON, 4);
+    layout.SetLayout(0xFFFFFFFF, D3D12_BARRIER_LAYOUT_RENDER_TARGET);
+    EXPECT_TRUE(layout.m_AllSame);
+    EXPECT_TRUE(layout.GetLayout(0) == D3D12_BARRIER_LAYOUT_RENDER_TARGET);
+}
+
+TEST(D3D12ResourceUtilsTest, SubresourceLayout_SetLayout_Individual_SplitsUniform)
+{
+    SubresourceLayout layout(D3D12_BARRIER_LAYOUT_COMMON, 4);
+    EXPECT_TRUE(layout.m_AllSame);
+
+    // Setting subresource 1 should expand to per-subresource
+    layout.SetLayout(1, D3D12_BARRIER_LAYOUT_COPY_SOURCE, 4);
+    EXPECT_FALSE(layout.m_AllSame);
+    EXPECT_TRUE(layout.GetLayout(0) == D3D12_BARRIER_LAYOUT_COMMON);
+    EXPECT_TRUE(layout.GetLayout(1) == D3D12_BARRIER_LAYOUT_COPY_SOURCE);
+    EXPECT_TRUE(layout.GetLayout(2) == D3D12_BARRIER_LAYOUT_COMMON);
+    EXPECT_TRUE(layout.GetLayout(3) == D3D12_BARRIER_LAYOUT_COMMON);
+}
+
+TEST(D3D12ResourceUtilsTest, SubresourceLayout_SetLayout_AllAfterPerSubresource_Collapses)
+{
+    SubresourceLayout layout(D3D12_BARRIER_LAYOUT_COMMON, 4);
+    layout.SetLayout(1, D3D12_BARRIER_LAYOUT_COPY_SOURCE, 4);
+    EXPECT_FALSE(layout.m_AllSame);
+
+    // Setting all subresources should collapse back to uniform
+    layout.SetLayout(0xFFFFFFFF, D3D12_BARRIER_LAYOUT_SHADER_RESOURCE);
+    EXPECT_TRUE(layout.m_AllSame);
+    EXPECT_TRUE(layout.GetLayout(0) == D3D12_BARRIER_LAYOUT_SHADER_RESOURCE);
+    EXPECT_TRUE(layout.m_PerSubresource.empty());
+}
+
+TEST(D3D12ResourceUtilsTest, SubresourceLayout_TryCollapse_AllMatch)
+{
+    SubresourceLayout layout(D3D12_BARRIER_LAYOUT_COMMON, 4);
+    layout.ExpandToPerSubresource(4);
+    EXPECT_FALSE(layout.m_AllSame);
+
+    // All subresources are COMMON — should collapse
+    layout.TryCollapse();
+    EXPECT_TRUE(layout.m_AllSame);
+    EXPECT_TRUE(layout.m_UniformLayout == D3D12_BARRIER_LAYOUT_COMMON);
+    EXPECT_TRUE(layout.m_PerSubresource.empty());
+}
+
+TEST(D3D12ResourceUtilsTest, SubresourceLayout_TryCollapse_Mismatch)
+{
+    SubresourceLayout layout(D3D12_BARRIER_LAYOUT_COMMON, 4);
+    layout.SetLayout(2, D3D12_BARRIER_LAYOUT_COPY_SOURCE, 4);
+    EXPECT_FALSE(layout.m_AllSame);
+
+    // Subresources differ — should NOT collapse
+    layout.TryCollapse();
+    EXPECT_FALSE(layout.m_AllSame);
+}
+
+TEST(D3D12ResourceUtilsTest, SubresourceLayout_TryCollapse_AfterUnifying)
+{
+    SubresourceLayout layout(D3D12_BARRIER_LAYOUT_COMMON, 4);
+    layout.SetLayout(0, D3D12_BARRIER_LAYOUT_RENDER_TARGET, 4);
+    layout.SetLayout(1, D3D12_BARRIER_LAYOUT_RENDER_TARGET, 4);
+    layout.SetLayout(2, D3D12_BARRIER_LAYOUT_RENDER_TARGET, 4);
+    layout.SetLayout(3, D3D12_BARRIER_LAYOUT_RENDER_TARGET, 4);
+
+    layout.TryCollapse();
+    EXPECT_TRUE(layout.m_AllSame);
+    EXPECT_TRUE(layout.m_UniformLayout == D3D12_BARRIER_LAYOUT_RENDER_TARGET);
+}
+
+TEST(D3D12ResourceUtilsTest, CTextureResource_InitLayout)
+{
+    // Create a real D3D12 device and texture to test CTextureResource
+    CComPtr<ID3D12Device> pDevice;
+    HRESULT hr = D3D12CreateDevice(nullptr, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&pDevice));
+    if (FAILED(hr))
     {
-    public:
+        FAIL() << "No D3D12 device available — skipping hardware test";
+        return;
+    }
 
-        TEST_METHOD(SubresourceLayout_UniformInit)
-        {
-            SubresourceLayout layout(D3D12_BARRIER_LAYOUT_COMMON, 4);
-            Assert::IsTrue(layout.m_AllSame);
-            Assert::IsTrue(layout.GetLayout(0) == D3D12_BARRIER_LAYOUT_COMMON);
-            Assert::IsTrue(layout.GetLayout(3) == D3D12_BARRIER_LAYOUT_COMMON);
-        }
+    CComPtr<ID3D12Device10> pDevice10;
+    hr = pDevice->QueryInterface(IID_PPV_ARGS(&pDevice10));
+    EXPECT_TRUE(SUCCEEDED(hr));
 
-        TEST_METHOD(SubresourceLayout_ExpandToPerSubresource)
-        {
-            SubresourceLayout layout(D3D12_BARRIER_LAYOUT_RENDER_TARGET, 4);
-            layout.ExpandToPerSubresource(4);
+    CD3DX12_RESOURCE_DESC1 desc = CD3DX12_RESOURCE_DESC1::Tex2D(
+        DXGI_FORMAT_R8G8B8A8_UNORM, 256, 256, 2, 2, 1, 0,
+        D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET);
+    CD3DX12_HEAP_PROPERTIES heapProp(D3D12_HEAP_TYPE_DEFAULT);
 
-            Assert::IsFalse(layout.m_AllSame);
-            Assert::AreEqual(size_t(4), layout.m_PerSubresource.size());
-            for (UINT i = 0; i < 4; ++i)
-                Assert::IsTrue(layout.m_PerSubresource[i] == D3D12_BARRIER_LAYOUT_RENDER_TARGET);
-        }
+    CComPtr<ID3D12Resource> pD3DResource;
+    hr = pDevice10->CreateCommittedResource3(
+        &heapProp, D3D12_HEAP_FLAG_ALLOW_ALL_BUFFERS_AND_TEXTURES,
+        &desc, D3D12_BARRIER_LAYOUT_COMMON, nullptr, nullptr, 0, nullptr,
+        IID_PPV_ARGS(&pD3DResource));
+    EXPECT_TRUE(SUCCEEDED(hr));
 
-        TEST_METHOD(SubresourceLayout_PerSubresourceModify)
-        {
-            SubresourceLayout layout(D3D12_BARRIER_LAYOUT_SHADER_RESOURCE, 4);
-            layout.ExpandToPerSubresource(4);
+    CTextureResource tex(pD3DResource, D3D12_BARRIER_LAYOUT_COMMON);
+    EXPECT_TRUE(tex.GetCurSubresourceLayout(0) == D3D12_BARRIER_LAYOUT_COMMON);
+    EXPECT_EQ(UINT(4), tex.m_NumSubresources); // 2 array * 2 mip
 
-            layout.m_PerSubresource[1] = D3D12_BARRIER_LAYOUT_COPY_SOURCE;
-            layout.m_PerSubresource[3] = D3D12_BARRIER_LAYOUT_COPY_SOURCE;
+    // Simulate ComputeFinalLayouts updating the committed state
+    tex.m_CurrentLayout = SubresourceLayout(D3D12_BARRIER_LAYOUT_RENDER_TARGET, tex.m_NumSubresources);
+    EXPECT_TRUE(tex.GetCurSubresourceLayout(0) == D3D12_BARRIER_LAYOUT_RENDER_TARGET);
+    EXPECT_TRUE(tex.m_CurrentLayout.m_AllSame);
+}
 
-            Assert::IsTrue(layout.GetLayout(0) == D3D12_BARRIER_LAYOUT_SHADER_RESOURCE);
-            Assert::IsTrue(layout.GetLayout(1) == D3D12_BARRIER_LAYOUT_COPY_SOURCE);
-            Assert::IsTrue(layout.GetLayout(2) == D3D12_BARRIER_LAYOUT_SHADER_RESOURCE);
-            Assert::IsTrue(layout.GetLayout(3) == D3D12_BARRIER_LAYOUT_COPY_SOURCE);
-        }
-
-        TEST_METHOD(SubresourceLayout_AssignUniform)
-        {
-            // Assigning a uniform layout after per-subresource expansion should work
-            SubresourceLayout layout(D3D12_BARRIER_LAYOUT_COMMON, 4);
-            layout.ExpandToPerSubresource(4);
-            Assert::IsFalse(layout.m_AllSame);
-
-            // Overwrite with a uniform layout
-            layout = SubresourceLayout(D3D12_BARRIER_LAYOUT_RENDER_TARGET, 4);
-            Assert::IsTrue(layout.m_AllSame);
-            Assert::IsTrue(layout.GetLayout(0) == D3D12_BARRIER_LAYOUT_RENDER_TARGET);
-        }
-
-        TEST_METHOD(SubresourceLayout_SetLayout_AllSubresources)
-        {
-            SubresourceLayout layout(D3D12_BARRIER_LAYOUT_COMMON, 4);
-            layout.SetLayout(0xFFFFFFFF, D3D12_BARRIER_LAYOUT_RENDER_TARGET);
-            Assert::IsTrue(layout.m_AllSame);
-            Assert::IsTrue(layout.GetLayout(0) == D3D12_BARRIER_LAYOUT_RENDER_TARGET);
-        }
-
-        TEST_METHOD(SubresourceLayout_SetLayout_Individual_SplitsUniform)
-        {
-            SubresourceLayout layout(D3D12_BARRIER_LAYOUT_COMMON, 4);
-            Assert::IsTrue(layout.m_AllSame);
-
-            // Setting subresource 1 should expand to per-subresource
-            layout.SetLayout(1, D3D12_BARRIER_LAYOUT_COPY_SOURCE, 4);
-            Assert::IsFalse(layout.m_AllSame);
-            Assert::IsTrue(layout.GetLayout(0) == D3D12_BARRIER_LAYOUT_COMMON);
-            Assert::IsTrue(layout.GetLayout(1) == D3D12_BARRIER_LAYOUT_COPY_SOURCE);
-            Assert::IsTrue(layout.GetLayout(2) == D3D12_BARRIER_LAYOUT_COMMON);
-            Assert::IsTrue(layout.GetLayout(3) == D3D12_BARRIER_LAYOUT_COMMON);
-        }
-
-        TEST_METHOD(SubresourceLayout_SetLayout_AllAfterPerSubresource_Collapses)
-        {
-            SubresourceLayout layout(D3D12_BARRIER_LAYOUT_COMMON, 4);
-            layout.SetLayout(1, D3D12_BARRIER_LAYOUT_COPY_SOURCE, 4);
-            Assert::IsFalse(layout.m_AllSame);
-
-            // Setting all subresources should collapse back to uniform
-            layout.SetLayout(0xFFFFFFFF, D3D12_BARRIER_LAYOUT_SHADER_RESOURCE);
-            Assert::IsTrue(layout.m_AllSame);
-            Assert::IsTrue(layout.GetLayout(0) == D3D12_BARRIER_LAYOUT_SHADER_RESOURCE);
-            Assert::IsTrue(layout.m_PerSubresource.empty());
-        }
-
-        TEST_METHOD(SubresourceLayout_TryCollapse_AllMatch)
-        {
-            SubresourceLayout layout(D3D12_BARRIER_LAYOUT_COMMON, 4);
-            layout.ExpandToPerSubresource(4);
-            Assert::IsFalse(layout.m_AllSame);
-
-            // All subresources are COMMON — should collapse
-            layout.TryCollapse();
-            Assert::IsTrue(layout.m_AllSame);
-            Assert::IsTrue(layout.m_UniformLayout == D3D12_BARRIER_LAYOUT_COMMON);
-            Assert::IsTrue(layout.m_PerSubresource.empty());
-        }
-
-        TEST_METHOD(SubresourceLayout_TryCollapse_Mismatch)
-        {
-            SubresourceLayout layout(D3D12_BARRIER_LAYOUT_COMMON, 4);
-            layout.SetLayout(2, D3D12_BARRIER_LAYOUT_COPY_SOURCE, 4);
-            Assert::IsFalse(layout.m_AllSame);
-
-            // Subresources differ — should NOT collapse
-            layout.TryCollapse();
-            Assert::IsFalse(layout.m_AllSame);
-        }
-
-        TEST_METHOD(SubresourceLayout_TryCollapse_AfterUnifying)
-        {
-            SubresourceLayout layout(D3D12_BARRIER_LAYOUT_COMMON, 4);
-            layout.SetLayout(0, D3D12_BARRIER_LAYOUT_RENDER_TARGET, 4);
-            layout.SetLayout(1, D3D12_BARRIER_LAYOUT_RENDER_TARGET, 4);
-            layout.SetLayout(2, D3D12_BARRIER_LAYOUT_RENDER_TARGET, 4);
-            layout.SetLayout(3, D3D12_BARRIER_LAYOUT_RENDER_TARGET, 4);
-
-            layout.TryCollapse();
-            Assert::IsTrue(layout.m_AllSame);
-            Assert::IsTrue(layout.m_UniformLayout == D3D12_BARRIER_LAYOUT_RENDER_TARGET);
-        }
-
-        TEST_METHOD(CTextureResource_InitLayout)
-        {
-            // Create a real D3D12 device and texture to test CTextureResource
-            CComPtr<ID3D12Device> pDevice;
-            HRESULT hr = D3D12CreateDevice(nullptr, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&pDevice));
-            if (FAILED(hr))
-            {
-                Assert::Fail(L"No D3D12 device available — skipping hardware test");
-                return;
-            }
-
-            CComPtr<ID3D12Device10> pDevice10;
-            hr = pDevice->QueryInterface(IID_PPV_ARGS(&pDevice10));
-            Assert::IsTrue(SUCCEEDED(hr));
-
-            CD3DX12_RESOURCE_DESC1 desc = CD3DX12_RESOURCE_DESC1::Tex2D(
-                DXGI_FORMAT_R8G8B8A8_UNORM, 256, 256, 2, 2, 1, 0,
-                D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET);
-            CD3DX12_HEAP_PROPERTIES heapProp(D3D12_HEAP_TYPE_DEFAULT);
-
-            CComPtr<ID3D12Resource> pD3DResource;
-            hr = pDevice10->CreateCommittedResource3(
-                &heapProp, D3D12_HEAP_FLAG_ALLOW_ALL_BUFFERS_AND_TEXTURES,
-                &desc, D3D12_BARRIER_LAYOUT_COMMON, nullptr, nullptr, 0, nullptr,
-                IID_PPV_ARGS(&pD3DResource));
-            Assert::IsTrue(SUCCEEDED(hr));
-
-            CTextureResource tex(pD3DResource, D3D12_BARRIER_LAYOUT_COMMON);
-            Assert::IsTrue(tex.GetCurSubresourceLayout(0) == D3D12_BARRIER_LAYOUT_COMMON);
-            Assert::AreEqual(UINT(4), tex.m_NumSubresources); // 2 array * 2 mip
-
-            // Simulate ComputeFinalLayouts updating the committed state
-            tex.m_CurrentLayout = SubresourceLayout(D3D12_BARRIER_LAYOUT_RENDER_TARGET, tex.m_NumSubresources);
-            Assert::IsTrue(tex.GetCurSubresourceLayout(0) == D3D12_BARRIER_LAYOUT_RENDER_TARGET);
-            Assert::IsTrue(tex.m_CurrentLayout.m_AllSame);
-        }
-    };
 }

--- a/src/CanvasUnitTest/GpuTaskGraphTest.cpp
+++ b/src/CanvasUnitTest/GpuTaskGraphTest.cpp
@@ -1,16 +1,9 @@
 #include "pch.h"
-#include "CppUnitTest.h"
-
-using namespace Microsoft::VisualStudio::CppUnitTestFramework;
-
 namespace CanvasUnitTest
 {
-    TEST_CLASS(GpuTaskGraphTest)
-    {
-    public:
-        TEST_METHOD(Placeholder)
-        {
-            Assert::IsTrue(true);
-        }
-    };
+TEST(GpuTaskGraphTest, Placeholder)
+{
+    EXPECT_TRUE(true);
+}
+
 }

--- a/src/CanvasUnitTest/LightBVHTest.cpp
+++ b/src/CanvasUnitTest/LightBVHTest.cpp
@@ -9,13 +9,10 @@
 //================================================================================================
 
 #include "pch.h"
-#include "CppUnitTest.h"
-
 #include "LightBVH.h"
 
 #include <algorithm>
 
-using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 using namespace Canvas;
 using namespace Canvas::Math;
 
@@ -35,13 +32,13 @@ void MakePointLight(XCanvas* canvas,
                     Gem::TGemPtr<XLight>& outLight,
                     Gem::TGemPtr<XSceneGraphNode>& outNode)
 {
-    Assert::IsTrue(Succeeded(canvas->CreateLight(LightType::Point, &outLight)));
+    EXPECT_TRUE(Succeeded(canvas->CreateLight(LightType::Point, &outLight)));
     outLight->SetRange(range);
 
-    Assert::IsTrue(Succeeded(canvas->CreateSceneGraphNode(&outNode)));
+    EXPECT_TRUE(Succeeded(canvas->CreateSceneGraphNode(&outNode)));
     outNode->SetLocalTranslation(position);
-    Assert::IsTrue(Succeeded(outNode->BindElement(outLight)));
-    Assert::IsTrue(Succeeded(parent->AddChild(outNode)));
+    EXPECT_TRUE(Succeeded(outNode->BindElement(outLight)));
+    EXPECT_TRUE(Succeeded(parent->AddChild(outNode)));
 }
 
 // Forward = +X by convention (Canvas row-vector basis: row 0).  Spot
@@ -54,16 +51,16 @@ void MakeSpotLight(XCanvas* canvas,
                    Gem::TGemPtr<XLight>& outLight,
                    Gem::TGemPtr<XSceneGraphNode>& outNode)
 {
-    Assert::IsTrue(Succeeded(canvas->CreateLight(LightType::Spot, &outLight)));
+    EXPECT_TRUE(Succeeded(canvas->CreateLight(LightType::Spot, &outLight)));
     outLight->SetRange(range);
     const float kDegToRad = 3.14159265f / 180.0f;
     outLight->SetSpotAngles(outerAngleDeg * 0.5f * kDegToRad, outerAngleDeg * kDegToRad);
 
-    Assert::IsTrue(Succeeded(canvas->CreateSceneGraphNode(&outNode)));
+    EXPECT_TRUE(Succeeded(canvas->CreateSceneGraphNode(&outNode)));
     outNode->SetLocalTranslation(position);
     // Identity rotation -- spot aims along the node's +X basis row.
-    Assert::IsTrue(Succeeded(outNode->BindElement(outLight)));
-    Assert::IsTrue(Succeeded(parent->AddChild(outNode)));
+    EXPECT_TRUE(Succeeded(outNode->BindElement(outLight)));
+    EXPECT_TRUE(Succeeded(parent->AddChild(outNode)));
 }
 
 void MakeDirectionalLight(XCanvas* canvas,
@@ -71,10 +68,10 @@ void MakeDirectionalLight(XCanvas* canvas,
                           Gem::TGemPtr<XLight>& outLight,
                           Gem::TGemPtr<XSceneGraphNode>& outNode)
 {
-    Assert::IsTrue(Succeeded(canvas->CreateLight(LightType::Directional, &outLight)));
-    Assert::IsTrue(Succeeded(canvas->CreateSceneGraphNode(&outNode)));
-    Assert::IsTrue(Succeeded(outNode->BindElement(outLight)));
-    Assert::IsTrue(Succeeded(parent->AddChild(outNode)));
+    EXPECT_TRUE(Succeeded(canvas->CreateLight(LightType::Directional, &outLight)));
+    EXPECT_TRUE(Succeeded(canvas->CreateSceneGraphNode(&outNode)));
+    EXPECT_TRUE(Succeeded(outNode->BindElement(outLight)));
+    EXPECT_TRUE(Succeeded(parent->AddChild(outNode)));
 }
 
 void MakeAmbientLight(XCanvas* canvas,
@@ -82,10 +79,10 @@ void MakeAmbientLight(XCanvas* canvas,
                       Gem::TGemPtr<XLight>& outLight,
                       Gem::TGemPtr<XSceneGraphNode>& outNode)
 {
-    Assert::IsTrue(Succeeded(canvas->CreateLight(LightType::Ambient, &outLight)));
-    Assert::IsTrue(Succeeded(canvas->CreateSceneGraphNode(&outNode)));
-    Assert::IsTrue(Succeeded(outNode->BindElement(outLight)));
-    Assert::IsTrue(Succeeded(parent->AddChild(outNode)));
+    EXPECT_TRUE(Succeeded(canvas->CreateLight(LightType::Ambient, &outLight)));
+    EXPECT_TRUE(Succeeded(canvas->CreateSceneGraphNode(&outNode)));
+    EXPECT_TRUE(Succeeded(outNode->BindElement(outLight)));
+    EXPECT_TRUE(Succeeded(parent->AddChild(outNode)));
 }
 
 // Build a row-vector view*proj for a camera at `eye` looking down +X.
@@ -117,182 +114,174 @@ bool ListContains(const std::vector<XLight*>& v, XLight* p)
 
 } // anonymous namespace
 
-TEST_CLASS(LightBVHTest)
+TEST(LightBVHTest, EmptySceneBuildsCleanly)
 {
-public:
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
 
-    TEST_METHOD(EmptySceneBuildsCleanly)
-    {
-        Gem::TGemPtr<XCanvas> pCanvas;
-        Gem::TGemPtr<XGfxDevice> pDevice;
-        CreateTestCanvasAndDevice(pCanvas, pDevice);
+    Gem::TGemPtr<XScene> pScene;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
 
-        Gem::TGemPtr<XScene> pScene;
-        Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
+    LightBVH bvh;
+    bvh.Build(pScene->GetRootNode());
+    EXPECT_TRUE(bvh.IsBuilt());
+    EXPECT_EQ(size_t(0), bvh.TrackedLightCount());
+    EXPECT_EQ(size_t(0), bvh.UntrackedLightCount());
 
-        LightBVH bvh;
-        bvh.Build(pScene->GetRootNode());
-        Assert::IsTrue(bvh.IsBuilt());
-        Assert::AreEqual(size_t(0), bvh.TrackedLightCount());
-        Assert::AreEqual(size_t(0), bvh.UntrackedLightCount());
+    std::vector<XLight*> visible;
+    Frustum f = Frustum::FromViewProjection(
+        PerspectiveReverseZ<float>(1.0f, 1.0f, 1.0f, 100.0f), true);
+    bvh.QueryFrustum(f, visible);
+    EXPECT_EQ(size_t(0), visible.size());
+}
 
-        std::vector<XLight*> visible;
-        Frustum f = Frustum::FromViewProjection(
-            PerspectiveReverseZ<float>(1.0f, 1.0f, 1.0f, 100.0f), true);
-        bvh.QueryFrustum(f, visible);
-        Assert::AreEqual(size_t(0), visible.size());
-    }
+// Directional / Ambient lights have no spatial bound; they must
+// land in the untracked list and never appear in QueryFrustum
+// output.  This is the contract that lets the renderer treat them
+// as always-visible without inflating the BVH.
+TEST(LightBVHTest, NonSpatialLightsAreUntracked)
+{
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+    Gem::TGemPtr<XScene> pScene;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
 
-    // Directional / Ambient lights have no spatial bound; they must
-    // land in the untracked list and never appear in QueryFrustum
-    // output.  This is the contract that lets the renderer treat them
-    // as always-visible without inflating the BVH.
-    TEST_METHOD(NonSpatialLightsAreUntracked)
-    {
-        Gem::TGemPtr<XCanvas> pCanvas;
-        Gem::TGemPtr<XGfxDevice> pDevice;
-        CreateTestCanvasAndDevice(pCanvas, pDevice);
-        Gem::TGemPtr<XScene> pScene;
-        Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
+    Gem::TGemPtr<XLight> pDir, pAmb;
+    Gem::TGemPtr<XSceneGraphNode> pDirNode, pAmbNode;
+    MakeDirectionalLight(pCanvas, pScene->GetRootNode(), pDir, pDirNode);
+    MakeAmbientLight   (pCanvas, pScene->GetRootNode(), pAmb, pAmbNode);
 
-        Gem::TGemPtr<XLight> pDir, pAmb;
-        Gem::TGemPtr<XSceneGraphNode> pDirNode, pAmbNode;
-        MakeDirectionalLight(pCanvas, pScene->GetRootNode(), pDir, pDirNode);
-        MakeAmbientLight   (pCanvas, pScene->GetRootNode(), pAmb, pAmbNode);
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
 
-        Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
+    LightBVH bvh;
+    bvh.Build(pScene->GetRootNode());
+    EXPECT_EQ(size_t(0), bvh.TrackedLightCount());
+    EXPECT_EQ(size_t(2), bvh.UntrackedLightCount());
+    EXPECT_FALSE(bvh.IsTrackedLight(pDir.Get()));
+    EXPECT_FALSE(bvh.IsTrackedLight(pAmb.Get()));
 
-        LightBVH bvh;
-        bvh.Build(pScene->GetRootNode());
-        Assert::AreEqual(size_t(0), bvh.TrackedLightCount());
-        Assert::AreEqual(size_t(2), bvh.UntrackedLightCount());
-        Assert::IsFalse(bvh.IsTrackedLight(pDir.Get()));
-        Assert::IsFalse(bvh.IsTrackedLight(pAmb.Get()));
+    EXPECT_TRUE(ListContains(bvh.GetUntrackedLights(), pDir.Get()));
+    EXPECT_TRUE(ListContains(bvh.GetUntrackedLights(), pAmb.Get()));
 
-        Assert::IsTrue(ListContains(bvh.GetUntrackedLights(), pDir.Get()));
-        Assert::IsTrue(ListContains(bvh.GetUntrackedLights(), pAmb.Get()));
+    // Untracked lights never come out of the frustum query (by design).
+    std::vector<XLight*> visible;
+    Frustum f = Frustum::FromViewProjection(
+        PerspectiveReverseZ<float>(1.0f, 1.0f, 1.0f, 100.0f), true);
+    bvh.QueryFrustum(f, visible);
+    EXPECT_EQ(size_t(0), visible.size());
+}
 
-        // Untracked lights never come out of the frustum query (by design).
-        std::vector<XLight*> visible;
-        Frustum f = Frustum::FromViewProjection(
-            PerspectiveReverseZ<float>(1.0f, 1.0f, 1.0f, 100.0f), true);
-        bvh.QueryFrustum(f, visible);
-        Assert::AreEqual(size_t(0), visible.size());
-    }
+TEST(LightBVHTest, PointLightsAreTrackedAndCulled)
+{
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+    Gem::TGemPtr<XScene> pScene;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
 
-    TEST_METHOD(PointLightsAreTrackedAndCulled)
-    {
-        Gem::TGemPtr<XCanvas> pCanvas;
-        Gem::TGemPtr<XGfxDevice> pDevice;
-        CreateTestCanvasAndDevice(pCanvas, pDevice);
-        Gem::TGemPtr<XScene> pScene;
-        Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
+    // Three point lights:
+    //   pInFront -- inside the camera frustum
+    //   pSide    -- well outside the FOV
+    //   pBehind  -- behind the camera
+    Gem::TGemPtr<XLight> pInFront, pSide, pBehind;
+    Gem::TGemPtr<XSceneGraphNode> pInFrontNode, pSideNode, pBehindNode;
+    MakePointLight(pCanvas, pScene->GetRootNode(),
+                   FloatVector4(10.0f, 0.0f, 0.0f, 1.0f), 1.0f, pInFront, pInFrontNode);
+    MakePointLight(pCanvas, pScene->GetRootNode(),
+                   FloatVector4(10.0f, 50.0f, 0.0f, 1.0f), 1.0f, pSide,    pSideNode);
+    MakePointLight(pCanvas, pScene->GetRootNode(),
+                   FloatVector4(-10.0f, 0.0f, 0.0f, 1.0f), 1.0f, pBehind,  pBehindNode);
 
-        // Three point lights:
-        //   pInFront -- inside the camera frustum
-        //   pSide    -- well outside the FOV
-        //   pBehind  -- behind the camera
-        Gem::TGemPtr<XLight> pInFront, pSide, pBehind;
-        Gem::TGemPtr<XSceneGraphNode> pInFrontNode, pSideNode, pBehindNode;
-        MakePointLight(pCanvas, pScene->GetRootNode(),
-                       FloatVector4(10.0f, 0.0f, 0.0f, 1.0f), 1.0f, pInFront, pInFrontNode);
-        MakePointLight(pCanvas, pScene->GetRootNode(),
-                       FloatVector4(10.0f, 50.0f, 0.0f, 1.0f), 1.0f, pSide,    pSideNode);
-        MakePointLight(pCanvas, pScene->GetRootNode(),
-                       FloatVector4(-10.0f, 0.0f, 0.0f, 1.0f), 1.0f, pBehind,  pBehindNode);
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
 
-        Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
+    LightBVH bvh;
+    bvh.Build(pScene->GetRootNode());
+    EXPECT_EQ(size_t(3), bvh.TrackedLightCount());
+    EXPECT_EQ(size_t(0), bvh.UntrackedLightCount());
+    EXPECT_TRUE(bvh.IsTrackedLight(pInFront.Get()));
+    EXPECT_TRUE(bvh.IsTrackedLight(pSide.Get()));
+    EXPECT_TRUE(bvh.IsTrackedLight(pBehind.Get()));
 
-        LightBVH bvh;
-        bvh.Build(pScene->GetRootNode());
-        Assert::AreEqual(size_t(3), bvh.TrackedLightCount());
-        Assert::AreEqual(size_t(0), bvh.UntrackedLightCount());
-        Assert::IsTrue(bvh.IsTrackedLight(pInFront.Get()));
-        Assert::IsTrue(bvh.IsTrackedLight(pSide.Get()));
-        Assert::IsTrue(bvh.IsTrackedLight(pBehind.Get()));
+    // Camera at origin looking down +X, 60deg FOV, near 0.5, far 100.
+    FloatMatrix4x4 vp = BuildViewProjLookingAlongX(
+        FloatVector4(0.0f, 0.0f, 0.0f, 1.0f),
+        float(3.14159 / 3), 1.0f, 0.5f, 100.0f);
+    Frustum f = Frustum::FromViewProjection(vp, true);
 
-        // Camera at origin looking down +X, 60deg FOV, near 0.5, far 100.
-        FloatMatrix4x4 vp = BuildViewProjLookingAlongX(
-            FloatVector4(0.0f, 0.0f, 0.0f, 1.0f),
-            float(3.14159 / 3), 1.0f, 0.5f, 100.0f);
-        Frustum f = Frustum::FromViewProjection(vp, true);
+    std::vector<XLight*> visible;
+    bvh.QueryFrustum(f, visible);
 
-        std::vector<XLight*> visible;
-        bvh.QueryFrustum(f, visible);
+    EXPECT_TRUE(ListContains(visible, pInFront.Get())) << "In-front point light must be visible";
+    EXPECT_FALSE(ListContains(visible, pSide.Get())) << "Side-offset point light must be culled";
+    EXPECT_FALSE(ListContains(visible, pBehind.Get())) << "Behind-camera point light must be culled";
+}
 
-        Assert::IsTrue(ListContains(visible, pInFront.Get()),
-                       L"In-front point light must be visible");
-        Assert::IsFalse(ListContains(visible, pSide.Get()),
-                        L"Side-offset point light must be culled");
-        Assert::IsFalse(ListContains(visible, pBehind.Get()),
-                        L"Behind-camera point light must be culled");
-    }
+TEST(LightBVHTest, SpotLightsAreTracked)
+{
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+    Gem::TGemPtr<XScene> pScene;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
 
-    TEST_METHOD(SpotLightsAreTracked)
-    {
-        Gem::TGemPtr<XCanvas> pCanvas;
-        Gem::TGemPtr<XGfxDevice> pDevice;
-        CreateTestCanvasAndDevice(pCanvas, pDevice);
-        Gem::TGemPtr<XScene> pScene;
-        Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
+    Gem::TGemPtr<XLight> pSpot;
+    Gem::TGemPtr<XSceneGraphNode> pSpotNode;
+    MakeSpotLight(pCanvas, pScene->GetRootNode(),
+                  FloatVector4(5.0f, 0.0f, 0.0f, 1.0f),
+                  10.0f, /*outerDeg*/ 30.0f,
+                  pSpot, pSpotNode);
 
-        Gem::TGemPtr<XLight> pSpot;
-        Gem::TGemPtr<XSceneGraphNode> pSpotNode;
-        MakeSpotLight(pCanvas, pScene->GetRootNode(),
-                      FloatVector4(5.0f, 0.0f, 0.0f, 1.0f),
-                      10.0f, /*outerDeg*/ 30.0f,
-                      pSpot, pSpotNode);
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
 
-        Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
+    LightBVH bvh;
+    bvh.Build(pScene->GetRootNode());
+    EXPECT_EQ(size_t(1), bvh.TrackedLightCount());
+    EXPECT_TRUE(bvh.IsTrackedLight(pSpot.Get()));
 
-        LightBVH bvh;
-        bvh.Build(pScene->GetRootNode());
-        Assert::AreEqual(size_t(1), bvh.TrackedLightCount());
-        Assert::IsTrue(bvh.IsTrackedLight(pSpot.Get()));
+    // Camera at origin looking down +X sees the spot apex.
+    FloatMatrix4x4 vp = BuildViewProjLookingAlongX(
+        FloatVector4(0.0f, 0.0f, 0.0f, 1.0f),
+        float(3.14159 / 3), 1.0f, 0.5f, 100.0f);
+    Frustum f = Frustum::FromViewProjection(vp, true);
 
-        // Camera at origin looking down +X sees the spot apex.
-        FloatMatrix4x4 vp = BuildViewProjLookingAlongX(
-            FloatVector4(0.0f, 0.0f, 0.0f, 1.0f),
-            float(3.14159 / 3), 1.0f, 0.5f, 100.0f);
-        Frustum f = Frustum::FromViewProjection(vp, true);
+    std::vector<XLight*> visible;
+    bvh.QueryFrustum(f, visible);
+    EXPECT_TRUE(ListContains(visible, pSpot.Get()));
+}
 
-        std::vector<XLight*> visible;
-        bvh.QueryFrustum(f, visible);
-        Assert::IsTrue(ListContains(visible, pSpot.Get()));
-    }
+// Rebuild must drop every primitive / tracking record from a prior
+// build before consuming the new scene.  Defends against state
+// accumulation when scene topology changes between Build calls.
+TEST(LightBVHTest, RebuildClearsPriorState)
+{
+    Gem::TGemPtr<XCanvas> pCanvas;
+    Gem::TGemPtr<XGfxDevice> pDevice;
+    CreateTestCanvasAndDevice(pCanvas, pDevice);
+    Gem::TGemPtr<XScene> pScene;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
 
-    // Rebuild must drop every primitive / tracking record from a prior
-    // build before consuming the new scene.  Defends against state
-    // accumulation when scene topology changes between Build calls.
-    TEST_METHOD(RebuildClearsPriorState)
-    {
-        Gem::TGemPtr<XCanvas> pCanvas;
-        Gem::TGemPtr<XGfxDevice> pDevice;
-        CreateTestCanvasAndDevice(pCanvas, pDevice);
-        Gem::TGemPtr<XScene> pScene;
-        Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
+    Gem::TGemPtr<XLight> pPt;
+    Gem::TGemPtr<XSceneGraphNode> pPtNode;
+    MakePointLight(pCanvas, pScene->GetRootNode(),
+                   FloatVector4(1.0f, 0.0f, 0.0f, 1.0f), 1.0f, pPt, pPtNode);
 
-        Gem::TGemPtr<XLight> pPt;
-        Gem::TGemPtr<XSceneGraphNode> pPtNode;
-        MakePointLight(pCanvas, pScene->GetRootNode(),
-                       FloatVector4(1.0f, 0.0f, 0.0f, 1.0f), 1.0f, pPt, pPtNode);
+    EXPECT_TRUE(Succeeded(pScene->Update(0.0f)));
 
-        Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
+    LightBVH bvh;
+    bvh.Build(pScene->GetRootNode());
+    EXPECT_EQ(size_t(1), bvh.TrackedLightCount());
+    XLight* pPtRaw = pPt.Get();
+    EXPECT_TRUE(bvh.IsTrackedLight(pPtRaw));
 
-        LightBVH bvh;
-        bvh.Build(pScene->GetRootNode());
-        Assert::AreEqual(size_t(1), bvh.TrackedLightCount());
-        XLight* pPtRaw = pPt.Get();
-        Assert::IsTrue(bvh.IsTrackedLight(pPtRaw));
-
-        // Rebuild against an empty root.
-        Gem::TGemPtr<XSceneGraphNode> pEmpty;
-        Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pEmpty)));
-        bvh.Build(pEmpty);
-        Assert::AreEqual(size_t(0), bvh.TrackedLightCount());
-        Assert::AreEqual(size_t(0), bvh.UntrackedLightCount());
-        Assert::IsFalse(bvh.IsTrackedLight(pPtRaw));
-    }
-};
+    // Rebuild against an empty root.
+    Gem::TGemPtr<XSceneGraphNode> pEmpty;
+    EXPECT_TRUE(Succeeded(pCanvas->CreateSceneGraphNode(&pEmpty)));
+    bvh.Build(pEmpty);
+    EXPECT_EQ(size_t(0), bvh.TrackedLightCount());
+    EXPECT_EQ(size_t(0), bvh.UntrackedLightCount());
+    EXPECT_FALSE(bvh.IsTrackedLight(pPtRaw));
+}
 
 } // namespace CanvasUnitTest

--- a/src/CanvasUnitTest/LightBVHTest.cpp
+++ b/src/CanvasUnitTest/LightBVHTest.cpp
@@ -1,0 +1,298 @@
+//================================================================================================
+// LightBVHTest -- correctness tests for per-light influence culling.
+//
+// Tests run against the real CanvasCore factory (XCanvas, XLight,
+// XSceneGraphNode) and the engine-loaded CanvasGfx12 plugin (only
+// because XScene construction needs an XGfxDevice).  No GPU work is
+// dispatched; we just exercise the LightBVH classification and
+// frustum-query logic against a hand-built scene graph.
+//================================================================================================
+
+#include "pch.h"
+#include "CppUnitTest.h"
+
+#include "LightBVH.h"
+
+#include <algorithm>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace Canvas;
+using namespace Canvas::Math;
+
+namespace CanvasUnitTest
+{
+
+namespace
+{
+
+// Create a point light at `position` with `range`, attach it under
+// the given parent, and return both the light and its node.  Light
+// is left in the default-enabled state.
+void MakePointLight(XCanvas* canvas,
+                    XSceneGraphNode* parent,
+                    const FloatVector4& position,
+                    float range,
+                    Gem::TGemPtr<XLight>& outLight,
+                    Gem::TGemPtr<XSceneGraphNode>& outNode)
+{
+    Assert::IsTrue(Succeeded(canvas->CreateLight(LightType::Point, &outLight)));
+    outLight->SetRange(range);
+
+    Assert::IsTrue(Succeeded(canvas->CreateSceneGraphNode(&outNode)));
+    outNode->SetLocalTranslation(position);
+    Assert::IsTrue(Succeeded(outNode->BindElement(outLight)));
+    Assert::IsTrue(Succeeded(parent->AddChild(outNode)));
+}
+
+// Forward = +X by convention (Canvas row-vector basis: row 0).  Spot
+// light starts aimed along world +X from its position.
+void MakeSpotLight(XCanvas* canvas,
+                   XSceneGraphNode* parent,
+                   const FloatVector4& position,
+                   float range,
+                   float outerAngleDeg,
+                   Gem::TGemPtr<XLight>& outLight,
+                   Gem::TGemPtr<XSceneGraphNode>& outNode)
+{
+    Assert::IsTrue(Succeeded(canvas->CreateLight(LightType::Spot, &outLight)));
+    outLight->SetRange(range);
+    const float kDegToRad = 3.14159265f / 180.0f;
+    outLight->SetSpotAngles(outerAngleDeg * 0.5f * kDegToRad, outerAngleDeg * kDegToRad);
+
+    Assert::IsTrue(Succeeded(canvas->CreateSceneGraphNode(&outNode)));
+    outNode->SetLocalTranslation(position);
+    // Identity rotation -- spot aims along the node's +X basis row.
+    Assert::IsTrue(Succeeded(outNode->BindElement(outLight)));
+    Assert::IsTrue(Succeeded(parent->AddChild(outNode)));
+}
+
+void MakeDirectionalLight(XCanvas* canvas,
+                          XSceneGraphNode* parent,
+                          Gem::TGemPtr<XLight>& outLight,
+                          Gem::TGemPtr<XSceneGraphNode>& outNode)
+{
+    Assert::IsTrue(Succeeded(canvas->CreateLight(LightType::Directional, &outLight)));
+    Assert::IsTrue(Succeeded(canvas->CreateSceneGraphNode(&outNode)));
+    Assert::IsTrue(Succeeded(outNode->BindElement(outLight)));
+    Assert::IsTrue(Succeeded(parent->AddChild(outNode)));
+}
+
+void MakeAmbientLight(XCanvas* canvas,
+                      XSceneGraphNode* parent,
+                      Gem::TGemPtr<XLight>& outLight,
+                      Gem::TGemPtr<XSceneGraphNode>& outNode)
+{
+    Assert::IsTrue(Succeeded(canvas->CreateLight(LightType::Ambient, &outLight)));
+    Assert::IsTrue(Succeeded(canvas->CreateSceneGraphNode(&outNode)));
+    Assert::IsTrue(Succeeded(outNode->BindElement(outLight)));
+    Assert::IsTrue(Succeeded(parent->AddChild(outNode)));
+}
+
+// Build a row-vector view*proj for a camera at `eye` looking down +X.
+// Forward = +X, side = +Y, up = +Z (Canvas convention).  Reverse-Z
+// projection so it matches Frustum::FromViewProjection's default.
+FloatMatrix4x4 BuildViewProjLookingAlongX(const FloatVector4& eye,
+                                          float fovY, float aspect,
+                                          float zn, float zf)
+{
+    FloatMatrix4x4 view = {};
+    // basis: forward=+X, side=+Y, up=+Z stored as columns of view
+    // (row-vector: world->view multiply column-wise).
+    view.M[0][0] = 0.0f; view.M[0][1] = 0.0f; view.M[0][2] = 1.0f; view.M[0][3] = 0.0f; // world X -> view forward (+Z)
+    view.M[1][0] = 1.0f; view.M[1][1] = 0.0f; view.M[1][2] = 0.0f; view.M[1][3] = 0.0f; // world Y -> view side (+X)
+    view.M[2][0] = 0.0f; view.M[2][1] = 1.0f; view.M[2][2] = 0.0f; view.M[2][3] = 0.0f; // world Z -> view up (+Y)
+    view.M[3][0] = -eye.V[1];
+    view.M[3][1] = -eye.V[2];
+    view.M[3][2] = -eye.V[0];
+    view.M[3][3] = 1.0f;
+
+    FloatMatrix4x4 proj = PerspectiveReverseZ<float>(fovY, aspect, zn, zf);
+    return view * proj;
+}
+
+bool ListContains(const std::vector<XLight*>& v, XLight* p)
+{
+    return std::find(v.begin(), v.end(), p) != v.end();
+}
+
+} // anonymous namespace
+
+TEST_CLASS(LightBVHTest)
+{
+public:
+
+    TEST_METHOD(EmptySceneBuildsCleanly)
+    {
+        Gem::TGemPtr<XCanvas> pCanvas;
+        Gem::TGemPtr<XGfxDevice> pDevice;
+        CreateTestCanvasAndDevice(pCanvas, pDevice);
+
+        Gem::TGemPtr<XScene> pScene;
+        Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
+
+        LightBVH bvh;
+        bvh.Build(pScene->GetRootNode());
+        Assert::IsTrue(bvh.IsBuilt());
+        Assert::AreEqual(size_t(0), bvh.TrackedLightCount());
+        Assert::AreEqual(size_t(0), bvh.UntrackedLightCount());
+
+        std::vector<XLight*> visible;
+        Frustum f = Frustum::FromViewProjection(
+            PerspectiveReverseZ<float>(1.0f, 1.0f, 1.0f, 100.0f), true);
+        bvh.QueryFrustum(f, visible);
+        Assert::AreEqual(size_t(0), visible.size());
+    }
+
+    // Directional / Ambient lights have no spatial bound; they must
+    // land in the untracked list and never appear in QueryFrustum
+    // output.  This is the contract that lets the renderer treat them
+    // as always-visible without inflating the BVH.
+    TEST_METHOD(NonSpatialLightsAreUntracked)
+    {
+        Gem::TGemPtr<XCanvas> pCanvas;
+        Gem::TGemPtr<XGfxDevice> pDevice;
+        CreateTestCanvasAndDevice(pCanvas, pDevice);
+        Gem::TGemPtr<XScene> pScene;
+        Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
+
+        Gem::TGemPtr<XLight> pDir, pAmb;
+        Gem::TGemPtr<XSceneGraphNode> pDirNode, pAmbNode;
+        MakeDirectionalLight(pCanvas, pScene->GetRootNode(), pDir, pDirNode);
+        MakeAmbientLight   (pCanvas, pScene->GetRootNode(), pAmb, pAmbNode);
+
+        Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
+
+        LightBVH bvh;
+        bvh.Build(pScene->GetRootNode());
+        Assert::AreEqual(size_t(0), bvh.TrackedLightCount());
+        Assert::AreEqual(size_t(2), bvh.UntrackedLightCount());
+        Assert::IsFalse(bvh.IsTrackedLight(pDir.Get()));
+        Assert::IsFalse(bvh.IsTrackedLight(pAmb.Get()));
+
+        Assert::IsTrue(ListContains(bvh.GetUntrackedLights(), pDir.Get()));
+        Assert::IsTrue(ListContains(bvh.GetUntrackedLights(), pAmb.Get()));
+
+        // Untracked lights never come out of the frustum query (by design).
+        std::vector<XLight*> visible;
+        Frustum f = Frustum::FromViewProjection(
+            PerspectiveReverseZ<float>(1.0f, 1.0f, 1.0f, 100.0f), true);
+        bvh.QueryFrustum(f, visible);
+        Assert::AreEqual(size_t(0), visible.size());
+    }
+
+    TEST_METHOD(PointLightsAreTrackedAndCulled)
+    {
+        Gem::TGemPtr<XCanvas> pCanvas;
+        Gem::TGemPtr<XGfxDevice> pDevice;
+        CreateTestCanvasAndDevice(pCanvas, pDevice);
+        Gem::TGemPtr<XScene> pScene;
+        Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
+
+        // Three point lights:
+        //   pInFront -- inside the camera frustum
+        //   pSide    -- well outside the FOV
+        //   pBehind  -- behind the camera
+        Gem::TGemPtr<XLight> pInFront, pSide, pBehind;
+        Gem::TGemPtr<XSceneGraphNode> pInFrontNode, pSideNode, pBehindNode;
+        MakePointLight(pCanvas, pScene->GetRootNode(),
+                       FloatVector4(10.0f, 0.0f, 0.0f, 1.0f), 1.0f, pInFront, pInFrontNode);
+        MakePointLight(pCanvas, pScene->GetRootNode(),
+                       FloatVector4(10.0f, 50.0f, 0.0f, 1.0f), 1.0f, pSide,    pSideNode);
+        MakePointLight(pCanvas, pScene->GetRootNode(),
+                       FloatVector4(-10.0f, 0.0f, 0.0f, 1.0f), 1.0f, pBehind,  pBehindNode);
+
+        Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
+
+        LightBVH bvh;
+        bvh.Build(pScene->GetRootNode());
+        Assert::AreEqual(size_t(3), bvh.TrackedLightCount());
+        Assert::AreEqual(size_t(0), bvh.UntrackedLightCount());
+        Assert::IsTrue(bvh.IsTrackedLight(pInFront.Get()));
+        Assert::IsTrue(bvh.IsTrackedLight(pSide.Get()));
+        Assert::IsTrue(bvh.IsTrackedLight(pBehind.Get()));
+
+        // Camera at origin looking down +X, 60deg FOV, near 0.5, far 100.
+        FloatMatrix4x4 vp = BuildViewProjLookingAlongX(
+            FloatVector4(0.0f, 0.0f, 0.0f, 1.0f),
+            float(3.14159 / 3), 1.0f, 0.5f, 100.0f);
+        Frustum f = Frustum::FromViewProjection(vp, true);
+
+        std::vector<XLight*> visible;
+        bvh.QueryFrustum(f, visible);
+
+        Assert::IsTrue(ListContains(visible, pInFront.Get()),
+                       L"In-front point light must be visible");
+        Assert::IsFalse(ListContains(visible, pSide.Get()),
+                        L"Side-offset point light must be culled");
+        Assert::IsFalse(ListContains(visible, pBehind.Get()),
+                        L"Behind-camera point light must be culled");
+    }
+
+    TEST_METHOD(SpotLightsAreTracked)
+    {
+        Gem::TGemPtr<XCanvas> pCanvas;
+        Gem::TGemPtr<XGfxDevice> pDevice;
+        CreateTestCanvasAndDevice(pCanvas, pDevice);
+        Gem::TGemPtr<XScene> pScene;
+        Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
+
+        Gem::TGemPtr<XLight> pSpot;
+        Gem::TGemPtr<XSceneGraphNode> pSpotNode;
+        MakeSpotLight(pCanvas, pScene->GetRootNode(),
+                      FloatVector4(5.0f, 0.0f, 0.0f, 1.0f),
+                      10.0f, /*outerDeg*/ 30.0f,
+                      pSpot, pSpotNode);
+
+        Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
+
+        LightBVH bvh;
+        bvh.Build(pScene->GetRootNode());
+        Assert::AreEqual(size_t(1), bvh.TrackedLightCount());
+        Assert::IsTrue(bvh.IsTrackedLight(pSpot.Get()));
+
+        // Camera at origin looking down +X sees the spot apex.
+        FloatMatrix4x4 vp = BuildViewProjLookingAlongX(
+            FloatVector4(0.0f, 0.0f, 0.0f, 1.0f),
+            float(3.14159 / 3), 1.0f, 0.5f, 100.0f);
+        Frustum f = Frustum::FromViewProjection(vp, true);
+
+        std::vector<XLight*> visible;
+        bvh.QueryFrustum(f, visible);
+        Assert::IsTrue(ListContains(visible, pSpot.Get()));
+    }
+
+    // Rebuild must drop every primitive / tracking record from a prior
+    // build before consuming the new scene.  Defends against state
+    // accumulation when scene topology changes between Build calls.
+    TEST_METHOD(RebuildClearsPriorState)
+    {
+        Gem::TGemPtr<XCanvas> pCanvas;
+        Gem::TGemPtr<XGfxDevice> pDevice;
+        CreateTestCanvasAndDevice(pCanvas, pDevice);
+        Gem::TGemPtr<XScene> pScene;
+        Assert::IsTrue(Succeeded(pCanvas->CreateScene(pDevice, &pScene)));
+
+        Gem::TGemPtr<XLight> pPt;
+        Gem::TGemPtr<XSceneGraphNode> pPtNode;
+        MakePointLight(pCanvas, pScene->GetRootNode(),
+                       FloatVector4(1.0f, 0.0f, 0.0f, 1.0f), 1.0f, pPt, pPtNode);
+
+        Assert::IsTrue(Succeeded(pScene->Update(0.0f)));
+
+        LightBVH bvh;
+        bvh.Build(pScene->GetRootNode());
+        Assert::AreEqual(size_t(1), bvh.TrackedLightCount());
+        XLight* pPtRaw = pPt.Get();
+        Assert::IsTrue(bvh.IsTrackedLight(pPtRaw));
+
+        // Rebuild against an empty root.
+        Gem::TGemPtr<XSceneGraphNode> pEmpty;
+        Assert::IsTrue(Succeeded(pCanvas->CreateSceneGraphNode(&pEmpty)));
+        bvh.Build(pEmpty);
+        Assert::AreEqual(size_t(0), bvh.TrackedLightCount());
+        Assert::AreEqual(size_t(0), bvh.UntrackedLightCount());
+        Assert::IsFalse(bvh.IsTrackedLight(pPtRaw));
+    }
+};
+
+} // namespace CanvasUnitTest

--- a/src/CanvasUnitTest/pch.h
+++ b/src/CanvasUnitTest/pch.h
@@ -13,9 +13,10 @@
 #include <atlbase.h>
 #include <comdef.h>
 
-// Headers for CppUnitTest
+// GoogleTest framework
+#include <gtest/gtest.h>
+
 #include "Gem.hpp"
-#include "CppUnitTest.h"
 #include "CanvasMath.hpp"
 #include "CanvasCore.h"
 #include "CanvasGfx.h"
@@ -35,13 +36,10 @@ inline void CreateTestCanvasAndDevice(
     Gem::TGemPtr<Canvas::XCanvas>& pCanvas,
     Gem::TGemPtr<Canvas::XGfxDevice>& pDevice)
 {
-    using Microsoft::VisualStudio::CppUnitTestFramework::Assert;
-    Assert::IsTrue(Succeeded(Canvas::CreateCanvas(nullptr, &pCanvas)));
+    ASSERT_TRUE(Succeeded(Canvas::CreateCanvas(nullptr, &pCanvas)));
     Gem::TGemPtr<Canvas::XCanvasPlugin> pPlugin;
-    Assert::IsTrue(Succeeded(pCanvas->LoadPlugin("CanvasGfx12.dll", &pPlugin)));
-    Assert::IsTrue(Succeeded(pPlugin->CreateCanvasElement(
+    ASSERT_TRUE(Succeeded(pCanvas->LoadPlugin("CanvasGfx12.dll", &pPlugin)));
+    ASSERT_TRUE(Succeeded(pPlugin->CreateCanvasElement(
         pCanvas, Canvas::TypeId::TypeId_GfxDevice, "TestDevice",
         Canvas::XGfxDevice::IId, reinterpret_cast<void**>(&pDevice))));
 }
-
-// TODO: reference additional headers your program requires here

--- a/src/HLSL/HlslTypes.h
+++ b/src/HLSL/HlslTypes.h
@@ -26,7 +26,7 @@ typedef uint32_t uint;
 #define LIGHT_SPOT        3
 #define LIGHT_AREA        4
 
-#define MAX_LIGHTS_PER_REGION 16
+#define MAX_LIGHTS_PER_REGION 1024
 
 #ifdef __cplusplus
 namespace HlslTypes {
@@ -132,7 +132,11 @@ struct ALIGN16 HlslPerFrameConstants
     float  _MoonPad1;
     float  _MoonPad2;
 
-    HlslLight Lights[MAX_LIGHTS_PER_REGION];
+    // Per-frame lights live in a separate StructuredBuffer<HlslLight>
+    // bound at t8, sized to LightCount.  Kept out of this CB so the
+    // per-frame constants stay small and LightCount can scale beyond
+    // a fixed-size CB array.  See PSComposite.hlsl for the buffer
+    // declaration.
 };
 
 struct ALIGN16 HlslPerObjectConstants

--- a/src/HLSL/HlslTypes.h
+++ b/src/HLSL/HlslTypes.h
@@ -26,7 +26,12 @@ typedef uint32_t uint;
 #define LIGHT_SPOT        3
 #define LIGHT_AREA        4
 
-#define MAX_LIGHTS_PER_REGION 1024
+// Forward+ tile parameters.  The composite shader divides
+// SV_Position.xy by LIGHT_TILE_SIZE_PIXELS to find the screen tile
+// owning a pixel; that tile's row in TileLightIndices lists up to
+// MAX_LIGHTS_PER_TILE indices into the per-frame Lights buffer.
+#define LIGHT_TILE_SIZE_PIXELS 32
+#define MAX_LIGHTS_PER_TILE     32
 
 #ifdef __cplusplus
 namespace HlslTypes {
@@ -131,6 +136,16 @@ struct ALIGN16 HlslPerFrameConstants
     float  _MoonPad0;
     float  _MoonPad1;
     float  _MoonPad2;
+
+    // Forward+ tile-binning parameters.  LightTileCountX/Y give the
+    // grid dimensions for the current framebuffer (ceil(W / tileSize),
+    // ceil(H / tileSize)); LightTileSizePixels is the square tile edge
+    // length and matches LIGHT_TILE_SIZE_PIXELS.  The shader uses these
+    // to index TileLightCounts (t9) and TileLightIndices (t10).
+    uint   LightTileCountX;
+    uint   LightTileCountY;
+    uint   LightTileSizePixels;
+    uint   _LightTilePad0;
 
     // Per-frame lights live in a separate StructuredBuffer<HlslLight>
     // bound at t8, sized to LightCount.  Kept out of this CB so the

--- a/src/HLSL/PSComposite.hlsl
+++ b/src/HLSL/PSComposite.hlsl
@@ -44,6 +44,18 @@ ConstantBuffer<HlslPerFrameConstants> PerFrame : register(b0);
 // composite stays at 8).
 StructuredBuffer<HlslLight> Lights : register(t8);
 
+// Forward+ tile data.  Together with PerFrame.LightTileCountX /
+// LightTileSizePixels these let a pixel resolve the (up to
+// MAX_LIGHTS_PER_TILE) light indices that actually influence its
+// screen tile.  TileLightCounts[t] holds the active index count for
+// tile t; TileLightIndices[t * MAX_LIGHTS_PER_TILE + i] is the i-th
+// index (into the Lights buffer above) for that tile.  Always-on
+// lights (ambient / directional) are pre-baked into every tile's list
+// by the engine, so the shader's per-tile loop is the sole light
+// iteration -- no separate "global" pass.
+StructuredBuffer<uint> TileLightCounts  : register(t9);
+StructuredBuffer<uint> TileLightIndices : register(t10);
+
 static const float PI = 3.14159265358979323846;
 static const float INV_PI = 1.0 / PI;
 static const float INV_FOUR_PI = 1.0 / (4.0 * PI);
@@ -305,9 +317,24 @@ float4 PSComposite(FSInput input) : SV_Target0
     // Accumulate lighting from all active lights
     float3 totalLight = float3(0.0, 0.0, 0.0);
 
-    for (uint i = 0; i < PerFrame.LightCount; ++i)
+    // Forward+: find the screen tile owning this pixel, read its
+    // light-index count, and iterate only the lights the engine binned
+    // into this tile.  Always-on lights (ambient / directional) are
+    // already present in every tile's list, so this single loop covers
+    // them too.  The clamp guards pixels that fall exactly on the
+    // right/bottom edge of the framebuffer (SV_Position.xy is the
+    // pixel center, so within-bounds pixels never trip it, but
+    // out-of-range framebuffer sizes or partial tiles might).
+    uint2 tileXY = uint2(input.Position.xy) / PerFrame.LightTileSizePixels;
+    tileXY.x = min(tileXY.x, PerFrame.LightTileCountX - 1);
+    tileXY.y = min(tileXY.y, PerFrame.LightTileCountY - 1);
+    uint tileIdx  = tileXY.y * PerFrame.LightTileCountX + tileXY.x;
+    uint tileBase = tileIdx * MAX_LIGHTS_PER_TILE;
+    uint tileCount = TileLightCounts[tileIdx];
+
+    for (uint i = 0; i < tileCount; ++i)
     {
-        HlslLight light = Lights[i];
+        HlslLight light = Lights[TileLightIndices[tileBase + i]];
 
         if (light.Type == LIGHT_DIRECTIONAL)
         {

--- a/src/HLSL/PSComposite.hlsl
+++ b/src/HLSL/PSComposite.hlsl
@@ -37,6 +37,13 @@ SamplerComparisonState ShadowCmpSampler  : register(s3);
 
 ConstantBuffer<HlslPerFrameConstants> PerFrame : register(b0);
 
+// Per-frame light table.  Sized to PerFrame.LightCount; uploaded by
+// the engine each frame from the visible-light set produced by the
+// Scene's LightBVH cull + importance sort.  Bound as a root SRV (no
+// descriptor table entry, so the descriptor heap slot count for the
+// composite stays at 8).
+StructuredBuffer<HlslLight> Lights : register(t8);
+
 static const float PI = 3.14159265358979323846;
 static const float INV_PI = 1.0 / PI;
 static const float INV_FOUR_PI = 1.0 / (4.0 * PI);
@@ -298,9 +305,9 @@ float4 PSComposite(FSInput input) : SV_Target0
     // Accumulate lighting from all active lights
     float3 totalLight = float3(0.0, 0.0, 0.0);
 
-    for (uint i = 0; i < PerFrame.LightCount && i < MAX_LIGHTS_PER_REGION; ++i)
+    for (uint i = 0; i < PerFrame.LightCount; ++i)
     {
-        HlslLight light = PerFrame.Lights[i];
+        HlslLight light = Lights[i];
 
         if (light.Type == LIGHT_DIRECTIONAL)
         {

--- a/src/Inc/CanvasCore.h
+++ b/src/Inc/CanvasCore.h
@@ -325,17 +325,20 @@ XSceneGraphElement : public XCanvasElement
 
     GEMMETHOD(Update)(float dtime) = 0;
 
-    // Element-local axis-aligned bounding box of the element's GEOMETRY.
+    // Element-local axis-aligned bounding box of the element's RENDERED
+    // EXTENT.
     //
     // Returned in node-local coordinates -- transformed through the
     // attached node's global matrix to obtain a world-space AABB for
     // shadow-caster aggregation, frustum culling of renderables, or
-    // spatial subdivision of scene geometry.
+    // spatial subdivision of the scene.
     //
-    // "Geometry" here is the element's physical extent: a mesh's vertex
-    // envelope, a model's union-of-meshes envelope.  Non-geometric
-    // elements (XLight, XCamera, ambient) return an empty AABB so they
-    // contribute nothing to geometric aggregates.
+    // The extent here is the element's physical region in space: a
+    // mesh's vertex envelope, a model's union-of-meshes envelope, a
+    // future particle system's emitter+lifetime envelope, a decal's
+    // projector volume.  Non-renderable elements (XLight, XCamera,
+    // ambient) return an empty AABB so they contribute nothing to
+    // renderable aggregates.
     //
     // Their AREAS OF INFLUENCE -- point/spot light attenuation volumes,
     // camera view frusta -- are a separate concept reported by
@@ -345,13 +348,14 @@ XSceneGraphElement : public XCanvasElement
 
     // Element-local axis-aligned bounding box of the element's AREA OF
     // INFLUENCE: the spatial region in which this element affects
-    // rendering or simulation, but does not itself occupy as geometry.
+    // rendering or simulation, but does not itself occupy as a
+    // renderable.
     //
     //   Point light  -> attenuation cutoff sphere -> AABB
     //   Spot light   -> attenuation + cone        -> AABB
     //   Camera       -> view frustum              -> AABB
     //   Directional / ambient light -> empty (infinite, no spatial bound)
-    //   XMeshInstance / XModel      -> empty (geometry-only, no influence)
+    //   XMeshInstance / XModel      -> empty (renderable-only, no influence)
     //
     // Aggregating shadow casters and aggregating light influences are
     // distinct queries served by separate methods (GetLocalBounds vs
@@ -476,6 +480,16 @@ XScene : public XCanvasElement
 
     GEMMETHOD(Update)(float dtime) = 0;
     GEMMETHOD(SubmitRenderables)(XGfxRenderQueue *pRenderQueue) = 0;
+
+    // Rebuild the scene's BVH over renderable scene elements.  Today:
+    // static-only, called explicitly after scene construction / load
+    // (e.g. asset bake step or end of viewer scene-setup).  The first
+    // SubmitRenderables call also auto-builds the BVH lazily if it has
+    // not been built yet, so omitting this call is correctness-safe --
+    // it just shifts the build cost to frame 1.  Calling BuildBVH
+    // again after scene topology changes is also safe; it discards any
+    // prior state.
+    GEMMETHOD_(void, BuildBVH)() = 0;
 };
 
 //------------------------------------------------------------------------------------------------

--- a/src/Inc/CanvasGfx.h
+++ b/src/Inc/CanvasGfx.h
@@ -366,6 +366,29 @@ namespace Canvas
         GEMMETHOD(SubmitForUIRender)(XUIGraphNode *pNode) = 0;
         GEMMETHOD_(void, SetActiveCamera)(XCamera *pCamera) = 0;
 
+        // Per-frame light visibility allowlist.  Once called, SubmitLight
+        // accepts only XLight pointers present in the supplied array
+        // and silently drops every other call; the engine still
+        // applies its own per-frame light cap on top.  count == 0 is a
+        // valid "drop every light this frame" state -- the filter is
+        // installed even when the array is empty, so a scene with no
+        // visible lights does not accidentally pass unculled lights
+        // through.
+        //
+        // Callers that never call SetVisibleLights see the no-filter
+        // default: SubmitLight accepts every call up to the engine cap
+        // in submission order.
+        //
+        // The render queue takes no reference on the supplied lights;
+        // pointers are observer references valid for the current frame
+        // only (typically the scene graph holds the strong refs).  The
+        // filter is auto-cleared at EndFrame back to the no-filter
+        // state, so the next frame's defaults apply automatically.
+        //
+        // Pointer comparison is by raw XLight*.  Two light objects with
+        // identical state but different addresses are distinct here.
+        GEMMETHOD_(void, SetVisibleLights)(XLight* const* ppLights, size_t count) = 0;
+
         // Set the scene background used by the composite pass to fill
         // pixels with no geometry.  Pass nullptr to clear back to opaque
         // black with no skybox.  The render queue takes its own strong

--- a/src/Inc/CanvasMath.hpp
+++ b/src/Inc/CanvasMath.hpp
@@ -1464,6 +1464,51 @@ namespace Canvas
                 }
                 return out;
             }
+
+            // Trivial axis-aligned overlap test against another AABB.
+            // Empty boxes never overlap anything (consistent with the
+            // empty-sentinel contract documented on IsEmpty).
+            bool Intersects(const AABB& other) const
+            {
+                if (IsEmpty() || other.IsEmpty())
+                    return false;
+                return !(Max.V[0] < other.Min.V[0] || Min.V[0] > other.Max.V[0]
+                      || Max.V[1] < other.Min.V[1] || Min.V[1] > other.Max.V[1]
+                      || Max.V[2] < other.Min.V[2] || Min.V[2] > other.Max.V[2]);
+            }
+        };
+
+        //------------------------------------------------------------------------------------------------
+        // Geometric sphere: center + radius.  Center.w is ignored.  A
+        // sphere with Radius <= 0 is the empty set and intersects
+        // nothing; defenders short-circuit on that.
+        struct Sphere
+        {
+            FloatVector4 Center;
+            float        Radius = 0.0f;
+
+            Sphere() = default;
+            Sphere(const FloatVector4& center, float radius)
+                : Center(center), Radius(radius) {}
+
+            // Exact closest-point sphere-vs-AABB overlap test: the
+            // sphere overlaps the box iff the squared distance from
+            // the center to its closest point on the box is <= r^2.
+            bool IntersectsAABB(const AABB& box) const
+            {
+                if (box.IsEmpty() || Radius <= 0.0f)
+                    return false;
+                float distSq = 0.0f;
+                for (int i = 0; i < 3; ++i)
+                {
+                    const float c  = Center.V[i];
+                    const float lo = box.Min.V[i];
+                    const float hi = box.Max.V[i];
+                    if      (c < lo) { const float d = lo - c; distSq += d * d; }
+                    else if (c > hi) { const float d = c - hi; distSq += d * d; }
+                }
+                return distSq <= Radius * Radius;
+            }
         };
 
         //------------------------------------------------------------------------------------------------
@@ -1574,6 +1619,114 @@ namespace Canvas
                         return false;
                 }
                 return true;
+            }
+        };
+
+        //------------------------------------------------------------------------------------------------
+        // Bounded cone (frustum-of-revolution truncated at a finite
+        // range).  The cone is the set of points p satisfying
+        //     0 <= (p - Apex) . AxisDir <= Range
+        //     angle((p - Apex), AxisDir) <= HalfAngle
+        // AxisDir MUST be unit-length; construct via FromAxisAndAngle
+        // to keep the cached trig consistent with the half-angle.
+        //
+        // Intended use: spot-light influence volumes, shadow-caster
+        // bounding cones, picking/selection volumes.  The trig fields
+        // are precomputed so repeated tests (e.g. one cone vs many
+        // AABBs in a BVH walk) avoid per-query transcendentals.
+        struct Cone
+        {
+            FloatVector4 Apex;
+            FloatVector4 AxisDir;        // unit
+            float Range           = 0.0f;
+            float CosHalfAngle    = 1.0f;
+            float SinHalfAngle    = 0.0f;
+            float TanHalfAngle    = 0.0f;
+            float InvCosHalfAngle = 1.0f; // 1 / CosHalfAngle, cached for hot path
+
+            // Convenience builder.  axisDir is normalized defensively so
+            // a non-unit input cannot silently bias intersection tests.
+            // halfAngle is clamped into (0, pi/2 - epsilon) so cos > 0
+            // and tan stays finite; a half-angle >= 90 deg is degenerate
+            // (cone becomes a half-space or worse) and is treated as a
+            // near-half-space where the range slab dominates.
+            static Cone FromAxisAndAngle(const FloatVector4& apex,
+                                         const FloatVector4& axisDir,
+                                         float range,
+                                         float halfAngleRadians)
+            {
+                const float lx = axisDir.V[0];
+                const float ly = axisDir.V[1];
+                const float lz = axisDir.V[2];
+                const float lenSq = lx * lx + ly * ly + lz * lz;
+                const float invLen = (lenSq > 1e-20f) ? 1.0f / std::sqrt(lenSq) : 0.0f;
+
+                constexpr float kMaxHalf = 1.5707f; // pi/2 - small epsilon
+                float ha = halfAngleRadians;
+                if (ha < 0.0f)     ha = 0.0f;
+                if (ha > kMaxHalf) ha = kMaxHalf;
+
+                Cone c;
+                c.Apex            = apex;
+                c.AxisDir         = FloatVector4(lx * invLen, ly * invLen, lz * invLen, 0.0f);
+                c.Range           = (range > 0.0f) ? range : 0.0f;
+                c.CosHalfAngle    = std::cos(ha);
+                c.SinHalfAngle    = std::sin(ha);
+                c.TanHalfAngle    = c.SinHalfAngle / c.CosHalfAngle;
+                c.InvCosHalfAngle = 1.0f / c.CosHalfAngle;
+                return c;
+            }
+
+            // Akenine-Möller sphere-vs-bounded-cone test.  Sphere
+            // overlaps the cone iff it overlaps any of: the cone's
+            // lateral surface, the range cap, or the apex point.
+            // Conservative at the boundary by a fraction of the sphere
+            // radius so borderline cases are admitted.
+            bool IntersectsSphere(const Sphere& sphere) const
+            {
+                if (Range <= 0.0f || sphere.Radius <= 0.0f)
+                    return false;
+
+                const float vx = sphere.Center.V[0] - Apex.V[0];
+                const float vy = sphere.Center.V[1] - Apex.V[1];
+                const float vz = sphere.Center.V[2] - Apex.V[2];
+                const float distAxis = vx * AxisDir.V[0]
+                                     + vy * AxisDir.V[1]
+                                     + vz * AxisDir.V[2];
+
+                // Range slab cull (sphere-padded on both ends).
+                if (distAxis > Range + sphere.Radius) return false;
+                if (distAxis < -sphere.Radius)        return false;
+
+                // Perpendicular distance from sphere center to cone axis.
+                const float vLenSq = vx * vx + vy * vy + vz * vz;
+                const float perpSq = vLenSq - distAxis * distAxis;
+                const float perp   = (perpSq > 0.0f) ? std::sqrt(perpSq) : 0.0f;
+
+                // Padded cone radius at axial distance t.  We clamp t at
+                // 0 (apex side): a sphere straddling the apex is admitted
+                // because it overlaps the apex point itself.
+                const float t = (distAxis > 0.0f) ? distAxis : 0.0f;
+                const float allowed = t * TanHalfAngle + sphere.Radius * InvCosHalfAngle;
+                return perp <= allowed;
+            }
+
+            // Conservative cone-vs-AABB test using the AABB's outer
+            // sphere as the bounding proxy.  Looseness is bounded by
+            // (AABB diagonal / 2); acceptable for BVH-tier culling
+            // where false positives are normal, false negatives forbidden.
+            // Callers that need a tight test should add a follow-up
+            // cone-vs-OBB or SAT refinement after this admits the AABB.
+            bool IntersectsAABB(const AABB& box) const
+            {
+                if (box.IsEmpty())
+                    return false;
+                const FloatVector4 center = box.GetCenter();
+                const FloatVector4 ext    = box.GetExtents();
+                const float radius = std::sqrt(ext.V[0] * ext.V[0]
+                                             + ext.V[1] * ext.V[1]
+                                             + ext.V[2] * ext.V[2]);
+                return IntersectsSphere(Sphere(center, radius));
             }
         };
 

--- a/src/Inc/CanvasMath.hpp
+++ b/src/Inc/CanvasMath.hpp
@@ -1479,9 +1479,11 @@ namespace Canvas
         };
 
         //------------------------------------------------------------------------------------------------
-        // Geometric sphere: center + radius.  Center.w is ignored.  A
-        // sphere with Radius <= 0 is the empty set and intersects
-        // nothing; defenders short-circuit on that.
+        // Geometric sphere: center + radius.  Center.w is ignored.
+        // Radius == 0 is a valid degenerate sphere (a single point) and
+        // participates in intersection tests like any other sphere.
+        // Radius < 0 is the empty set and intersects nothing; defenders
+        // short-circuit on that.
         struct Sphere
         {
             FloatVector4 Center;
@@ -1496,7 +1498,7 @@ namespace Canvas
             // the center to its closest point on the box is <= r^2.
             bool IntersectsAABB(const AABB& box) const
             {
-                if (box.IsEmpty() || Radius <= 0.0f)
+                if (box.IsEmpty() || Radius < 0.0f)
                     return false;
                 float distSq = 0.0f;
                 for (int i = 0; i < 3; ++i)
@@ -1681,34 +1683,17 @@ namespace Canvas
             // overlaps the cone iff it overlaps any of: the cone's
             // lateral surface, the range cap, or the apex point.
             // Conservative at the boundary by a fraction of the sphere
-            // radius so borderline cases are admitted.
+            // radius so borderline cases are admitted.  Degenerate
+            // inputs (radius == 0 point spheres, Range == 0 apex-only
+            // cones, HalfAngle == 0 line-segment cones) are
+            // mathematically valid and produce sensible (possibly
+            // conservative) results.  Only strictly negative Radius /
+            // Range short-circuit to no-intersection.
             bool IntersectsSphere(const Sphere& sphere) const
             {
-                if (Range <= 0.0f || sphere.Radius <= 0.0f)
+                if (Range < 0.0f || sphere.Radius < 0.0f)
                     return false;
-
-                const float vx = sphere.Center.V[0] - Apex.V[0];
-                const float vy = sphere.Center.V[1] - Apex.V[1];
-                const float vz = sphere.Center.V[2] - Apex.V[2];
-                const float distAxis = vx * AxisDir.V[0]
-                                     + vy * AxisDir.V[1]
-                                     + vz * AxisDir.V[2];
-
-                // Range slab cull (sphere-padded on both ends).
-                if (distAxis > Range + sphere.Radius) return false;
-                if (distAxis < -sphere.Radius)        return false;
-
-                // Perpendicular distance from sphere center to cone axis.
-                const float vLenSq = vx * vx + vy * vy + vz * vz;
-                const float perpSq = vLenSq - distAxis * distAxis;
-                const float perp   = (perpSq > 0.0f) ? std::sqrt(perpSq) : 0.0f;
-
-                // Padded cone radius at axial distance t.  We clamp t at
-                // 0 (apex side): a sphere straddling the apex is admitted
-                // because it overlaps the apex point itself.
-                const float t = (distAxis > 0.0f) ? distAxis : 0.0f;
-                const float allowed = t * TanHalfAngle + sphere.Radius * InvCosHalfAngle;
-                return perp <= allowed;
+                return OverlapsPaddedPoint(sphere.Center, sphere.Radius);
             }
 
             // Conservative cone-vs-AABB test using the AABB's outer
@@ -1719,14 +1704,48 @@ namespace Canvas
             // cone-vs-OBB or SAT refinement after this admits the AABB.
             bool IntersectsAABB(const AABB& box) const
             {
-                if (box.IsEmpty())
+                if (Range < 0.0f || box.IsEmpty())
                     return false;
                 const FloatVector4 center = box.GetCenter();
                 const FloatVector4 ext    = box.GetExtents();
                 const float radius = std::sqrt(ext.V[0] * ext.V[0]
                                              + ext.V[1] * ext.V[1]
                                              + ext.V[2] * ext.V[2]);
-                return IntersectsSphere(Sphere(center, radius));
+                return OverlapsPaddedPoint(center, radius);
+            }
+
+        private:
+            // Shared cone-vs-padded-point math used by both
+            // IntersectsSphere and IntersectsAABB.  Caller guarantees
+            // Range >= 0 and radius >= 0; degenerate values are
+            // mathematically valid and handled naturally by the
+            // formulation (radius == 0 collapses padding, Range == 0
+            // collapses the slab to {apex}, HalfAngle == 0 collapses
+            // the lateral surface to the axis ray).
+            bool OverlapsPaddedPoint(const FloatVector4& center, float radius) const
+            {
+                const float vx = center.V[0] - Apex.V[0];
+                const float vy = center.V[1] - Apex.V[1];
+                const float vz = center.V[2] - Apex.V[2];
+                const float distAxis = vx * AxisDir.V[0]
+                                     + vy * AxisDir.V[1]
+                                     + vz * AxisDir.V[2];
+
+                // Range slab cull (padded on both ends).
+                if (distAxis > Range + radius) return false;
+                if (distAxis < -radius)        return false;
+
+                // Perpendicular distance from center to cone axis.
+                const float vLenSq = vx * vx + vy * vy + vz * vz;
+                const float perpSq = vLenSq - distAxis * distAxis;
+                const float perp   = (perpSq > 0.0f) ? std::sqrt(perpSq) : 0.0f;
+
+                // Padded cone radius at axial distance t.  We clamp t at
+                // 0 (apex side): a sample straddling the apex is admitted
+                // because it overlaps the apex point itself.
+                const float t = (distAxis > 0.0f) ? distAxis : 0.0f;
+                const float allowed = t * TanHalfAngle + radius * InvCosHalfAngle;
+                return perp <= allowed;
             }
         };
 

--- a/src/Inc/CanvasMath.hpp
+++ b/src/Inc/CanvasMath.hpp
@@ -1466,6 +1466,119 @@ namespace Canvas
             }
         };
 
+        //------------------------------------------------------------------------------------------------
+        // View frustum represented as 6 outward-pointing inequality planes.
+        //
+        // Plane encoding: each plane is stored as (nx, ny, nz, d) in a
+        // FloatVector4.  A point p is INSIDE the half-space iff
+        //     dot(p.xyz, n) + d >= 0.
+        // The frustum interior is the intersection of all 6 half-spaces.
+        // Plane normals are NOT renormalized -- they retain whatever length
+        // falls out of Gribb-Hartmann extraction.  This is correct for
+        // half-space sign tests (positive scaling preserves the sign) and
+        // intentionally avoids a sqrt per plane during extraction.  Code
+        // that needs signed Euclidean distances must normalize first.
+        //
+        // Matrix convention: Canvas uses ROW VECTORS (clip = world * VP), so
+        // plane coefficients are derived from COLUMNS of the view-projection
+        // matrix (see FromViewProjection below).  Passing a column-vector
+        // matrix here will silently produce a degenerate frustum.
+        struct Frustum
+        {
+            enum PlaneIndex
+            {
+                Left = 0,
+                Right,
+                Bottom,
+                Top,
+                Near,
+                Far,
+                PlaneCount
+            };
+
+            FloatVector4 Planes[PlaneCount];
+
+            // Extract clip-volume planes from a row-vector view-projection
+            // matrix.  reverseZ=true assumes the projection maps the near
+            // plane to clip-space z=w and the far plane to z=0 (matches
+            // Canvas::Math::PerspectiveReverseZ).  reverseZ=false assumes
+            // the standard z=0 near / z=w far mapping
+            // (matches PerspectiveForwardZ).  The only difference between
+            // the two paths is which column combination becomes Near vs Far.
+            static Frustum FromViewProjection(const FloatMatrix4x4& vp, bool reverseZ = true)
+            {
+                // With row vectors, clip.c = world_h . column_c(vp).
+                // Half-space "clip.c + clip.w >= 0" becomes
+                // "world_h . (column_c + column_3) >= 0", so the plane
+                // coefficients are simply that column sum/difference.
+                auto col = [&](int c) {
+                    return FloatVector4(vp.M[0][c], vp.M[1][c], vp.M[2][c], vp.M[3][c]);
+                };
+                const FloatVector4 c0 = col(0);
+                const FloatVector4 c1 = col(1);
+                const FloatVector4 c2 = col(2);
+                const FloatVector4 c3 = col(3);
+
+                auto add = [](const FloatVector4& a, const FloatVector4& b) {
+                    return FloatVector4(a.V[0] + b.V[0], a.V[1] + b.V[1], a.V[2] + b.V[2], a.V[3] + b.V[3]);
+                };
+                auto sub = [](const FloatVector4& a, const FloatVector4& b) {
+                    return FloatVector4(a.V[0] - b.V[0], a.V[1] - b.V[1], a.V[2] - b.V[2], a.V[3] - b.V[3]);
+                };
+
+                Frustum f;
+                f.Planes[Left]   = add(c3, c0); // clip.x + clip.w >= 0
+                f.Planes[Right]  = sub(c3, c0); // clip.w - clip.x >= 0
+                f.Planes[Bottom] = add(c3, c1); // clip.y + clip.w >= 0
+                f.Planes[Top]    = sub(c3, c1); // clip.w - clip.y >= 0
+                if (reverseZ)
+                {
+                    // Reverse-Z: near at z=w (clip.w - clip.z >= 0),
+                    //            far  at z=0 (clip.z >= 0).
+                    f.Planes[Near] = sub(c3, c2);
+                    f.Planes[Far]  = c2;
+                }
+                else
+                {
+                    // Forward-Z: near at z=0 (clip.z >= 0),
+                    //            far  at z=w (clip.w - clip.z >= 0).
+                    f.Planes[Near] = c2;
+                    f.Planes[Far]  = sub(c3, c2);
+                }
+                return f;
+            }
+
+            // Conservative AABB-vs-frustum overlap test using the
+            // p-vertex (positive vertex) trick: for each plane, the AABB
+            // corner most aligned with the plane normal is the last point
+            // to leave the positive half-space.  If that corner is outside
+            // (signed distance < 0) for ANY plane, the AABB cannot overlap
+            // the frustum and we early-out.  This may return true for boxes
+            // that straddle every plane but actually miss the frustum at a
+            // corner -- accepted false positive in renderer culling.
+            //
+            // Empty AABBs return false (nothing to draw, nothing to cull
+            // in).  Invalid (inside-out, non-sentinel) AABBs are treated as
+            // their corner positions describe -- garbage in, garbage out;
+            // construction-side bug, not this code's job to mask.
+            bool IntersectsAABB(const AABB& box) const
+            {
+                if (box.IsEmpty())
+                    return false;
+                for (int i = 0; i < PlaneCount; ++i)
+                {
+                    const FloatVector4& p = Planes[i];
+                    // Positive vertex: per-axis pick Max if normal >= 0 else Min.
+                    const float px = (p.V[0] >= 0.0f) ? box.Max.V[0] : box.Min.V[0];
+                    const float py = (p.V[1] >= 0.0f) ? box.Max.V[1] : box.Min.V[1];
+                    const float pz = (p.V[2] >= 0.0f) ? box.Max.V[2] : box.Min.V[2];
+                    const float signedDist = p.V[0] * px + p.V[1] * py + p.V[2] * pz + p.V[3];
+                    if (signedDist < 0.0f)
+                        return false;
+                }
+                return true;
+            }
+        };
 
     }
 }

--- a/src/Inc/CanvasMath.hpp
+++ b/src/Inc/CanvasMath.hpp
@@ -1555,12 +1555,9 @@ namespace Canvas
             // (signed distance < 0) for ANY plane, the AABB cannot overlap
             // the frustum and we early-out.  This may return true for boxes
             // that straddle every plane but actually miss the frustum at a
-            // corner -- accepted false positive in renderer culling.
+            // corner - an accepted false positive in renderer culling.
             //
-            // Empty AABBs return false (nothing to draw, nothing to cull
-            // in).  Invalid (inside-out, non-sentinel) AABBs are treated as
-            // their corner positions describe -- garbage in, garbage out;
-            // construction-side bug, not this code's job to mask.
+            // Empty AABBs return false.
             bool IntersectsAABB(const AABB& box) const
             {
                 if (box.IsEmpty())


### PR DESCRIPTION
Uses BVHs for renderable elements and lights. This reduces pixel rendering costs considerably at the cost of CPU overhead. Will need to consider optimizations down the road.

Adds support for up to 32 lights per 32x32 screen space tile. Each tile is rendered discretely, culling out lights that do not have influence AABB intersecting the associated frustum slice.

Adds a CanvasLightGarden sample using procedurally generated scene with dozens of spot and point lights influencing a grid of mesh objects. 