### PR TITLE
CanvasPlatformWin32: Implement XImage to store loaded image data

### DIFF
--- a/src/CanvasModelViewer/CanvasModelViewer.cpp
+++ b/src/CanvasModelViewer/CanvasModelViewer.cpp
@@ -36,11 +36,11 @@ bool LoadFbxTexture(
 
     outSurface = nullptr;
 
-    ImageData img;
+    Gem::TGemPtr<XImage> img;
     if (ref.Embedded && !ref.EmbeddedBytes.empty())
     {
-        if (!LoadImageData(ref.EmbeddedBytes.data(), ref.EmbeddedBytes.size(),
-                Canvas::GfxFormat::R8G8B8A8_UNorm, &img, pLogger))
+        if (Gem::Failed(LoadImageData(ref.EmbeddedBytes.data(), ref.EmbeddedBytes.size(),
+                Canvas::GfxFormat::R8G8B8A8_UNorm, &img, pLogger)))
         {
             Canvas::LogWarn(pLogger, "LoadFbxTexture: embedded decode failed for '%s'",
                 ref.AbsoluteFilePath.c_str());
@@ -50,7 +50,7 @@ bool LoadFbxTexture(
     else
     {
         std::wstring widePath(ref.AbsoluteFilePath.begin(), ref.AbsoluteFilePath.end());
-        if (!LoadImageData(widePath.c_str(), Canvas::GfxFormat::R8G8B8A8_UNorm, &img, pLogger))
+        if (Gem::Failed(LoadImageData(widePath.c_str(), Canvas::GfxFormat::R8G8B8A8_UNorm, &img, pLogger)))
         {
             Canvas::LogWarn(pLogger, "LoadFbxTexture: file decode failed for '%s'",
                 ref.AbsoluteFilePath.c_str());
@@ -59,7 +59,7 @@ bool LoadFbxTexture(
     }
 
     Canvas::GfxSurfaceDesc desc = Canvas::GfxSurfaceDesc::SurfaceDesc2D(
-        Canvas::GfxFormat::R8G8B8A8_UNorm, img.Width, img.Height,
+        Canvas::GfxFormat::R8G8B8A8_UNorm, img->GetWidth(), img->GetHeight(),
         Canvas::SurfaceFlag_ShaderResource);
     Gem::Result r = pDevice->CreateSurface(desc, &outSurface);
     if (Gem::Failed(r))
@@ -70,9 +70,9 @@ bool LoadFbxTexture(
         return false;
     }
 
-    const UINT rowPitch = img.Width * img.BytesPerPixel();
-    r = pDevice->UploadTextureRegion(outSurface.Get(), 0, 0, 0, img.Width, img.Height,
-        img.Pixels.data(), rowPitch);
+    const UINT rowPitch = img->GetWidth() * img->GetBytesPerPixel();
+    r = pDevice->UploadTextureRegion(outSurface.Get(), 0, 0, 0, img->GetWidth(), img->GetHeight(),
+        img->GetPixels(), rowPitch);
     if (Gem::Failed(r))
     {
         Canvas::LogWarn(pLogger, "LoadFbxTexture: UploadTextureRegion failed for '%s'",

--- a/src/CanvasPlatformWin32/ImageLoader.cpp
+++ b/src/CanvasPlatformWin32/ImageLoader.cpp
@@ -1,9 +1,62 @@
 #include "pch.h"
 #include "CanvasCore.h"
+#include <vector>
 
 namespace Canvas::Platform::Win32 {
 
 namespace {
+
+//------------------------------------------------------------------------------------------------
+// CImage - XImage implementation. Holds the decoded pixels in a std::vector that never
+// escapes this DLL; callers only ever see the XImage interface.
+//------------------------------------------------------------------------------------------------
+class CImage : public XImage
+{
+public:
+    CImage() = default;
+
+    Gem::Result Initialize() { return Gem::Result::Success; }
+    void Uninitialize() {}
+
+    BEGIN_GEM_INTERFACE_MAP()
+        GEM_INTERFACE_ENTRY(XImage)
+    END_GEM_INTERFACE_MAP()
+
+    GEMMETHOD_(uint32_t, GetWidth)() final { return m_Width; }
+    GEMMETHOD_(uint32_t, GetHeight)() final { return m_Height; }
+    GEMMETHOD_(Canvas::GfxFormat, GetFormat)() final { return m_Format; }
+    GEMMETHOD_(uint32_t, GetBytesPerPixel)() final { return m_BytesPerPixel; }
+
+    GEMMETHOD_(const uint8_t*, GetPixels)() final
+    {
+        return m_Pixels.empty() ? nullptr : m_Pixels.data();
+    }
+
+    GEMMETHOD_(size_t, GetPixelByteCount)() final { return m_Pixels.size(); }
+
+    GEMMETHOD_(bool, IsEmpty)() final
+    {
+        return m_Pixels.empty() || m_Width == 0 || m_Height == 0;
+    }
+
+    // Internal - takes ownership of a freshly decoded frame. Called once by the loader.
+    void SetPixels(uint32_t width, uint32_t height, Canvas::GfxFormat format,
+        uint32_t bytesPerPixel, std::vector<uint8_t>&& pixels)
+    {
+        m_Width         = width;
+        m_Height        = height;
+        m_Format        = format;
+        m_BytesPerPixel = bytesPerPixel;
+        m_Pixels        = std::move(pixels);
+    }
+
+private:
+    uint32_t              m_Width         = 0;
+    uint32_t              m_Height        = 0;
+    Canvas::GfxFormat     m_Format        = Canvas::GfxFormat::Unknown;
+    uint32_t              m_BytesPerPixel = 0;
+    std::vector<uint8_t>  m_Pixels;
+};
 
 struct FormatDesc
 {
@@ -34,7 +87,7 @@ bool DecodeToFormat(
     IWICImagingFactory* pFactory,
     IWICBitmapDecoder*  pDecoder,
     Canvas::GfxFormat   format,
-    ImageData*          outImage,
+    CImage*             outImage,
     Canvas::XLogger*    pLogger)
 {
     FormatDesc fd;
@@ -87,10 +140,7 @@ bool DecodeToFormat(
         return false;
     }
 
-    outImage->Width  = width;
-    outImage->Height = height;
-    outImage->Format = format;
-    outImage->Pixels = std::move(pixels);
+    outImage->SetPixels(width, height, format, fd.bytesPerPixel, std::move(pixels));
     return true;
 }
 
@@ -105,24 +155,42 @@ bool MakeFactory(IWICImagingFactory** ppFactory, Canvas::XLogger* pLogger)
     return SUCCEEDED(hr);
 }
 
+bool DecodeIntoImage(
+    IWICImagingFactory* pFactory, IWICBitmapDecoder* pDecoder, Canvas::GfxFormat format,
+    XImage** ppImage, Canvas::XLogger* pLogger)
+{
+    Gem::TGemPtr<CImage> pImage;
+    Gem::Result gr = Gem::TGenericImpl<CImage>::Create(&pImage);
+    if (Gem::Failed(gr))
+    {
+        LogError(pLogger, "LoadImageData: failed to allocate image object");
+        return false;
+    }
+
+    if (!DecodeToFormat(pFactory, pDecoder, format, pImage.Get(), pLogger))
+        return false;
+
+    return Gem::Succeeded(pImage->QueryInterface(ppImage));
+}
+
 } // anonymous namespace
 
-bool LoadImageData(
-    const wchar_t* path, Canvas::GfxFormat format, ImageData* outImage, Canvas::XLogger* pLogger)
+Gem::Result LoadImageData(
+    const wchar_t* path, Canvas::GfxFormat format, XImage** ppImage, Canvas::XLogger* pLogger)
 {
-    if (!outImage)
-        return false;
-    *outImage = ImageData{};
+    if (!ppImage)
+        return Gem::Result::BadPointer;
+    *ppImage = nullptr;
 
     if (!path || !*path)
     {
         LogError(pLogger, "LoadImageData: null/empty path");
-        return false;
+        return Gem::Result::InvalidArg;
     }
 
     CComPtr<IWICImagingFactory> pFactory;
     if (!MakeFactory(&pFactory, pLogger))
-        return false;
+        return Gem::Result::Fail;
 
     CComPtr<IWICBitmapDecoder> pDecoder;
     HRESULT hr = pFactory->CreateDecoderFromFilename(
@@ -131,47 +199,47 @@ bool LoadImageData(
     {
         LogError(pLogger, "LoadImageData: failed to open '%ls' hr=0x%08X",
             path, static_cast<unsigned>(hr));
-        return false;
+        return Gem::Result::Fail;
     }
 
-    if (!DecodeToFormat(pFactory, pDecoder, format, outImage, pLogger))
-        return false;
+    if (!DecodeIntoImage(pFactory, pDecoder, format, ppImage, pLogger))
+        return Gem::Result::Fail;
 
     LogInfo(pLogger, "LoadImageData: loaded %ux%u from '%ls'",
-        outImage->Width, outImage->Height, path);
-    return true;
+        (*ppImage)->GetWidth(), (*ppImage)->GetHeight(), path);
+    return Gem::Result::Success;
 }
 
-bool LoadImageData(
+Gem::Result LoadImageData(
     const uint8_t* data, size_t byteCount, Canvas::GfxFormat format,
-    ImageData* outImage, Canvas::XLogger* pLogger)
+    XImage** ppImage, Canvas::XLogger* pLogger)
 {
-    if (!outImage)
-        return false;
-    *outImage = ImageData{};
+    if (!ppImage)
+        return Gem::Result::BadPointer;
+    *ppImage = nullptr;
 
     if (!data || byteCount == 0)
     {
         LogError(pLogger, "LoadImageData: null/empty data buffer");
-        return false;
+        return Gem::Result::InvalidArg;
     }
 
     CComPtr<IWICImagingFactory> pFactory;
     if (!MakeFactory(&pFactory, pLogger))
-        return false;
+        return Gem::Result::Fail;
 
     HGLOBAL hMem = GlobalAlloc(GMEM_MOVEABLE, byteCount);
     if (!hMem)
     {
         LogError(pLogger, "LoadImageData: GlobalAlloc failed for %zu bytes", byteCount);
-        return false;
+        return Gem::Result::OutOfMemory;
     }
     void* pDst = GlobalLock(hMem);
     if (!pDst)
     {
         GlobalFree(hMem);
         LogError(pLogger, "LoadImageData: GlobalLock failed");
-        return false;
+        return Gem::Result::Fail;
     }
     memcpy(pDst, data, byteCount);
     GlobalUnlock(hMem);
@@ -183,7 +251,7 @@ bool LoadImageData(
         GlobalFree(hMem);
         LogError(pLogger, "LoadImageData: CreateStreamOnHGlobal failed hr=0x%08X",
             static_cast<unsigned>(hr));
-        return false;
+        return Gem::Result::Fail;
     }
 
     CComPtr<IWICBitmapDecoder> pDecoder;
@@ -193,15 +261,15 @@ bool LoadImageData(
     {
         LogError(pLogger, "LoadImageData: decoder creation from stream failed hr=0x%08X",
             static_cast<unsigned>(hr));
-        return false;
+        return Gem::Result::Fail;
     }
 
-    if (!DecodeToFormat(pFactory, pDecoder, format, outImage, pLogger))
-        return false;
+    if (!DecodeIntoImage(pFactory, pDecoder, format, ppImage, pLogger))
+        return Gem::Result::Fail;
 
     LogInfo(pLogger, "LoadImageData: loaded %ux%u from memory (%zu bytes)",
-        outImage->Width, outImage->Height, byteCount);
-    return true;
+        (*ppImage)->GetWidth(), (*ppImage)->GetHeight(), byteCount);
+    return Gem::Result::Success;
 }
 
 } // namespace Canvas::Platform::Win32

--- a/src/CanvasPlatformWin32/README.md
+++ b/src/CanvasPlatformWin32/README.md
@@ -13,7 +13,7 @@ CanvasPlatformWin32 publishes two interfaces from `CanvasPlatformWin32.h` in the
 
 It also exposes a free-function image-loading API in the same namespace:
 
-- **`LoadImageData`** - decodes an image from a file path or in-memory buffer into a tightly-packed `ImageData` pixel block of a caller-chosen `Canvas::GfxFormat`. Implemented on top of the Windows Imaging Component (WIC).
+- **`LoadImageData`** - decodes an image from a file path or in-memory buffer into a tightly-packed `XImage` of a caller-chosen `Canvas::GfxFormat`. Implemented on top of the Windows Imaging Component (WIC).
 
 Both GEM interfaces derive from `Gem::XGeneric`. GEM is the lightweight COM-style object model used throughout Canvas; it provides reference counting (`AddRef`/`Release`), interface discovery (`QueryInterface`), and 64-bit interface IDs. Smart pointers (`Gem::TGemPtr<T>`) automate lifetime management. See the [GEM repository](../../deps/GEM) for details.
 
@@ -130,27 +130,30 @@ This keeps mouse-look sensitivity identical to the local case while remaining us
 
 ## Image Loading
 
-`LoadImageData` decodes an image into a CPU-side pixel buffer suitable for handing to `XGfxDevice::UploadTextureRegion` or any other consumer that wants raw pixels. Two overloads are provided:
+`LoadImageData` decodes an image into a CPU-side pixel buffer suitable for handing to `XGfxDevice::UploadTextureRegion` or any other consumer that wants raw pixels. The decoded image is returned as an `XImage` GEM object; the pixel storage lives entirely inside the implementation, so no STL container crosses the DLL boundary. Two overloads are provided:
 
 ```cpp
-struct ImageData
+struct XImage : public Gem::XGeneric
 {
-    uint32_t              Width  = 0;
-    uint32_t              Height = 0;
-    Canvas::GfxFormat     Format = Canvas::GfxFormat::Unknown;
-    std::vector<uint8_t>  Pixels;   // tightly packed, row pitch = Width * bytesPerPixel
+    GEMMETHOD_(uint32_t, GetWidth)() = 0;
+    GEMMETHOD_(uint32_t, GetHeight)() = 0;
+    GEMMETHOD_(Canvas::GfxFormat, GetFormat)() = 0;
+    GEMMETHOD_(uint32_t, GetBytesPerPixel)() = 0;
+    GEMMETHOD_(const uint8_t*, GetPixels)() = 0;       // tightly packed, row pitch = Width * GetBytesPerPixel()
+    GEMMETHOD_(size_t, GetPixelByteCount)() = 0;
+    GEMMETHOD_(bool, IsEmpty)() = 0;
 };
 
-bool LoadImageData(const wchar_t*    path,
-                   Canvas::GfxFormat format,
-                   ImageData*        outImage,
-                   Canvas::XLogger*  pLogger);
+Gem::Result LoadImageData(const wchar_t*    path,
+                          Canvas::GfxFormat format,
+                          XImage**          ppImage,
+                          Canvas::XLogger*  pLogger);
 
-bool LoadImageData(const uint8_t*    data,
-                   size_t            byteCount,
-                   Canvas::GfxFormat format,
-                   ImageData*        outImage,
-                   Canvas::XLogger*  pLogger);
+Gem::Result LoadImageData(const uint8_t*    data,
+                          size_t            byteCount,
+                          Canvas::GfxFormat format,
+                          XImage**          ppImage,
+                          Canvas::XLogger*  pLogger);
 ```
 
 The path overload opens the file directly via `IWICImagingFactory::CreateDecoderFromFilename`; the memory overload copies the bytes into an `HGLOBAL`-backed `IStream` and decodes via `CreateDecoderFromStream`. Both paths funnel through the same WIC `IWICFormatConverter` step, so the output is always tightly packed in the requested `GfxFormat` regardless of the source pixel layout.
@@ -164,9 +167,9 @@ Supported target formats:
 | `R8_UNorm`             | `GUID_WICPixelFormat8bppGray`       | 1             |
 | `R16_UNorm`            | `GUID_WICPixelFormat16bppGray`      | 2             |
 
-Any other `GfxFormat` value is rejected with an `XLogger` error and `false` return; if you need a new format, extend the switch in `ImageLoader.cpp`.
+Any other `GfxFormat` value is rejected with an `XLogger` error and a failing `Gem::Result`; if you need a new format, extend the switch in `ImageLoader.cpp`.
 
-Both overloads return `false` on any failure (null/empty input, unsupported format, file-open error, decoder error, format-converter error, `CopyPixels` error) and leave `*outImage` cleared. On failure they log an error through the supplied `XLogger`; on success they log an info line with the decoded dimensions and source. A null `XLogger` is allowed - log calls are routed through the standard `LogError` / `LogInfo` helpers, which no-op when the logger is null.
+Both overloads return a failing `Gem::Result` on any failure (null/empty input, unsupported format, file-open error, decoder error, format-converter error, `CopyPixels` error) and leave `*ppImage` null. On failure they log an error through the supplied `XLogger`; on success they log an info line with the decoded dimensions and source. A null `XLogger` is allowed - log calls are routed through the standard `LogError` / `LogInfo` helpers, which no-op when the logger is null.
 
 **COM apartment.** WIC requires COM to be initialized on the calling thread. CanvasPlatformWin32 does **not** call `CoInitializeEx` for you; consumers that decode images off the main thread are responsible for initializing COM on those threads themselves.
 
@@ -215,11 +218,11 @@ while (pWindow->PumpMessages())
 }
 
 // Decode a texture from disk into a tightly-packed RGBA8 pixel block.
-ImageData img;
-if (LoadImageData(L"assets/diffuse.png",
-                  Canvas::GfxFormat::R8G8B8A8_UNorm, &img, pLogger))
+Gem::TGemPtr<XImage> img;
+if (Gem::Succeeded(LoadImageData(L"assets/diffuse.png",
+                  Canvas::GfxFormat::R8G8B8A8_UNorm, &img, pLogger)))
 {
-    // img.Width / img.Height / img.Pixels.data() ready to hand to
+    // img->GetWidth() / img->GetHeight() / img->GetPixels() ready to hand to
     // XGfxDevice::UploadTextureRegion.
 }
 ```

--- a/src/CanvasTerrainViewer/CanvasTerrainViewer.cpp
+++ b/src/CanvasTerrainViewer/CanvasTerrainViewer.cpp
@@ -429,16 +429,16 @@ class CTerrainApp
             return false;
         }
 
-        Canvas::Platform::Win32::ImageData albedoAtlas, ormAtlas;
-        if (!Canvas::Platform::Win32::LoadImageData(mat.AtlasAlbedo.wstring().c_str(),
-                Canvas::GfxFormat::R8G8B8A8_UNorm, &albedoAtlas, m_pLogger.Get()))
+        Gem::TGemPtr<Canvas::Platform::Win32::XImage> albedoAtlas, ormAtlas;
+        if (Gem::Failed(Canvas::Platform::Win32::LoadImageData(mat.AtlasAlbedo.wstring().c_str(),
+                Canvas::GfxFormat::R8G8B8A8_UNorm, &albedoAtlas, m_pLogger.Get())))
         {
             Canvas::LogError(m_pLogger.Get(), "Failed to load atlas albedo '%s'",
                 mat.AtlasAlbedo.string().c_str());
             return false;
         }
-        if (!Canvas::Platform::Win32::LoadImageData(mat.AtlasORM.wstring().c_str(),
-                Canvas::GfxFormat::R8G8B8A8_UNorm, &ormAtlas, m_pLogger.Get()))
+        if (Gem::Failed(Canvas::Platform::Win32::LoadImageData(mat.AtlasORM.wstring().c_str(),
+                Canvas::GfxFormat::R8G8B8A8_UNorm, &ormAtlas, m_pLogger.Get())))
         {
             Canvas::LogError(m_pLogger.Get(), "Failed to load atlas ORM '%s'",
                 mat.AtlasORM.string().c_str());
@@ -753,10 +753,10 @@ class CTerrainApp
         // Moon billboard sprite (2D RGBA).  Composite samples it inside
         // the angular disc around MoonDirection (see GfxBackgroundDesc).
         const std::filesystem::path moonPath = skyDir / "moon.png";
-        Canvas::Platform::Win32::ImageData moonImg;
-        if (!Canvas::Platform::Win32::LoadImageData(
+        Gem::TGemPtr<Canvas::Platform::Win32::XImage> moonImg;
+        if (Gem::Failed(Canvas::Platform::Win32::LoadImageData(
                 moonPath.wstring().c_str(),
-                Canvas::GfxFormat::R8G8B8A8_UNorm, &moonImg, m_pLogger.Get()))
+                Canvas::GfxFormat::R8G8B8A8_UNorm, &moonImg, m_pLogger.Get())))
         {
             Canvas::LogError(m_pLogger.Get(), "LoadSky: failed to load '%s'",
                 moonPath.string().c_str());
@@ -765,13 +765,13 @@ class CTerrainApp
         {
             Canvas::GfxSurfaceDesc desc = Canvas::GfxSurfaceDesc::SurfaceDesc2D(
                 Canvas::GfxFormat::R8G8B8A8_UNorm,
-                moonImg.Width, moonImg.Height,
+                moonImg->GetWidth(), moonImg->GetHeight(),
                 Canvas::SurfaceFlag_ShaderResource);
             Gem::ThrowGemError(m_pGfxDevice->CreateSurface(desc, &m_pMoonTexture));
             Gem::ThrowGemError(m_pGfxDevice->UploadTextureRegion(
                 m_pMoonTexture, 0, 0, 0,
-                moonImg.Width, moonImg.Height,
-                moonImg.Pixels.data(), moonImg.Width * 4));
+                moonImg->GetWidth(), moonImg->GetHeight(),
+                moonImg->GetPixels(), moonImg->GetWidth() * 4));
             Gem::ThrowGemError(m_pGfxRenderQueue->FinalizeUploadAsShaderResource(m_pMoonTexture.Get()));
         }
         return true;

--- a/src/CanvasTerrainViewer/SkyCubeLoader.cpp
+++ b/src/CanvasTerrainViewer/SkyCubeLoader.cpp
@@ -34,40 +34,41 @@ bool LoadSkyCube(
 
     // Load all six faces into RAM first so we can validate dimensions before
     // committing a GPU surface allocation.
-    Canvas::Platform::Win32::ImageData faces[6];
+    Gem::TGemPtr<Canvas::Platform::Win32::XImage> faces[6];
     for (uint32_t i = 0; i < 6; ++i)
     {
         char filename[64];
         snprintf(filename, sizeof(filename), "sky_%s_%s.png", presetName, kFaceSuffix[i]);
         const std::filesystem::path facePath = assetsDir / filename;
 
-        if (!Canvas::Platform::Win32::LoadImageData(facePath.wstring().c_str(),
-                Canvas::GfxFormat::R8G8B8A8_UNorm, &faces[i], pLogger))
+        if (Gem::Failed(Canvas::Platform::Win32::LoadImageData(facePath.wstring().c_str(),
+                Canvas::GfxFormat::R8G8B8A8_UNorm, &faces[i], pLogger)))
         {
             LogError(pLogger, "LoadSkyCube: failed to load face '%s'",
                 facePath.string().c_str());
             return false;
         }
-        if (faces[i].Width != faces[0].Width || faces[i].Height != faces[0].Height)
+        if (faces[i]->GetWidth() != faces[0]->GetWidth() ||
+            faces[i]->GetHeight() != faces[0]->GetHeight())
         {
             LogError(pLogger,
                 "LoadSkyCube: face '%s' dimensions %ux%u do not match face 0 (%ux%u)",
                 facePath.string().c_str(),
-                faces[i].Width, faces[i].Height,
-                faces[0].Width, faces[0].Height);
+                faces[i]->GetWidth(), faces[i]->GetHeight(),
+                faces[0]->GetWidth(), faces[0]->GetHeight());
             return false;
         }
     }
 
-    if (faces[0].Width != faces[0].Height)
+    if (faces[0]->GetWidth() != faces[0]->GetHeight())
     {
         LogError(pLogger,
             "LoadSkyCube: preset '%s' faces are not square (%ux%u)",
-            presetName, faces[0].Width, faces[0].Height);
+            presetName, faces[0]->GetWidth(), faces[0]->GetHeight());
         return false;
     }
 
-    const uint32_t faceSize = faces[0].Width;
+    const uint32_t faceSize = faces[0]->GetWidth();
 
     GfxSurfaceDesc desc = GfxSurfaceDesc::SurfaceDescCube(
         GfxFormat::R8G8B8A8_UNorm,
@@ -94,7 +95,7 @@ bool LoadSkyCube(
             /*subresourceIndex*/ i,
             /*dstX*/ 0, /*dstY*/ 0,
             faceSize, faceSize,
-            faces[i].Pixels.data(), rowPitchBytes);
+            faces[i]->GetPixels(), rowPitchBytes);
         if (Gem::Failed(hr))
         {
             LogError(pLogger,

--- a/src/CanvasTerrainViewer/TerrainMaterial.cpp
+++ b/src/CanvasTerrainViewer/TerrainMaterial.cpp
@@ -18,6 +18,15 @@ inline float smoothstep01(float edge0, float edge1, float x)
     return t * t * (3.0f - 2.0f * t);
 }
 
+// Raw view of a decoded RGBA8 atlas. Built once from an XImage so the per-texel
+// sampling loop reads pixels directly instead of paying a virtual call per access.
+struct AtlasView
+{
+    const uint8_t* Pixels;
+    uint32_t       Width;
+    uint32_t       Height;
+};
+
 // Sample an atlas slot at world-relative UV. The atlas is 2x2 of equal-sized
 // slots; slotU/slotV in {0, 1} pick the slot. (atlasU, atlasV) are world UVs
 // in [0, 1) coordinates *within a single slot* (modulo the slot's repeat
@@ -25,7 +34,7 @@ inline float smoothstep01(float edge0, float edge1, float x)
 //
 // Returns the RGBA8 atlas pixel via the per-channel outputs.
 inline void SampleAtlas(
-    const Canvas::Platform::Win32::ImageData& atlas,
+    const AtlasView&  atlas,
     uint32_t          slotU,    // 0 or 1
     uint32_t          slotV,    // 0 or 1
     float             atlasU,
@@ -63,23 +72,26 @@ inline void SampleAtlas(
 Gem::Result BuildTerrainMaterial(
     XGfxDevice*                     pDevice,
     const HeightField::HeightField& field,
-    const Canvas::Platform::Win32::ImageData& albedoAtlas,
-    const Canvas::Platform::Win32::ImageData& ormAtlas,
+    Canvas::Platform::Win32::XImage* albedoAtlas,
+    Canvas::Platform::Win32::XImage* ormAtlas,
     const TerrainMaterialOptions&   opts,
     TerrainMaterialOutputs*         outputs,
     XLogger*                        pLogger)
 {
-    if (!pDevice || !outputs)
+    if (!pDevice || !outputs || !albedoAtlas || !ormAtlas)
         return Gem::Result::InvalidArg;
     *outputs = TerrainMaterialOutputs{};
-    if (field.IsEmpty() || albedoAtlas.IsEmpty() || ormAtlas.IsEmpty())
+    if (field.IsEmpty() || albedoAtlas->IsEmpty() || ormAtlas->IsEmpty())
         return Gem::Result::InvalidArg;
-    if ((albedoAtlas.Width & 1u) || (albedoAtlas.Height & 1u) ||
-        (ormAtlas.Width    & 1u) || (ormAtlas.Height    & 1u))
+    if ((albedoAtlas->GetWidth() & 1u) || (albedoAtlas->GetHeight() & 1u) ||
+        (ormAtlas->GetWidth()    & 1u) || (ormAtlas->GetHeight()    & 1u))
     {
         LogError(pLogger, "BuildTerrainMaterial: atlas dimensions must be even (2x2 packing)");
         return Gem::Result::InvalidArg;
     }
+
+    const AtlasView albedoView{ albedoAtlas->GetPixels(), albedoAtlas->GetWidth(), albedoAtlas->GetHeight() };
+    const AtlasView ormView   { ormAtlas->GetPixels(),    ormAtlas->GetWidth(),    ormAtlas->GetHeight() };
 
     const uint32_t W = field.Desc.Width;
     const uint32_t H = field.Desc.Height;
@@ -152,19 +164,19 @@ Gem::Result BuildTerrainMaterial(
             const float aV = wy * invRepeat;
 
             // Sample each slot once from each atlas (4 samples per atlas).
-            uint8_t gR, gG, gB; SampleAtlas(albedoAtlas, kGrassU, kGrassV, aU, aV, gR, gG, gB);
-            uint8_t rR, rG, rB; SampleAtlas(albedoAtlas, kRockU,  kRockV,  aU, aV, rR, rG, rB);
-            uint8_t sR, sG, sB; SampleAtlas(albedoAtlas, kSandU,  kSandV,  aU, aV, sR, sG, sB);
-            uint8_t nR, nG, nB; SampleAtlas(albedoAtlas, kSnowU,  kSnowV,  aU, aV, nR, nG, nB);
+            uint8_t gR, gG, gB; SampleAtlas(albedoView, kGrassU, kGrassV, aU, aV, gR, gG, gB);
+            uint8_t rR, rG, rB; SampleAtlas(albedoView, kRockU,  kRockV,  aU, aV, rR, rG, rB);
+            uint8_t sR, sG, sB; SampleAtlas(albedoView, kSandU,  kSandV,  aU, aV, sR, sG, sB);
+            uint8_t nR, nG, nB; SampleAtlas(albedoView, kSnowU,  kSnowV,  aU, aV, nR, nG, nB);
 
             uint8_t go_ao, go_rough, go_metal; (void)go_metal;
-            SampleAtlas(ormAtlas, kGrassU, kGrassV, aU, aV, go_ao, go_rough, go_metal);
+            SampleAtlas(ormView, kGrassU, kGrassV, aU, aV, go_ao, go_rough, go_metal);
             uint8_t ro_ao, ro_rough, ro_metal; (void)ro_metal;
-            SampleAtlas(ormAtlas, kRockU,  kRockV,  aU, aV, ro_ao, ro_rough, ro_metal);
+            SampleAtlas(ormView, kRockU,  kRockV,  aU, aV, ro_ao, ro_rough, ro_metal);
             uint8_t so_ao, so_rough, so_metal; (void)so_metal;
-            SampleAtlas(ormAtlas, kSandU,  kSandV,  aU, aV, so_ao, so_rough, so_metal);
+            SampleAtlas(ormView, kSandU,  kSandV,  aU, aV, so_ao, so_rough, so_metal);
             uint8_t no_ao, no_rough, no_metal; (void)no_metal;
-            SampleAtlas(ormAtlas, kSnowU,  kSnowV,  aU, aV, no_ao, no_rough, no_metal);
+            SampleAtlas(ormView, kSnowU,  kSnowV,  aU, aV, no_ao, no_rough, no_metal);
 
             // Blend.
             const float rF = wGrass * gR + wRock * rR + wSand * sR + wSnow * nR;

--- a/src/CanvasTerrainViewer/TerrainMaterial.h
+++ b/src/CanvasTerrainViewer/TerrainMaterial.h
@@ -79,8 +79,8 @@ struct TerrainMaterialOutputs
 Gem::Result BuildTerrainMaterial(
     XGfxDevice*                     pDevice,
     const HeightField::HeightField& field,
-    const Canvas::Platform::Win32::ImageData& albedoAtlas,
-    const Canvas::Platform::Win32::ImageData& ormAtlas,
+    Canvas::Platform::Win32::XImage* albedoAtlas,
+    Canvas::Platform::Win32::XImage* ormAtlas,
     const TerrainMaterialOptions&   opts,
     TerrainMaterialOutputs*         outputs,
     XLogger*                        pLogger = nullptr);

--- a/src/Inc/CanvasPlatformWin32.h
+++ b/src/Inc/CanvasPlatformWin32.h
@@ -2,54 +2,56 @@
 #include "Gem.hpp"
 #include "CanvasFormat.h"
 #include <cstdint>
-#include <vector>
 
 namespace Canvas { struct XLogger; }
 
 namespace Canvas::Platform::Win32 {
 
 //------------------------------------------------------------------------------------------------
-// Image loading — WIC-backed loader. Accepts any Canvas::GfxFormat that has a
-// direct WIC IWICFormatConverter mapping; unsupported formats return false.
-// Currently supported: R8G8B8A8_UNorm, R16G16B16A16_Float, R8_UNorm, R16_UNorm.
+// XImage - a decoded image returned by LoadImageData. The pixel storage lives entirely inside
+// the implementation, so no STL container crosses the DLL boundary. Pixels are row-major; the
+// row stride is GetWidth() * GetBytesPerPixel() bytes.
 //------------------------------------------------------------------------------------------------
-struct ImageData
+struct XImage : public Gem::XGeneric
 {
-    uint32_t              Width  = 0;
-    uint32_t              Height = 0;
-    Canvas::GfxFormat     Format = Canvas::GfxFormat::Unknown;
-    std::vector<uint8_t>  Pixels; // Row-major raw bytes; stride = Width * BytesPerPixel()
+    GEM_INTERFACE_DECLARE(XImage, 0x7A1C39E6D2840FB5);
 
-    uint32_t BytesPerPixel() const
-    {
-        switch (Format)
-        {
-        case Canvas::GfxFormat::R8G8B8A8_UNorm:        return 4;
-        case Canvas::GfxFormat::R16G16B16A16_Float:    return 8;
-        case Canvas::GfxFormat::R8_UNorm:              return 1;
-        case Canvas::GfxFormat::R16_UNorm:             return 2;
-        default:                                        return 0;
-        }
-    }
+    GEMMETHOD_(uint32_t, GetWidth)() = 0;
+    GEMMETHOD_(uint32_t, GetHeight)() = 0;
+    GEMMETHOD_(Canvas::GfxFormat, GetFormat)() = 0;
+    GEMMETHOD_(uint32_t, GetBytesPerPixel)() = 0;
 
-    bool IsEmpty() const { return Pixels.empty() || Width == 0 || Height == 0; }
+    // Pointer to the row-major pixel bytes, valid for the lifetime of this object.
+    // Returns nullptr when the image is empty.
+    GEMMETHOD_(const uint8_t*, GetPixels)() = 0;
+
+    // Total size of the pixel buffer in bytes (Height * GetWidth() * GetBytesPerPixel()).
+    GEMMETHOD_(size_t, GetPixelByteCount)() = 0;
+
+    // True when no pixels are present (zero dimensions or an empty buffer).
+    GEMMETHOD_(bool, IsEmpty)() = 0;
 };
 
-// Load any WIC-decodable image file and convert to the requested pixel format.
-// Returns true on success; on failure outImage is left empty and an error is
-// logged via pLogger (if non-null).
-bool LoadImageData(
+//------------------------------------------------------------------------------------------------
+// Image loading - WIC-backed loader. Accepts any Canvas::GfxFormat that has a direct WIC
+// IWICFormatConverter mapping; unsupported formats fail.
+// Currently supported: R8G8B8A8_UNorm, R16G16B16A16_Float, R8_UNorm, R16_UNorm.
+//
+// On success *ppImage receives a new XImage (the caller owns the reference); on failure
+// *ppImage is set to null and an error is logged via pLogger (if non-null).
+//------------------------------------------------------------------------------------------------
+Gem::Result LoadImageData(
     const wchar_t*     path,
     Canvas::GfxFormat  format,
-    ImageData*         outImage,
+    XImage**           ppImage,
     Canvas::XLogger*   pLogger = nullptr);
 
 // Memory-based overload: decode from raw image bytes (e.g. an embedded FBX texture).
-bool LoadImageData(
+Gem::Result LoadImageData(
     const uint8_t*     data,
     size_t             byteCount,
     Canvas::GfxFormat  format,
-    ImageData*         outImage,
+    XImage**           ppImage,
     Canvas::XLogger*   pLogger = nullptr);
 
 struct AppWindowDesc


### PR DESCRIPTION
Replaces `ImageData` struct with `XImage` interface in `CanvasCore.h`. This eliminates the dependency on `<vector>` in `CanvasCore.h` - which is a problem because STL version dependencies should never cross DLL boundaries.

The interface better governs data lifetime, while still providing platform-specific handling of image data.