### PR TITLE
Copy queue cleanup

### DIFF
--- a/src/CanvasGfx12/Lib/CMakeLists.txt
+++ b/src/CanvasGfx12/Lib/CMakeLists.txt
@@ -6,6 +6,8 @@ add_library(CanvasGfx12 SHARED
     CanvasGfx12.cpp
     CommandAllocatorPool.cpp
     CopyQueue.cpp
+    DescriptorHeapAllocator.cpp
+    DescriptorRing.cpp
     Device12.cpp
     GpuTask.cpp
     RenderQueue12.cpp

--- a/src/CanvasGfx12/Lib/CopyQueue.cpp
+++ b/src/CanvasGfx12/Lib/CopyQueue.cpp
@@ -30,6 +30,10 @@ void CCopyQueue::Initialize(CDevice12* pDevice)
     m_AllocatorPool.Init(pDevice, D3D12_COMMAND_LIST_TYPE_COPY);
     m_AllocatorPool.SwapAllocator(m_pAllocator, 0, 0);
 
+    Gem::ThrowGemError(ResultFromHRESULT(m_pDevice->GetD3DDevice()->CreateCommandList1(
+        0, D3D12_COMMAND_LIST_TYPE_COPY, D3D12_COMMAND_LIST_FLAG_NONE, IID_PPV_ARGS(&m_pCommandList))));
+    SetD3D12DebugName(m_pCommandList, "CopyQueue_CommandList");
+
     // 1 MB initial — same as the render queue's ring; grows on demand.
     m_UploadRing.Initialize(pDevice, 1 * 1024 * 1024);
 
@@ -55,6 +59,7 @@ void CCopyQueue::Shutdown()
     }
 
     m_UploadRing.Shutdown();
+    m_pCommandList.Release();
     m_pAllocator.Release();
     m_pFence.Release();
     m_pCommandQueue.Release();
@@ -148,10 +153,8 @@ std::optional<FenceToken> CCopyQueue::FlushIfPending()
 
     const UINT64 completedValue = m_pFence->GetCompletedValue();
 
-    CComPtr<ID3D12GraphicsCommandList> pCL;
-    Gem::ThrowGemError(ResultFromHRESULT(m_pDevice->GetD3DDevice()->CreateCommandList(
-        0, D3D12_COMMAND_LIST_TYPE_COPY, m_pAllocator, nullptr, IID_PPV_ARGS(&pCL))));
-    SetD3D12DebugName(pCL, "CopyQueue_CommandList");
+    Gem::ThrowGemError(ResultFromHRESULT(m_pCommandList->Reset(m_pAllocator, nullptr)));
+    ID3D12GraphicsCommandList* pCL = m_pCommandList;
 
     for (const auto& op : bufferOps)
         pCL->CopyBufferRegion(op.pDst, op.DstOffset, op.pSrc, op.SrcOffset, op.Size);

--- a/src/CanvasGfx12/Lib/CopyQueue.h
+++ b/src/CanvasGfx12/Lib/CopyQueue.h
@@ -106,11 +106,12 @@ private:
 
     CDevice12* m_pDevice = nullptr;
 
-    CComPtr<ID3D12CommandQueue>     m_pCommandQueue;
-    CComPtr<ID3D12Fence>            m_pFence;
-    CCommandAllocatorPool           m_AllocatorPool;
-    CComPtr<ID3D12CommandAllocator> m_pAllocator;   // recycled across flushes via the pool
-    CUploadRing                     m_UploadRing;
+    CComPtr<ID3D12CommandQueue>        m_pCommandQueue;
+    CComPtr<ID3D12Fence>               m_pFence;
+    CCommandAllocatorPool              m_AllocatorPool;
+    CComPtr<ID3D12CommandAllocator>    m_pAllocator;     // recycled across flushes via the pool
+    CComPtr<ID3D12GraphicsCommandList> m_pCommandList;   // created once, Reset() and reused each flush
+    CUploadRing                        m_UploadRing;
 
     uint32_t m_TimelineId       = FenceToken::kInvalidTimelineId;
     UINT64   m_LastSignaledValue = 0;

--- a/src/CanvasGfx12/Lib/DescriptorHeapAllocator.cpp
+++ b/src/CanvasGfx12/Lib/DescriptorHeapAllocator.cpp
@@ -1,0 +1,54 @@
+//================================================================================================
+// CDescriptorHeapAllocator - Implementation.
+//================================================================================================
+
+#include "pch.h"
+#include "DescriptorHeapAllocator.h"
+
+//------------------------------------------------------------------------------------------------
+void CDescriptorHeapAllocator::Initialize(UINT baseSlot, UINT count)
+{
+    std::lock_guard<std::mutex> lock(m_Mutex);
+    m_Next = baseSlot;
+    m_End  = baseSlot + count;
+    m_FreeLists.clear();
+}
+
+//------------------------------------------------------------------------------------------------
+UINT CDescriptorHeapAllocator::Allocate(UINT count)
+{
+    if (count == 0)
+        return kInvalidSlot;
+
+    std::lock_guard<std::mutex> lock(m_Mutex);
+
+    // Reuse a previously-freed block of this exact size if one is available.
+    auto it = m_FreeLists.find(count);
+    if (it != m_FreeLists.end() && !it->second.empty())
+    {
+        const UINT base = it->second.back();
+        it->second.pop_back();
+        return base;
+    }
+
+    // Otherwise carve fresh slots off the bump pointer.  Subtraction avoids overflow since
+    // m_Next never exceeds m_End.
+    if (m_End - m_Next >= count)
+    {
+        const UINT base = m_Next;
+        m_Next += count;
+        return base;
+    }
+
+    return kInvalidSlot;  // region exhausted
+}
+
+//------------------------------------------------------------------------------------------------
+void CDescriptorHeapAllocator::Free(UINT baseSlot, UINT count)
+{
+    if (count == 0 || baseSlot == kInvalidSlot)
+        return;
+
+    std::lock_guard<std::mutex> lock(m_Mutex);
+    m_FreeLists[count].push_back(baseSlot);
+}

--- a/src/CanvasGfx12/Lib/DescriptorHeapAllocator.h
+++ b/src/CanvasGfx12/Lib/DescriptorHeapAllocator.h
@@ -1,0 +1,60 @@
+//================================================================================================
+// CDescriptorHeapAllocator - Persistent allocator over a descriptor-heap slot range.
+//
+// Hands out contiguous runs of descriptor slots that live until explicitly freed, i.e. for the
+// lifetime of the resource that owns them (a mesh's vertex-stream SRVs, a material's texture
+// SRVs).  This is the counterpart to CDescriptorRing: the ring recycles slots every frame for
+// transient per-draw descriptors, while this allocator holds slots indefinitely so per-resource
+// descriptors can be created once and bound by GPU handle every draw with no per-frame cost.
+//
+// The two share one shader-visible heap by partitioning it: this allocator owns a low slot
+// range [baseSlot, baseSlot + count); the ring owns the remainder.
+//
+// Implemented as size-segregated free lists plus a bump pointer.  The handful of block sizes in
+// use are fixed per resource type (e.g. 5 for a mesh group, 6 for a material), so a free list
+// per size gives O(1) allocate/free with exact-fit reuse: no scan and no rounding waste (unlike
+// a buddy allocator, which would round 5 and 6 up to 8).  A freed block is reusable only by a
+// same-size request, which matches how each resource type churns within its own size class.
+//
+// Thread-safe: resources may be created and destroyed from application threads, so Allocate /
+// Free take an internal lock.
+//================================================================================================
+
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+//------------------------------------------------------------------------------------------------
+class CDescriptorHeapAllocator
+{
+public:
+    static constexpr UINT kInvalidSlot = UINT(-1);
+
+    CDescriptorHeapAllocator() = default;
+
+    CDescriptorHeapAllocator(const CDescriptorHeapAllocator&) = delete;
+    CDescriptorHeapAllocator& operator=(const CDescriptorHeapAllocator&) = delete;
+
+    // Manage the slot range [baseSlot, baseSlot + count).  Resets all bookkeeping.
+    void Initialize(UINT baseSlot, UINT count);
+
+    // Allocate `count` contiguous slots; returns the absolute base slot index, or kInvalidSlot
+    // when the managed range is exhausted (no same-size free block and the bump region is full).
+    UINT Allocate(UINT count);
+
+    // Return a run previously handed out by Allocate so a later same-size Allocate can reuse it.
+    // `count` must match the value passed to the originating Allocate.
+    void Free(UINT baseSlot, UINT count);
+
+private:
+    UINT m_Next = 0;   // next never-used slot (bump pointer)
+    UINT m_End  = 0;   // one past the last managed slot
+
+    // size (in slots) -> stack of free block base slots of that exact size.
+    std::unordered_map<UINT, std::vector<UINT>> m_FreeLists;
+
+    std::mutex m_Mutex;
+};

--- a/src/CanvasGfx12/Lib/DescriptorRing.cpp
+++ b/src/CanvasGfx12/Lib/DescriptorRing.cpp
@@ -1,0 +1,133 @@
+//================================================================================================
+// CDescriptorRing - Implementation.
+//================================================================================================
+
+#include "pch.h"
+#include "DescriptorRing.h"
+
+//------------------------------------------------------------------------------------------------
+void CDescriptorRing::Initialize(UINT baseSlot, UINT capacity)
+{
+    m_BaseSlot            = baseSlot;
+    m_Capacity            = capacity;
+    m_WriteOffset         = 0;
+    m_ReadOffset          = 0;
+    m_InFlight            = 0;
+    m_AllocatedThisFrame  = 0;
+    m_LastCompletedFenceValue = 0;
+    m_FrameMarkers.clear();
+}
+
+//------------------------------------------------------------------------------------------------
+void CDescriptorRing::Reset()
+{
+    m_WriteOffset        = 0;
+    m_ReadOffset         = 0;
+    m_InFlight           = 0;
+    m_AllocatedThisFrame = 0;
+    m_FrameMarkers.clear();
+}
+
+//------------------------------------------------------------------------------------------------
+UINT CDescriptorRing::Allocate(UINT count, const WaitFn& waitFn)
+{
+    // A run larger than the whole heap can never be satisfied.
+    if (count == 0 || count > m_Capacity)
+        throw Gem::GemError(Gem::Result::OutOfMemory);
+
+    auto available = [&]() -> UINT { return m_Capacity - m_InFlight; };
+
+    // Block on (and then reclaim) the oldest in-flight submission.  Caller must ensure a
+    // marker exists; the only way to run dry of markers is a single un-submitted frame
+    // demanding more than the heap holds, which the callers below report as OutOfMemory.
+    auto reclaimOldestBlocking = [&]()
+    {
+        const UINT64 fenceValue = m_FrameMarkers.front().FenceValue;
+        waitFn(fenceValue);
+        Reclaim(fenceValue);
+    };
+
+    // Reclaim anything the GPU has already finished, for free.
+    Reclaim(m_LastCompletedFenceValue);
+
+    // When the ring has drained completely, restart the cursor at slot 0.  Nothing
+    // references any slot, so this cannot overwrite live work and it keeps long runs from
+    // accumulating abandoned wrap slack.
+    if (m_InFlight == 0)
+    {
+        m_WriteOffset = 0;
+        m_ReadOffset  = 0;
+    }
+
+    // Ensure enough total free slots, blocking on in-flight submissions only when the cheap
+    // reclaim above was not enough.
+    while (count > available())
+    {
+        if (m_FrameMarkers.empty())
+            throw Gem::GemError(Gem::Result::OutOfMemory);  // one frame needs more than the heap
+        reclaimOldestBlocking();
+    }
+
+    // A descriptor table must be contiguous, so a run cannot straddle the end of the heap.
+    // When it would, abandon the slack from the cursor to the end and restart at slot 0 --
+    // but first make sure slots [0, count) are clear of in-flight descriptors.
+    UINT wrapSlack = 0;
+    if (m_WriteOffset + count > m_Capacity)
+    {
+        while (count > m_ReadOffset && m_InFlight > 0)
+            reclaimOldestBlocking();
+
+        if (m_InFlight == 0)
+        {
+            // The ring drained while making room; lay out fresh from the start with no
+            // slack to charge.
+            m_WriteOffset = 0;
+            m_ReadOffset  = 0;
+        }
+        else
+        {
+            wrapSlack     = m_Capacity - m_WriteOffset;
+            m_WriteOffset = 0;
+        }
+    }
+
+    const UINT baseSlot = m_WriteOffset;
+    m_WriteOffset += count;
+
+    const UINT consumed   = count + wrapSlack;
+    m_InFlight           += consumed;
+    m_AllocatedThisFrame += consumed;
+    // Hand back an absolute heap slot; internal bookkeeping stays relative to m_BaseSlot.
+    return m_BaseSlot + baseSlot;
+}
+
+//------------------------------------------------------------------------------------------------
+void CDescriptorRing::MarkSubmissionEnd(UINT64 fenceValue)
+{
+    // Frames that reserved no slots add no marker; the cursor is unchanged so there is
+    // nothing to reclaim later.
+    if (m_AllocatedThisFrame == 0)
+        return;
+
+    m_FrameMarkers.push_back({ fenceValue, m_AllocatedThisFrame });
+    m_AllocatedThisFrame = 0;
+}
+
+//------------------------------------------------------------------------------------------------
+void CDescriptorRing::Reclaim(UINT64 completedFenceValue)
+{
+    m_LastCompletedFenceValue = completedFenceValue;
+
+    // Advance the read pointer past each fully retired submission, shrinking the in-flight
+    // count by exactly that submission's slot footprint (including any abandoned wrap slack)
+    // so the read pointer tracks the write pointer monotonically through the ring.
+    while (!m_FrameMarkers.empty())
+    {
+        const FrameMarker& oldest = m_FrameMarkers.front();
+        if (oldest.FenceValue > completedFenceValue)
+            break;
+        m_InFlight  -= oldest.SlotsInFrame;
+        m_ReadOffset = (m_ReadOffset + oldest.SlotsInFrame) % m_Capacity;
+        m_FrameMarkers.pop_front();
+    }
+}

--- a/src/CanvasGfx12/Lib/DescriptorRing.h
+++ b/src/CanvasGfx12/Lib/DescriptorRing.h
@@ -1,0 +1,90 @@
+//================================================================================================
+// CDescriptorRing - Fence-protected ring allocator for a fixed-size descriptor heap.
+//
+// Hands out contiguous runs of descriptor slots from a single D3D12 descriptor heap, treating
+// the heap as a ring.  Slots handed out during a frame stay reserved until the GPU work that
+// references them has completed, tracked by per-submission {fenceValue, slotCount} markers.
+// When the ring cannot satisfy a request without overwriting slots still referenced by
+// in-flight GPU work, it blocks on the owning queue's fence and reclaims completed
+// submissions before reusing those slots.
+//
+// This guards against the bug where simple modular wrap-around reuses a descriptor that the
+// GPU is still reading from a prior frame.
+//
+// Slot granularity only: the ring tracks slot indices, not bytes, so the caller maps the
+// returned base slot to a CPU/GPU handle using the heap's descriptor increment size.  The
+// heap itself is owned and sized by the caller; the ring never creates or resizes it.
+//
+// NOT thread-safe; intended to be owned by a single CRenderQueue12 and touched only by that
+// queue's thread (the same model as CUploadRing).
+//================================================================================================
+
+#pragma once
+
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <Gem.hpp>
+
+//------------------------------------------------------------------------------------------------
+class CDescriptorRing
+{
+public:
+    // Invoked when the ring must wait for in-flight GPU work to retire before reusing slots.
+    // Implementations block the CPU until the queue fence reaches the supplied value.
+    using WaitFn = std::function<void(UINT64)>;
+
+    CDescriptorRing() = default;
+
+    CDescriptorRing(const CDescriptorRing&) = delete;
+    CDescriptorRing& operator=(const CDescriptorRing&) = delete;
+
+    // Manage `capacity` contiguous slots starting at `baseSlot`, and reset all bookkeeping.
+    // baseSlot is non-zero when the ring shares a heap with a persistent allocator that owns
+    // the slots below it; the returned slot indices are absolute (include baseSlot).
+    void Initialize(UINT baseSlot, UINT capacity);
+
+    // Drop all markers and rewind the cursor.  Caller must guarantee the GPU is idle first.
+    void Reset();
+
+    // Reserve `count` contiguous slots and return the absolute base slot index in
+    // [baseSlot, baseSlot + capacity).
+    // A descriptor table must be contiguous, so a run never straddles the end of the heap;
+    // when the cursor is too close to the end the trailing slack is abandoned and the run
+    // restarts at slot 0.  Reclaims completed submissions first, and blocks via waitFn only
+    // when live in-flight slots must be freed to make room.  Throws Gem::Result::OutOfMemory
+    // if `count` exceeds the heap capacity or if a single un-submitted frame's demand cannot
+    // be satisfied (no in-flight work remains to wait on).
+    UINT Allocate(UINT count, const WaitFn& waitFn);
+
+    // Record that every slot handed out since the previous mark belongs to the submission
+    // signalling `fenceValue`; those slots become reclaimable once that fence completes.
+    void MarkSubmissionEnd(UINT64 fenceValue);
+
+    // Release the slots of every submission whose fence value has completed.
+    void Reclaim(UINT64 completedFenceValue);
+
+    // Cache the latest known completed fence value for the cheap reclaim attempt that
+    // Allocate performs before it considers blocking.
+    void SetLastCompletedFenceValue(UINT64 value) { m_LastCompletedFenceValue = value; }
+
+private:
+    UINT m_BaseSlot    = 0;   // absolute index of the ring's first slot in the heap
+    UINT m_Capacity    = 0;   // descriptor slots managed by the ring
+    UINT m_WriteOffset = 0;   // next free slot (head), relative to m_BaseSlot
+    UINT m_ReadOffset  = 0;   // oldest in-flight slot (tail), relative to m_BaseSlot
+    // Authoritative count of slots reserved by in-flight (un-reclaimed) submissions plus
+    // the current un-submitted frame.  Removes the head==tail full-vs-empty ambiguity:
+    // free <=> m_Capacity - m_InFlight.
+    UINT m_InFlight    = 0;
+    // Slots reserved since the most recent MarkSubmissionEnd, folded into the next marker.
+    UINT m_AllocatedThisFrame = 0;
+    UINT64 m_LastCompletedFenceValue = 0;
+
+    struct FrameMarker
+    {
+        UINT64 FenceValue;     // value the owning queue signals for this submission
+        UINT   SlotsInFrame;   // slots (including abandoned wrap slack) to release on reclaim
+    };
+    std::deque<FrameMarker> m_FrameMarkers;
+};

--- a/src/CanvasGfx12/Lib/Device12.cpp
+++ b/src/CanvasGfx12/Lib/Device12.cpp
@@ -171,7 +171,66 @@ Gem::Result CDevice12::Initialize()
     m_ResourceManager.Initialize(this);
     m_CopyQueue.Initialize(this);
 
+    try
+    {
+        InitializeDescriptorHeap();
+    }
+    catch (Gem::GemError& e)
+    {
+        return e.Result();
+    }
+    catch (_com_error& e)
+    {
+        return ResultFromHRESULT(e.Error());
+    }
+
     return Gem::Result::Success;
+}
+
+//------------------------------------------------------------------------------------------------
+void CDevice12::InitializeDescriptorHeap()
+{
+    D3D12_DESCRIPTOR_HEAP_DESC desc = {};
+    desc.Type           = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+    desc.Flags          = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+    desc.NumDescriptors = kNumShaderResourceDescriptors;
+    ThrowFailedHResult(m_pD3DDevice->CreateDescriptorHeap(&desc, IID_PPV_ARGS(&m_pShaderResourceDescriptorHeap)));
+    SetD3D12DebugName(m_pShaderResourceDescriptorHeap, "Device_SRV_DescHeap");
+
+    m_CbvSrvUavIncrement = m_pD3DDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+
+    // Persistent allocator owns the low region; render-queue rings own the high region.
+    m_PersistentSrvAllocator.Initialize(0, kNumPersistentSrvDescriptors);
+}
+
+//------------------------------------------------------------------------------------------------
+void CDevice12::AcquireTransientSrvRange(UINT& baseSlotOut, UINT& countOut)
+{
+    if (m_TransientSrvRangeClaimed)
+    {
+        Canvas::LogError(GetLogger(),
+            "CDevice12: the shared descriptor heap's transient partition is already owned by a "
+            "render queue; only one render queue per device is supported.");
+        throw Gem::GemError(Gem::Result::Unavailable);
+    }
+
+    m_TransientSrvRangeClaimed = true;
+    baseSlotOut = kNumPersistentSrvDescriptors;
+    countOut    = kNumTransientSrvDescriptors;
+}
+
+//------------------------------------------------------------------------------------------------
+D3D12_CPU_DESCRIPTOR_HANDLE CDevice12::GetSrvCpuHandle(UINT slot) const
+{
+    return CD3DX12_CPU_DESCRIPTOR_HANDLE(
+        m_pShaderResourceDescriptorHeap->GetCPUDescriptorHandleForHeapStart(), slot, m_CbvSrvUavIncrement);
+}
+
+//------------------------------------------------------------------------------------------------
+D3D12_GPU_DESCRIPTOR_HANDLE CDevice12::GetSrvGpuHandle(UINT slot) const
+{
+    return CD3DX12_GPU_DESCRIPTOR_HANDLE(
+        m_pShaderResourceDescriptorHeap->GetGPUDescriptorHandleForHeapStart(), slot, m_CbvSrvUavIncrement);
 }
 
 //------------------------------------------------------------------------------------------------

--- a/src/CanvasGfx12/Lib/Device12.cpp
+++ b/src/CanvasGfx12/Lib/Device12.cpp
@@ -201,6 +201,12 @@ void CDevice12::InitializeDescriptorHeap()
 
     // Persistent allocator owns the low region; render-queue rings own the high region.
     m_PersistentSrvAllocator.Initialize(0, kNumPersistentSrvDescriptors);
+
+    // Reserve the shared all-null material block up front, bound by DrawMesh for groups that
+    // legitimately have no material (MeshDataGroupDesc::pMaterial is documented optional).
+    m_DefaultMaterialSlot = m_PersistentSrvAllocator.Allocate(kMaterialDescriptorCount);
+    for (UINT i = 0; i < kMaterialDescriptorCount; ++i)
+        WriteTexture2DSRV(m_DefaultMaterialSlot + i, nullptr);
 }
 
 //------------------------------------------------------------------------------------------------
@@ -231,6 +237,62 @@ D3D12_GPU_DESCRIPTOR_HANDLE CDevice12::GetSrvGpuHandle(UINT slot) const
 {
     return CD3DX12_GPU_DESCRIPTOR_HANDLE(
         m_pShaderResourceDescriptorHeap->GetGPUDescriptorHandleForHeapStart(), slot, m_CbvSrvUavIncrement);
+}
+
+//------------------------------------------------------------------------------------------------
+void CDevice12::WriteStructuredBufferSRV(UINT slot, CBuffer12* pBuffer, UINT stride)
+{
+    D3D12_CPU_DESCRIPTOR_HANDLE h = GetSrvCpuHandle(slot);
+    if (pBuffer && stride > 0)
+    {
+        D3D12_RESOURCE_DESC rd = pBuffer->GetD3DResource()->GetDesc();
+        D3D12_SHADER_RESOURCE_VIEW_DESC d = {};
+        d.Format                     = DXGI_FORMAT_UNKNOWN;
+        d.ViewDimension              = D3D12_SRV_DIMENSION_BUFFER;
+        d.Shader4ComponentMapping    = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+        d.Buffer.NumElements         = static_cast<UINT>(rd.Width / stride);
+        d.Buffer.StructureByteStride = stride;
+        m_pD3DDevice->CreateShaderResourceView(pBuffer->GetD3DResource(), &d, h);
+    }
+    else
+    {
+        D3D12_SHADER_RESOURCE_VIEW_DESC nullDesc = {};
+        nullDesc.Format                  = DXGI_FORMAT_R32_FLOAT;
+        nullDesc.ViewDimension           = D3D12_SRV_DIMENSION_BUFFER;
+        nullDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+        m_pD3DDevice->CreateShaderResourceView(nullptr, &nullDesc, h);
+    }
+}
+
+//------------------------------------------------------------------------------------------------
+void CDevice12::WriteTexture2DSRV(UINT slot, CSurface12* pSurface)
+{
+    D3D12_CPU_DESCRIPTOR_HANDLE h = GetSrvCpuHandle(slot);
+    if (pSurface)
+    {
+        D3D12_RESOURCE_DESC rd = pSurface->GetD3DResource()->GetDesc();
+        D3D12_SHADER_RESOURCE_VIEW_DESC d = {};
+        d.Format                  = rd.Format;
+        d.ViewDimension           = D3D12_SRV_DIMENSION_TEXTURE2D;
+        d.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+        d.Texture2D.MipLevels     = rd.MipLevels ? rd.MipLevels : 1;
+        m_pD3DDevice->CreateShaderResourceView(pSurface->GetD3DResource(), &d, h);
+    }
+    else
+    {
+        D3D12_SHADER_RESOURCE_VIEW_DESC nullDesc = {};
+        nullDesc.Format                  = DXGI_FORMAT_R8G8B8A8_UNORM;
+        nullDesc.ViewDimension           = D3D12_SRV_DIMENSION_TEXTURE2D;
+        nullDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+        nullDesc.Texture2D.MipLevels     = 1;
+        m_pD3DDevice->CreateShaderResourceView(nullptr, &nullDesc, h);
+    }
+}
+
+//------------------------------------------------------------------------------------------------
+D3D12_GPU_DESCRIPTOR_HANDLE CDevice12::GetDefaultMaterialTableHandle()
+{
+    return GetSrvGpuHandle(m_DefaultMaterialSlot);
 }
 
 //------------------------------------------------------------------------------------------------
@@ -266,7 +328,7 @@ GEMMETHODIMP CDevice12::CreateMaterial(Canvas::XGfxMaterial **ppMaterial)
     {
         Gem::TGemPtr<CMaterial12> pMaterial;
         Gem::ThrowGemError(TGfxElement<Canvas::XGfxMaterial>::CreateAndRegister<CMaterial12>(
-            &pMaterial, GetCanvas(), "Material"));
+            &pMaterial, GetCanvas(), this, "Material"));
         *ppMaterial = pMaterial.Detach();
         return Gem::Result::Success;
     }
@@ -664,8 +726,37 @@ GEMMETHODIMP CDevice12::CreateMeshData(
         for (uint32_t gi = 0; gi < desc.GroupCount; ++gi)
             groups[gi].pMaterial = desc.pGroups[gi].pMaterial;
 
+        // Populate each group's persistent mesh-stream descriptor block: kMeshStreamDescriptorCount
+        // contiguous SRVs in the shared heap (normals t1, UV0 t2, tangents t3, bone indices t10,
+        // bone weights t11),
+        // null where the stream is absent.  Created once here and bound by GPU handle every draw.
+        for (size_t gi = 0; gi < groups.size(); ++gi)
+        {
+            auto& group = groups[gi];
+            const UINT base = AllocatePersistentDescriptors(kMeshStreamDescriptorCount);
+            if (base == CDescriptorHeapAllocator::kInvalidSlot)
+            {
+                // Roll back the blocks already taken for earlier groups: the CMeshData12 that frees
+                // them on destruction has not been created yet, so nothing else owns them.
+                for (size_t gj = 0; gj < gi; ++gj)
+                    FreePersistentDescriptors(groups[gj].StreamDescriptorBase, kMeshStreamDescriptorCount);
+                throw Gem::GemError(Gem::Result::OutOfMemory);
+            }
+            group.StreamDescriptorBase = base;
+
+            auto bufOf = [](Canvas::GfxResourceAllocation& a) -> CBuffer12*
+            {
+                return a.pBuffer ? static_cast<CBuffer12*>(a.pBuffer.Get()) : nullptr;
+            };
+            WriteStructuredBufferSRV(base + 0, bufOf(group.NormalVB),      sizeof(Canvas::Math::FloatVector4));
+            WriteStructuredBufferSRV(base + 1, bufOf(group.UV0VB),         sizeof(Canvas::Math::FloatVector2));
+            WriteStructuredBufferSRV(base + 2, bufOf(group.TangentVB),     sizeof(Canvas::Math::FloatVector4));
+            WriteStructuredBufferSRV(base + 3, bufOf(group.BoneIndicesVB), sizeof(Canvas::Math::UIntVector4));
+            WriteStructuredBufferSRV(base + 4, bufOf(group.BoneWeightsVB), sizeof(Canvas::Math::FloatVector4));
+        }
+
         Gem::TGemPtr<CMeshData12> pMeshData;
-        Gem::ThrowGemError(TGfxElement<Canvas::XGfxMeshData>::CreateAndRegister(&pMeshData, GetCanvas(), baseName));
+        Gem::ThrowGemError(TGfxElement<Canvas::XGfxMeshData>::CreateAndRegister(&pMeshData, GetCanvas(), this, baseName));
         pMeshData->SetGroups(std::move(groups));
         pMeshData->SetTopology(desc.Topology);
         pMeshData->SetTotalVertexCount(totalVertexCount);

--- a/src/CanvasGfx12/Lib/Device12.cpp
+++ b/src/CanvasGfx12/Lib/Device12.cpp
@@ -145,12 +145,14 @@ Gem::Result CDevice12::Initialize()
             DWORD cookie = 0;
             if (m_pDebugLogger && SUCCEEDED(pInfoQueue1->RegisterMessageCallback(
                 D3D12DebugMessageCallback,
-                D3D12_MESSAGE_CALLBACK_IGNORE_FILTERS,
+                D3D12_MESSAGE_CALLBACK_FLAG_NONE,
                 static_cast<Canvas::XLogger*>(m_pDebugLogger),
                 &cookie)))
             {
                 m_pInfoQueue1 = pInfoQueue1;
                 m_debugCallbackCookie = cookie;
+                // Default the storage filter to warnings-and-above
+                SetDebugMessageSeverity(Canvas::GfxDebugSeverity::Warning);
                 Canvas::LogInfo(GetLogger(), "D3D12 debug message callback registered");
             }
             else
@@ -825,4 +827,51 @@ GEMMETHODIMP CDevice12::CreateRectElement(Canvas::XUIRectElement **ppElement)
         return result;
     *ppElement = pElement.Detach();
     return Gem::Result::Success;
+}
+
+//------------------------------------------------------------------------------------------------
+GEMMETHODIMP_(void) CDevice12::SetDebugMessageSeverity(Canvas::GfxDebugSeverity maxSeverity)
+{
+#if defined(_DEBUG)
+    // No-op when the debug layer / info queue is unavailable (e.g. the debug
+    // layer was not enabled, or RegisterMessageCallback failed during init).
+    if (!m_pInfoQueue1)
+        return;
+
+    // D3D severities run most-severe (CORRUPTION=0) to least-severe (MESSAGE=4).
+    // Translate the requested threshold into the least-severe D3D value we still
+    // allow; everything with a larger value is denied.  Off allows nothing.
+    int allowDownTo;
+    switch (maxSeverity)
+    {
+    case Canvas::GfxDebugSeverity::Off:        allowDownTo = -1;                                break;
+    case Canvas::GfxDebugSeverity::Corruption: allowDownTo = D3D12_MESSAGE_SEVERITY_CORRUPTION; break;
+    case Canvas::GfxDebugSeverity::Error:      allowDownTo = D3D12_MESSAGE_SEVERITY_ERROR;      break;
+    case Canvas::GfxDebugSeverity::Warning:    allowDownTo = D3D12_MESSAGE_SEVERITY_WARNING;    break;
+    case Canvas::GfxDebugSeverity::Info:       allowDownTo = D3D12_MESSAGE_SEVERITY_INFO;       break;
+    case Canvas::GfxDebugSeverity::Verbose:    allowDownTo = D3D12_MESSAGE_SEVERITY_MESSAGE;    break;
+    default:                                   allowDownTo = D3D12_MESSAGE_SEVERITY_WARNING;    break;
+    }
+
+    D3D12_MESSAGE_SEVERITY denied[D3D12_MESSAGE_SEVERITY_MESSAGE + 1];
+    UINT denyCount = 0;
+    for (int s = D3D12_MESSAGE_SEVERITY_CORRUPTION; s <= D3D12_MESSAGE_SEVERITY_MESSAGE; ++s)
+    {
+        if (s > allowDownTo)
+            denied[denyCount++] = static_cast<D3D12_MESSAGE_SEVERITY>(s);
+    }
+
+    // Replace any existing storage filter with the new deny list.  An empty deny
+    // list (Verbose) leaves the filter cleared so everything passes.
+    m_pInfoQueue1->ClearStorageFilter();
+    if (denyCount > 0)
+    {
+        D3D12_INFO_QUEUE_FILTER filter = {};
+        filter.DenyList.NumSeverities = denyCount;
+        filter.DenyList.pSeverityList = denied;
+        m_pInfoQueue1->AddStorageFilterEntries(&filter);
+    }
+#else
+    (void)maxSeverity;
+#endif
 }

--- a/src/CanvasGfx12/Lib/Device12.h
+++ b/src/CanvasGfx12/Lib/Device12.h
@@ -18,6 +18,7 @@
 #include "UploadRing.h"
 #include "CopyQueue.h"
 #include "GlyphAtlas.h"
+#include "DescriptorHeapAllocator.h"
 
 inline constexpr D3D12_HEAP_TYPE GfxMemoryUsageToD3D12HeapType(Canvas::GfxMemoryUsage usage)
 {
@@ -129,7 +130,61 @@ public:
     Canvas::XGfxSurface* GetGlyphAtlasSurface();
     Canvas::CGlyphCache& GetGlyphCache() { return m_GlyphCache; }
 
+    //--------------------------------------------------------------------------------------------
+    // Shared shader-visible CBV/SRV/UAV descriptor heap.
+    //
+    // One heap per device so per-resource descriptors (mesh vertex-stream SRVs, material
+    // texture SRVs) have a stable home that any render queue can bind by GPU handle.  The heap
+    // is partitioned: a low persistent region [0, kNumPersistentSrvDescriptors) owned by
+    // m_PersistentSrvAllocator (lifetime-scoped per-resource blocks), and a high transient
+    // region that each render queue's CDescriptorRing recycles per frame for dynamic
+    // per-draw descriptors.  Sizes are a tunable split of the fixed heap capacity.
+    //--------------------------------------------------------------------------------------------
+    static constexpr UINT kNumShaderResourceDescriptors = 65536;
+    static constexpr UINT kNumPersistentSrvDescriptors  = 32768;
+    static constexpr UINT kNumTransientSrvDescriptors   =
+        kNumShaderResourceDescriptors - kNumPersistentSrvDescriptors;
+
+    ID3D12DescriptorHeap* GetShaderResourceDescriptorHeap() const { return m_pShaderResourceDescriptorHeap; }
+    UINT GetCbvSrvUavIncrement() const { return m_CbvSrvUavIncrement; }
+
+    // Claim the shared heap's transient partition for a render queue's per-frame SRV ring.
+    // Only one render queue per device is supported: a GPU has a single rendering engine, so
+    // there is never a second render queue in practice, and the transient ring's fence-gated
+    // reclaim is keyed to exactly one queue's fence.  The first call hands out the whole
+    // transient partition; a second call throws (Gem::Result::Unavailable) rather than let two
+    // rings hand out overlapping slots in the shared heap.  The owning queue releases the
+    // claim at teardown.
+    //
+    // FUTURE (compute queues): physics / work-graph / other compute workloads are expected to
+    // address resources through the persistent region (stable per-resource indices) or through
+    // root descriptors (GPU VA, no heap slot) -- NOT this transient ring.  If a compute queue
+    // ever genuinely needs transient heap slots, give it its own disjoint sub-range; do not
+    // share this ring.  A shared ring would let a long-running compute submission stall
+    // rendering (the ring blocks on a fence to reclaim slots) and could set up a fence lock
+    // inversion (render waiting on compute while compute waits on render).  Keep the render
+    // and compute transient lifetimes independent.
+    void AcquireTransientSrvRange(UINT& baseSlotOut, UINT& countOut);
+    void ReleaseTransientSrvRange() { m_TransientSrvRangeClaimed = false; }
+
+    // Persistent per-resource descriptor blocks.  Allocate returns an absolute heap slot (or
+    // CDescriptorHeapAllocator::kInvalidSlot when the persistent region is exhausted); Free
+    // returns the run.  GetSrv*Handle map a slot to a CPU handle (to write the descriptor) or
+    // a GPU handle (to bind the table).
+    UINT AllocatePersistentDescriptors(UINT count) { return m_PersistentSrvAllocator.Allocate(count); }
+    void FreePersistentDescriptors(UINT baseSlot, UINT count) { m_PersistentSrvAllocator.Free(baseSlot, count); }
+    D3D12_CPU_DESCRIPTOR_HANDLE GetSrvCpuHandle(UINT slot) const;
+    D3D12_GPU_DESCRIPTOR_HANDLE GetSrvGpuHandle(UINT slot) const;
+
 private:
+    // Create the shared shader-visible heap and initialize the persistent allocator.
+    void InitializeDescriptorHeap();
+
+    CComPtr<ID3D12DescriptorHeap> m_pShaderResourceDescriptorHeap;
+    UINT m_CbvSrvUavIncrement = 0;
+    CDescriptorHeapAllocator m_PersistentSrvAllocator;
+    bool m_TransientSrvRangeClaimed = false;  // see AcquireTransientSrvRange
+
     Canvas::CGlyphCache m_GlyphCache;
     Gem::TGemPtr<Canvas::XGfxSurface> m_pGlyphAtlasSurface;
 };

--- a/src/CanvasGfx12/Lib/Device12.h
+++ b/src/CanvasGfx12/Lib/Device12.h
@@ -124,6 +124,8 @@ public:
     GEMMETHOD(CreateTextElement)(Canvas::XUITextElement **ppElement) final;
     GEMMETHOD(CreateRectElement)(Canvas::XUIRectElement **ppElement) final;
 
+    GEMMETHOD_(void, SetDebugMessageSeverity)(Canvas::GfxDebugSeverity maxSeverity) final;
+
     Canvas::XGfxSurface* GetGlyphAtlasSurface();
     Canvas::CGlyphCache& GetGlyphCache() { return m_GlyphCache; }
 

--- a/src/CanvasGfx12/Lib/Device12.h
+++ b/src/CanvasGfx12/Lib/Device12.h
@@ -176,6 +176,23 @@ public:
     D3D12_CPU_DESCRIPTOR_HANDLE GetSrvCpuHandle(UINT slot) const;
     D3D12_GPU_DESCRIPTOR_HANDLE GetSrvGpuHandle(UINT slot) const;
 
+    // Write one persistent descriptor at absolute heap slot `slot`.  A null resource writes a
+    // null SRV of the matching kind so the table slot stays well-defined.  Used by meshes and
+    // materials to populate their persistent per-resource descriptor blocks.
+    void WriteStructuredBufferSRV(UINT slot, class CBuffer12* pBuffer, UINT stride);
+    void WriteTexture2DSRV(UINT slot, class CSurface12* pSurface);
+
+    // Sizes of a per-mesh-group vertex-stream descriptor block and a per-material texture
+    // descriptor block.  The slot-to-stream / slot-to-role mappings are defined where the blocks
+    // are filled (CDevice12::CreateMeshData and CMaterial12::PopulateDescriptors) and matched by
+    // the default root signature in CRenderQueue12.
+    static constexpr UINT kMeshStreamDescriptorCount = 5;
+    static constexpr UINT kMaterialDescriptorCount   = 6;
+
+    // GPU handle of the shared all-null material texture block, bound by DrawMesh for groups that
+    // legitimately have no material (reserved once in InitializeDescriptorHeap).
+    D3D12_GPU_DESCRIPTOR_HANDLE GetDefaultMaterialTableHandle();
+
 private:
     // Create the shared shader-visible heap and initialize the persistent allocator.
     void InitializeDescriptorHeap();
@@ -184,6 +201,7 @@ private:
     UINT m_CbvSrvUavIncrement = 0;
     CDescriptorHeapAllocator m_PersistentSrvAllocator;
     bool m_TransientSrvRangeClaimed = false;  // see AcquireTransientSrvRange
+    UINT m_DefaultMaterialSlot = CDescriptorHeapAllocator::kInvalidSlot;  // null block for null-material groups
 
     Canvas::CGlyphCache m_GlyphCache;
     Gem::TGemPtr<Canvas::XGfxSurface> m_pGlyphAtlasSurface;

--- a/src/CanvasGfx12/Lib/Material12.cpp
+++ b/src/CanvasGfx12/Lib/Material12.cpp
@@ -4,13 +4,58 @@
 
 #include "pch.h"
 #include "Material12.h"
+#include "Device12.h"
+#include "Surface12.h"
 
 //------------------------------------------------------------------------------------------------
-CMaterial12::CMaterial12(Canvas::XCanvas *pCanvas, PCSTR name) :
-    TGfxElement(pCanvas)
+CMaterial12::CMaterial12(Canvas::XCanvas *pCanvas, CDevice12 *pDevice, PCSTR name) :
+    TGfxElement(pCanvas),
+    m_pDevice(pDevice)
 {
     if (name != nullptr)
         SetName(name);
+
+    // Allocate this material's persistent texture block (kMaterialDescriptorCount SRVs, one per
+    // SupportedRole; see PopulateDescriptors) once and seed it from the current textures (all null
+    // at creation; SetTexture refreshes it later).
+    m_DescriptorBase = m_pDevice->AllocatePersistentDescriptors(CDevice12::kMaterialDescriptorCount);
+    if (m_DescriptorBase == CDescriptorHeapAllocator::kInvalidSlot)
+        throw Gem::GemError(Gem::Result::OutOfMemory);
+    PopulateDescriptors();
+}
+
+//------------------------------------------------------------------------------------------------
+CMaterial12::~CMaterial12()
+{
+    m_pDevice->FreePersistentDescriptors(m_DescriptorBase, CDevice12::kMaterialDescriptorCount);
+}
+
+//------------------------------------------------------------------------------------------------
+void CMaterial12::PopulateDescriptors()
+{
+    // Material table slot order is albedo, normal, emissive, roughness, metallic, AO -- which
+    // maps onto m_Textures (indexed by SupportedRole) in this order.
+    const SupportedRole blockOrder[CDevice12::kMaterialDescriptorCount] = {
+        Role_Albedo, Role_Normal, Role_Emissive, Role_Roughness, Role_Metallic, Role_AmbientOcclusion,
+    };
+
+    for (UINT i = 0; i < CDevice12::kMaterialDescriptorCount; ++i)
+    {
+        CSurface12* pSurf = nullptr;
+        if (Canvas::XGfxSurface* pSurface = m_Textures[blockOrder[i]].Get())
+        {
+            Gem::TGemPtr<CSurface12> pSurf12;
+            pSurface->QueryInterface(&pSurf12);
+            pSurf = pSurf12.Get();
+        }
+        m_pDevice->WriteTexture2DSRV(m_DescriptorBase + i, pSurf);
+    }
+}
+
+//------------------------------------------------------------------------------------------------
+D3D12_GPU_DESCRIPTOR_HANDLE CMaterial12::GetTextureTableHandle()
+{
+    return m_pDevice->GetSrvGpuHandle(m_DescriptorBase);
 }
 
 //------------------------------------------------------------------------------------------------
@@ -49,6 +94,12 @@ GEMMETHODIMP CMaterial12::SetTexture(Canvas::MaterialLayerRole role, Canvas::XGf
         return Gem::Result::NotImplemented;
 
     m_Textures[mapped] = pSurface;
+
+    // Refresh the persistent descriptor block so the new texture is visible to draws.
+    // NOTE: this writes the shared, shader-visible descriptor in place; configure materials
+    // before they are used for rendering, since a change while a frame referencing this block
+    // is in flight is not synchronized against the GPU.
+    PopulateDescriptors();
     return Gem::Result::Success;
 }
 

--- a/src/CanvasGfx12/Lib/Material12.h
+++ b/src/CanvasGfx12/Lib/Material12.h
@@ -9,6 +9,9 @@
 #pragma once
 
 #include "CanvasGfx12.h"
+#include "DescriptorHeapAllocator.h"
+
+class CDevice12;
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -24,10 +27,18 @@ public:
         GEM_INTERFACE_ENTRY(Canvas::XNamedElement)
     END_GEM_INTERFACE_MAP()
 
-    CMaterial12(Canvas::XCanvas *pCanvas, PCSTR name = nullptr);
+    // pDevice (the owning device, which holds the shared descriptor heap) is required and never
+    // changes.  The ctor allocates + populates this material's persistent texture descriptor
+    // block (kMaterialDescriptorCount SRVs, one per SupportedRole) and throws
+    // Gem::Result::OutOfMemory if the persistent region is exhausted.
+    CMaterial12(Canvas::XCanvas *pCanvas, CDevice12 *pDevice, PCSTR name = nullptr);
+    ~CMaterial12();
 
     Gem::Result Initialize() { return Gem::Result::Success; }
     void Uninitialize() {}
+
+    // GPU handle of the material's persistent texture table, bound by DrawMesh.
+    D3D12_GPU_DESCRIPTOR_HANDLE GetTextureTableHandle();
 
     // XGfxMaterial
     GEMMETHOD(SetTexture)(Canvas::MaterialLayerRole role, Canvas::XGfxSurface *pSurface) final;
@@ -97,6 +108,13 @@ private:
     };
 
     static bool MapRole(Canvas::MaterialLayerRole role, SupportedRole &out);
+
+    // (Re)write this material's persistent texture SRVs from m_Textures, in material-table slot
+    // order (defined by the blockOrder table in PopulateDescriptors).
+    void PopulateDescriptors();
+
+    CDevice12* m_pDevice = nullptr;  // owns the shared descriptor heap
+    UINT       m_DescriptorBase = CDescriptorHeapAllocator::kInvalidSlot;  // base of the persistent texture block (kMaterialDescriptorCount SRVs)
 
     Gem::TGemPtr<Canvas::XGfxSurface> m_Textures[Role_Count];
     Canvas::Math::FloatVector4 m_BaseColorFactor    = { 1.0f, 1.0f, 1.0f, 1.0f };

--- a/src/CanvasGfx12/Lib/MeshData12.cpp
+++ b/src/CanvasGfx12/Lib/MeshData12.cpp
@@ -8,11 +8,30 @@
 #include <algorithm>
 
 //------------------------------------------------------------------------------------------------
-CMeshData12::CMeshData12(Canvas::XCanvas* pCanvas, PCSTR name) :
-    TGfxElement(pCanvas)
+CMeshData12::CMeshData12(Canvas::XCanvas* pCanvas, CDevice12* pDevice, PCSTR name) :
+    TGfxElement(pCanvas),
+    m_pDevice(pDevice)
 {
     if (name != nullptr)
         SetName(name);
+}
+
+//------------------------------------------------------------------------------------------------
+CMeshData12::~CMeshData12()
+{
+    // Return each group's persistent mesh-stream descriptor block to the device allocator.
+    if (m_pDevice)
+    {
+        for (auto& group : m_Groups)
+        {
+            if (group.StreamDescriptorBase != CDescriptorHeapAllocator::kInvalidSlot)
+            {
+                m_pDevice->FreePersistentDescriptors(group.StreamDescriptorBase,
+                                                     CDevice12::kMeshStreamDescriptorCount);
+                group.StreamDescriptorBase = CDescriptorHeapAllocator::kInvalidSlot;
+            }
+        }
+    }
 }
 
 //------------------------------------------------------------------------------------------------

--- a/src/CanvasGfx12/Lib/MeshData12.h
+++ b/src/CanvasGfx12/Lib/MeshData12.h
@@ -6,6 +6,9 @@
 
 #include <vector>
 #include "CanvasGfx12.h"
+#include "DescriptorHeapAllocator.h"
+
+class CDevice12;
 
 //------------------------------------------------------------------------------------------------
 class CMeshData12 : public TGfxElement<Canvas::XGfxMeshData>
@@ -28,12 +31,29 @@ public:
         Canvas::GfxResourceAllocation       BoneWeightsVB;  // empty when not skinned
         Canvas::GfxResourceAllocation       BoneIndicesVB;  // empty when not skinned
         Gem::TGemPtr<Canvas::XGfxMaterial>  pMaterial;      // may be null
+
+        // Base slot of this group's persistent mesh-stream descriptor block in the device's shared
+        // heap (kMeshStreamDescriptorCount SRVs; CDevice12::CreateMeshData defines the
+        // slot-to-stream mapping).  kInvalidSlot until populated by CDevice12::CreateMeshData.
+        UINT                                StreamDescriptorBase = CDescriptorHeapAllocator::kInvalidSlot;
     };
 
-    CMeshData12(Canvas::XCanvas* pCanvas, PCSTR name = nullptr);
+    // pDevice (the owning device, which holds the shared descriptor heap) is required and never
+    // changes; the mesh frees its per-group persistent descriptor blocks back to it on
+    // destruction.
+    CMeshData12(Canvas::XCanvas* pCanvas, CDevice12* pDevice, PCSTR name = nullptr);
+    ~CMeshData12();
 
     Gem::Result Initialize() { return Gem::Result::Success; }
     void Uninitialize() {}
+
+    // Base slot of the given group's persistent mesh-stream descriptor block, or
+    // CDescriptorHeapAllocator::kInvalidSlot if it has none.
+    UINT GetStreamDescriptorBase(uint32_t materialIndex) const
+    {
+        return materialIndex < m_Groups.size() ? m_Groups[materialIndex].StreamDescriptorBase
+                                               : CDescriptorHeapAllocator::kInvalidSlot;
+    }
 
     // XGfxMeshData interface
     GEMMETHOD_(uint32_t, GetNumMaterialGroups)() override;
@@ -54,5 +74,6 @@ private:
     Canvas::GfxPrimitiveTopology   m_Topology         = Canvas::GfxPrimitiveTopology::TriangleList;
     uint32_t                       m_TotalVertexCount = 0;
     Canvas::Math::AABB             m_LocalBounds;  // empty by default
+    CDevice12*                     m_pDevice          = nullptr;  // owns the shared descriptor heap
 };
 

--- a/src/CanvasGfx12/Lib/RenderQueue12.cpp
+++ b/src/CanvasGfx12/Lib/RenderQueue12.cpp
@@ -3643,11 +3643,17 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
                     auto* pTextImpl = static_cast<CUITextElement12*>(static_cast<Canvas::XUITextElement*>(pElem));
                     if (pTextImpl->GetGlyphCount() > 0)
                     {
+                        pTextImpl->EnsureGlyphBufferUploaded(m_pDevice, this);
+
                         Canvas::GfxResourceAllocation glyphSRV = pTextImpl->GetGlyphBuffer();
-                        Gem::ThrowGemError(m_pDevice->AllocateStructuredBuffer(
-                            pTextImpl->GetGlyphCount(), sizeof(HlslTypes::HlslGlyphInstance),
-                            pTextImpl->GetGlyphData(), this, glyphSRV));
-                        pTextImpl->SetGlyphBuffer(glyphSRV);
+                        assert(glyphSRV.pBuffer && "text element has glyphs but no uploaded glyph buffer");
+                        if (!glyphSRV.pBuffer)
+                        {
+                            Canvas::LogError(m_pDevice->GetLogger(),
+                                "Text element has %u glyphs but no uploaded glyph buffer; skipping draw",
+                                pTextImpl->GetGlyphCount());
+                            Gem::ThrowGemError(Gem::Result::Uninitialized);
+                        }
 
                         DeferRelease(glyphSRV.pBuffer.Get());
 

--- a/src/CanvasGfx12/Lib/RenderQueue12.cpp
+++ b/src/CanvasGfx12/Lib/RenderQueue12.cpp
@@ -14,6 +14,7 @@
 #include "Surface12.h"
 #include "SwapChain12.h"
 #include "MeshData12.h"
+#include "Material12.h"
 #include "UITextElement12.h"
 
 #include <filesystem>
@@ -147,43 +148,40 @@ CRenderQueue12::CRenderQueue12(Canvas::XCanvas* pCanvas, CDevice12 *pDevice, PCS
     CComPtr<ID3D12Fence> pFence;
     Gem::ThrowGemError(ResultFromHRESULT(pD3DDevice->CreateFence(m_FenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&pFence))));
 
-    // The default root signature uses the following parameters
-    //  Root CBV (descriptor static)
-    //  Root SRV (descriptor static)
-    //  Root UAV (descriptor static)
-    //  Root descriptor table
-
-    // The default root descriptor table is laid out as follows:
-    //  CBV[2]  @ b1, b2  (data static)
-    //  SRV[9]  @ t1..t9  (data static) - t1=normals, t2=UV0, t3=tangents,
-    //                    t4=albedo, t5=normalMap, t6=emissive,
-    //                    t7=roughness, t8=metallic, t9=ambient occlusion
-    //  UAV[2]  @ u1, u2  (descriptor static)
+    // Default root signature layout.  Per-resource SRVs (mesh streams, material
+    // textures) live in persistent descriptor-heap blocks owned by the mesh / material
+    // and are bound by GPU handle as two descriptor tables; nothing is allocated per draw.
     //
-    // A single static sampler s0 (LinearWrap, anisotropic mip filter) covers
-    // all material texture sampling.
+    //   Param 0: Root CBV  b0   - per-frame constants
+    //   Param 1: Root SRV  t0   - vertex positions (per draw)
+    //   Param 2: Root CBV  b1   - per-object constants (per draw, uploaded to upload ring)
+    //   Param 3: Descriptor table (VS) - mesh-stream block: SRV t1..t3 (normals, UV0,
+    //            tangents) + t10,t11 (bone indices, bone weights)
+    //   Param 4: Descriptor table (PS) - material block: SRV t4..t9 (albedo, normal,
+    //            emissive, roughness, metallic, ambient occlusion)
+    //   Param 5: Root SRV  t12  - bone matrix palette (per draw, uploaded to upload ring)
+    //
+    // A single static sampler s0 (LinearWrap, anisotropic mip filter) covers all
+    // material texture sampling.
+    // Mesh-stream table: vertex-stream SRVs that live in a persistent per-mesh-group block.
+    // Two ranges over the block's contiguous slots -> t1,t2,t3 (normals, UV0, tangents) then
+    // t10,t11 (bone indices, bone weights).  Vertex-shader visible.
+    CD3DX12_DESCRIPTOR_RANGE1 MeshStreamRanges[2];
+    MeshStreamRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 3, 1,  0, D3D12_DESCRIPTOR_RANGE_FLAG_NONE, 0);
+    MeshStreamRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 10, 0, D3D12_DESCRIPTOR_RANGE_FLAG_NONE, 3);
 
-    // Default root signature layout:
-    //   Param 0: Root CBV  b0        - per-frame constants
-    //   Param 1: Root SRV  t0        - vertex positions
-    //   Param 2: Root UAV  u0        - (unused)
-    //   Param 3: Descriptor table
-    //     CBV[2]  b1, b2             - per-object CB + null
-    //     SRV[11] t1..t11            - normals(t1), UV0(t2), tangents(t3),
-    //                                  albedo(t4..t9), boneIndices(t10), boneWeights(t11)
-    //     UAV[2]  u1, u2             - null
-    //   Param 4: Root SRV  t12       - bone matrix palette (per-draw, uploaded to upload ring)
-    std::vector<CD3DX12_DESCRIPTOR_RANGE1> DefaultDescriptorRanges(3);
-    DefaultDescriptorRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 2,  1, 0, D3D12_DESCRIPTOR_RANGE_FLAG_NONE, 0);
-    DefaultDescriptorRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 11, 1, 0, D3D12_DESCRIPTOR_RANGE_FLAG_NONE, 2);
-    DefaultDescriptorRanges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 2,  1, 0, D3D12_DESCRIPTOR_RANGE_FLAG_NONE, 13);
+    // Material table: texture SRVs t4..t9 (albedo, normal, emissive, roughness, metallic, AO)
+    // in a persistent per-material block.  Pixel-shader visible.
+    CD3DX12_DESCRIPTOR_RANGE1 MaterialRanges[1];
+    MaterialRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 6, 4, 0, D3D12_DESCRIPTOR_RANGE_FLAG_NONE, 0);
 
-    std::vector<CD3DX12_ROOT_PARAMETER1> DefaultRootParams(5);
-    DefaultRootParams[0].InitAsConstantBufferView(0,  0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC,   D3D12_SHADER_VISIBILITY_ALL);
-    DefaultRootParams[1].InitAsShaderResourceView(0,  0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC,   D3D12_SHADER_VISIBILITY_ALL);
-    DefaultRootParams[2].InitAsUnorderedAccessView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_NONE,          D3D12_SHADER_VISIBILITY_ALL);
-    DefaultRootParams[3].InitAsDescriptorTable(static_cast<UINT>(DefaultDescriptorRanges.size()), DefaultDescriptorRanges.data(), D3D12_SHADER_VISIBILITY_ALL);
-    DefaultRootParams[4].InitAsShaderResourceView(12, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE, D3D12_SHADER_VISIBILITY_VERTEX);
+    std::vector<CD3DX12_ROOT_PARAMETER1> DefaultRootParams(6);
+    DefaultRootParams[0].InitAsConstantBufferView(0,  0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC,                 D3D12_SHADER_VISIBILITY_ALL);    // b0 per-frame
+    DefaultRootParams[1].InitAsShaderResourceView(0,  0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC,                 D3D12_SHADER_VISIBILITY_ALL);    // t0 positions
+    DefaultRootParams[2].InitAsConstantBufferView(1,  0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC_WHILE_SET_AT_EXECUTE, D3D12_SHADER_VISIBILITY_ALL);  // b1 per-object
+    DefaultRootParams[3].InitAsDescriptorTable(_countof(MeshStreamRanges), MeshStreamRanges, D3D12_SHADER_VISIBILITY_VERTEX); // mesh-stream table
+    DefaultRootParams[4].InitAsDescriptorTable(_countof(MaterialRanges),   MaterialRanges,   D3D12_SHADER_VISIBILITY_PIXEL);  // material table
+    DefaultRootParams[5].InitAsShaderResourceView(12, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE, D3D12_SHADER_VISIBILITY_VERTEX); // t12 bone palette
 
     CD3DX12_STATIC_SAMPLER_DESC DefaultStaticSamplers[1] = {};
     DefaultStaticSamplers[0].Init(
@@ -194,7 +192,7 @@ CRenderQueue12::CRenderQueue12(Canvas::XCanvas* pCanvas, CDevice12 *pDevice, PCS
         D3D12_TEXTURE_ADDRESS_MODE_WRAP);
 
     CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC DefaultRootSigDesc(
-        5U, DefaultRootParams.data(),
+        static_cast<UINT>(DefaultRootParams.size()), DefaultRootParams.data(),
         _countof(DefaultStaticSamplers), DefaultStaticSamplers,
         D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 
@@ -2047,103 +2045,20 @@ Gem::Result CRenderQueue12::DrawMesh(
         Gem::ThrowGemError(m_UploadRing.AllocateFromRing(cbSize, hw));
         memcpy(hw.pMapped, &objectConstants, sizeof(HlslTypes::HlslPerObjectConstants));
         
-        // Allocate a contiguous block of 15 descriptors:
-        //   slots 0-1  : CBV[2] @ b1, b2
-        //   slots 2-12 : SRV[11] @ t1..t11 (normals, UV0, tangents, albedo..AO,
-        //                                    boneIndices, boneWeights)
-        //   slots 13-14: UAV[2] @ u1, u2 (null)
-        constexpr UINT kDescCount = 15;
-        UINT baseSlot = AllocateSRVSlots(kDescCount);
-        
-        const UINT incSize = m_CbvSrvUavIncrement;
-        ID3D12Device *pD3DDevice = m_pDevice->GetD3DDevice();
-        CD3DX12_CPU_DESCRIPTOR_HANDLE baseCpuHandle(m_pShaderResourceDescriptorHeap->GetCPUDescriptorHandleForHeapStart(), baseSlot, incSize);
-        CD3DX12_GPU_DESCRIPTOR_HANDLE baseGpuHandle(m_pShaderResourceDescriptorHeap->GetGPUDescriptorHandleForHeapStart(), baseSlot, incSize);
-        
-        // CBV b1: per-object constants
-        D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc = {};
-        cbvDesc.BufferLocation = hw.GpuAddress;
-        cbvDesc.SizeInBytes = static_cast<UINT>(cbSize);
-        pD3DDevice->CreateConstantBufferView(&cbvDesc, baseCpuHandle);
-        
-        // CBV b2: null placeholder
-        D3D12_CONSTANT_BUFFER_VIEW_DESC nullCbvDesc = {};
-        pD3DDevice->CreateConstantBufferView(&nullCbvDesc, CD3DX12_CPU_DESCRIPTOR_HANDLE(baseCpuHandle, 1, incSize));
-        
-        // Helper lambdas for null fallbacks
-        D3D12_SHADER_RESOURCE_VIEW_DESC nullBufSrvDesc = {};
-        nullBufSrvDesc.Format = DXGI_FORMAT_R32_FLOAT;
-        nullBufSrvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
-        nullBufSrvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        
-        D3D12_SHADER_RESOURCE_VIEW_DESC nullTex2DSrvDesc = {};
-        nullTex2DSrvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        nullTex2DSrvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        nullTex2DSrvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        nullTex2DSrvDesc.Texture2D.MipLevels = 1;
-        
-        auto WriteStructuredBufSRV = [&](UINT tableSlot, CBuffer12* pBuf, UINT stride)
-        {
-            CD3DX12_CPU_DESCRIPTOR_HANDLE h(baseCpuHandle, tableSlot, incSize);
-            if (pBuf)
-            {
-                D3D12_RESOURCE_DESC rd = pBuf->GetD3DResource()->GetDesc();
-                D3D12_SHADER_RESOURCE_VIEW_DESC d = {};
-                d.Format = DXGI_FORMAT_UNKNOWN;
-                d.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
-                d.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-                d.Buffer.NumElements = static_cast<UINT>(rd.Width / stride);
-                d.Buffer.StructureByteStride = stride;
-                pD3DDevice->CreateShaderResourceView(pBuf->GetD3DResource(), &d, h);
-            }
-            else
-            {
-                pD3DDevice->CreateShaderResourceView(nullptr, &nullBufSrvDesc, h);
-            }
-        };
-        auto WriteTexture2DSRV = [&](UINT tableSlot, CSurface12* pSurf)
-        {
-            CD3DX12_CPU_DESCRIPTOR_HANDLE h(baseCpuHandle, tableSlot, incSize);
-            if (pSurf)
-            {
-                D3D12_RESOURCE_DESC rd = pSurf->GetD3DResource()->GetDesc();
-                D3D12_SHADER_RESOURCE_VIEW_DESC d = {};
-                d.Format = rd.Format;
-                d.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-                d.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-                d.Texture2D.MipLevels = rd.MipLevels ? rd.MipLevels : 1;
-                pD3DDevice->CreateShaderResourceView(pSurf->GetD3DResource(), &d, h);
-            }
-            else
-            {
-                pD3DDevice->CreateShaderResourceView(nullptr, &nullTex2DSrvDesc, h);
-            }
-        };
-        
-        // SRV t1: normals (slot 2)
-        WriteStructuredBufSRV(2, pNormBuf, sizeof(Canvas::Math::FloatVector4));
-        // SRV t2: UV0 (slot 3)
-        WriteStructuredBufSRV(3, pUV0Buf, sizeof(Canvas::Math::FloatVector2));
-        // SRV t3: tangents (slot 4)
-        WriteStructuredBufSRV(4, pTanBuf, sizeof(Canvas::Math::FloatVector4));
-        // SRV t4..t9: material textures (slots 5..10)
-        WriteTexture2DSRV(5,  pTextures[0]); // Albedo
-        WriteTexture2DSRV(6,  pTextures[1]); // Normal map
-        WriteTexture2DSRV(7,  pTextures[2]); // Emissive
-        WriteTexture2DSRV(8,  pTextures[3]); // Roughness
-        WriteTexture2DSRV(9,  pTextures[4]); // Metallic
-        WriteTexture2DSRV(10, pTextures[5]); // AO
-        // SRV t10: bone indices (slot 11); SRV t11: bone weights (slot 12)
-        WriteStructuredBufSRV(11, pBoneIBuf, sizeof(Canvas::Math::UIntVector4));
-        WriteStructuredBufSRV(12, pBoneWBuf, sizeof(Canvas::Math::FloatVector4));
+        // Per-resource SRVs live in persistent descriptor blocks owned by the mesh group
+        // (vertex streams) and the material (textures); bind them by GPU handle, nothing is
+        // allocated per draw.  The group always has a stream block (CreateMeshData fails the whole
+        // mesh otherwise).  A group with no material is a deliberate, supported state, bound to the
+        // device's all-null texture block.
+        const UINT streamBase = pMesh->GetStreamDescriptorBase(materialGroupIndex);
+        D3D12_GPU_DESCRIPTOR_HANDLE meshStreamHandle = m_pDevice->GetSrvGpuHandle(streamBase);
+        D3D12_GPU_DESCRIPTOR_HANDLE materialHandle =
+            pMaterial ? static_cast<CMaterial12*>(pMaterial)->GetTextureTableHandle()
+                      : m_pDevice->GetDefaultMaterialTableHandle();
 
-        // UAVs u1, u2: null (slots 13, 14)
-        D3D12_UNORDERED_ACCESS_VIEW_DESC nullUavDesc = {};
-        nullUavDesc.Format = DXGI_FORMAT_R32_FLOAT;
-        nullUavDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
-        for (UINT i = 13; i <= 14; ++i)
-            pD3DDevice->CreateUnorderedAccessView(nullptr, nullptr, &nullUavDesc, CD3DX12_CPU_DESCRIPTOR_HANDLE(baseCpuHandle, i, incSize));
-        
+        // Per-object constants are bound as a root CBV (b1) directly from the upload ring.
+        D3D12_GPU_VIRTUAL_ADDRESS perObjectCbvAddr = hw.GpuAddress;
+
         // Set root SRV (param 1) for positions (t0)
         D3D12_GPU_VIRTUAL_ADDRESS posGpuAddr = pPosBuf->GetD3DResource()->GetGPUVirtualAddress();
         D3D12_RESOURCE_DESC posDesc = pPosBuf->GetD3DResource()->GetDesc();
@@ -2179,16 +2094,18 @@ Gem::Result CRenderQueue12::DrawMesh(
                     D3D12_BARRIER_ACCESS_SHADER_RESOURCE);
             }
         }
-        drawTask.RecordFunc = [posGpuAddr, boneMatricesGpuAddr, baseGpuHandle, vertexCount, this](ID3D12GraphicsCommandList* pCL)
+        drawTask.RecordFunc = [posGpuAddr, perObjectCbvAddr, meshStreamHandle, materialHandle, boneMatricesGpuAddr, vertexCount, this](ID3D12GraphicsCommandList* pCL)
         {
             pCL->SetPipelineState(GetActiveDefaultPSO());
             pCL->SetGraphicsRootSignature(m_pDefaultRootSig);
             pCL->OMSetRenderTargets(5, m_GBufferRTVs, FALSE, &m_CurrentDSV);
             pCL->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
             pCL->SetDescriptorHeaps(2, m_DescriptorHeapsArray);
-            pCL->SetGraphicsRootShaderResourceView(1, posGpuAddr);
-            pCL->SetGraphicsRootDescriptorTable(3, baseGpuHandle);
-            pCL->SetGraphicsRootShaderResourceView(4, boneMatricesGpuAddr);
+            pCL->SetGraphicsRootShaderResourceView(1, posGpuAddr);           // t0 positions
+            pCL->SetGraphicsRootConstantBufferView(2, perObjectCbvAddr);     // b1 per-object
+            pCL->SetGraphicsRootDescriptorTable(3, meshStreamHandle);        // t1-t3, t10-t11
+            pCL->SetGraphicsRootDescriptorTable(4, materialHandle);          // t4-t9 material
+            pCL->SetGraphicsRootShaderResourceView(5, boneMatricesGpuAddr);  // t12 bone palette
             pCL->DrawInstanced(vertexCount, 1, 0, 0);
         };
         m_GpuTaskGraph.InsertTask(drawTask);

--- a/src/CanvasGfx12/Lib/RenderQueue12.cpp
+++ b/src/CanvasGfx12/Lib/RenderQueue12.cpp
@@ -105,7 +105,7 @@ CRenderQueue12::CRenderQueue12(Canvas::XCanvas* pCanvas, CDevice12 *pDevice, PCS
     // Initialize allocator pool (grows on demand as allocators are needed)
     m_AllocatorPool.Init(pDevice, D3D12_COMMAND_LIST_TYPE_DIRECT);
 
-    // Initialize task graphs — all start with work CLs closed
+    // Initialize task graphs - all start with work CLs closed
     m_GpuTaskGraph.Init(pD3DDevice, pCQ, &m_AllocatorPool);
     m_UIGpuTaskGraph.Init(pD3DDevice, pCQ, &m_AllocatorPool);
     m_PresentGpuTaskGraph.Init(pD3DDevice, pCQ, &m_AllocatorPool);
@@ -121,14 +121,12 @@ CRenderQueue12::CRenderQueue12(Canvas::XCanvas* pCanvas, CDevice12 *pDevice, PCS
         SetD3D12DebugName(m_PresentGpuTaskGraph.GetFixupCommandList(),name, "Present_FixupCL");
     }
 
-    CComPtr<ID3D12DescriptorHeap> pResDH;
-    D3D12_DESCRIPTOR_HEAP_DESC DHDesc = {};
-    DHDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
-    DHDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-    DHDesc.NumDescriptors = NumShaderResourceDescriptors; // BUGBUG: This needs to be a well-known constant
-    Gem::ThrowGemError(ResultFromHRESULT(pD3DDevice->CreateDescriptorHeap(&DHDesc, IID_PPV_ARGS(&pResDH))));
-
+    // The shader-visible CBV/SRV/UAV heap is owned by the device and shared across render
+    // queues so per-resource descriptors (mesh streams, material textures) have a stable home.
+    // This queue caches a ref to it and binds it; its transient SRV ring carves the heap's
+    // upper partition (the lower partition is the device's persistent allocator).
     CComPtr<ID3D12DescriptorHeap> pSamplerDH;
+    D3D12_DESCRIPTOR_HEAP_DESC DHDesc = {};
     DHDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
     DHDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
     DHDesc.NumDescriptors = NumSamplerDescriptors; // BUGBUG: This needs to be a well-known constant
@@ -157,7 +155,7 @@ CRenderQueue12::CRenderQueue12(Canvas::XCanvas* pCanvas, CDevice12 *pDevice, PCS
 
     // The default root descriptor table is laid out as follows:
     //  CBV[2]  @ b1, b2  (data static)
-    //  SRV[9]  @ t1..t9  (data static) — t1=normals, t2=UV0, t3=tangents,
+    //  SRV[9]  @ t1..t9  (data static) - t1=normals, t2=UV0, t3=tangents,
     //                    t4=albedo, t5=normalMap, t6=emissive,
     //                    t7=roughness, t8=metallic, t9=ambient occlusion
     //  UAV[2]  @ u1, u2  (descriptor static)
@@ -166,15 +164,15 @@ CRenderQueue12::CRenderQueue12(Canvas::XCanvas* pCanvas, CDevice12 *pDevice, PCS
     // all material texture sampling.
 
     // Default root signature layout:
-    //   Param 0: Root CBV  b0        — per-frame constants
-    //   Param 1: Root SRV  t0        — vertex positions
-    //   Param 2: Root UAV  u0        — (unused)
+    //   Param 0: Root CBV  b0        - per-frame constants
+    //   Param 1: Root SRV  t0        - vertex positions
+    //   Param 2: Root UAV  u0        - (unused)
     //   Param 3: Descriptor table
-    //     CBV[2]  b1, b2             — per-object CB + null
-    //     SRV[11] t1..t11            — normals(t1), UV0(t2), tangents(t3),
+    //     CBV[2]  b1, b2             - per-object CB + null
+    //     SRV[11] t1..t11            - normals(t1), UV0(t2), tangents(t3),
     //                                  albedo(t4..t9), boneIndices(t10), boneWeights(t11)
-    //     UAV[2]  u1, u2             — null
-    //   Param 4: Root SRV  t12       — bone matrix palette (per-draw, uploaded to upload ring)
+    //     UAV[2]  u1, u2             - null
+    //   Param 4: Root SRV  t12       - bone matrix palette (per-draw, uploaded to upload ring)
     std::vector<CD3DX12_DESCRIPTOR_RANGE1> DefaultDescriptorRanges(3);
     DefaultDescriptorRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_CBV, 2,  1, 0, D3D12_DESCRIPTOR_RANGE_FLAG_NONE, 0);
     DefaultDescriptorRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 11, 1, 0, D3D12_DESCRIPTOR_RANGE_FLAG_NONE, 2);
@@ -207,7 +205,7 @@ CRenderQueue12::CRenderQueue12(Canvas::XCanvas* pCanvas, CDevice12 *pDevice, PCS
     pD3DDevice->CreateRootSignature(1, pRSBlob->GetBufferPointer(), pRSBlob->GetBufferSize(), IID_PPV_ARGS(&pDefaultRootSig));
 
     m_pDefaultRootSig.Attach(pDefaultRootSig.Detach());
-    m_pShaderResourceDescriptorHeap.Attach(pResDH.Detach());
+    m_pShaderResourceDescriptorHeap = m_pDevice->GetShaderResourceDescriptorHeap();  // shared, ref-counted
     m_pSamplerDescriptorHeap.Attach(pSamplerDH.Detach());
     m_pRTVDescriptorHeap.Attach(pRTVDH.Detach());
     m_pDSVDescriptorHeap.Attach(pDSVDH.Detach());
@@ -219,7 +217,8 @@ CRenderQueue12::CRenderQueue12(Canvas::XCanvas* pCanvas, CDevice12 *pDevice, PCS
     {
         SetD3D12DebugName(m_pCommandQueue,                name, "CommandQueue");
         SetD3D12DebugName(m_pFence,                       name, "Fence");
-        SetD3D12DebugName(m_pShaderResourceDescriptorHeap,name, "SRV_DescHeap");
+        // m_pShaderResourceDescriptorHeap is the device-owned shared heap; it is named once
+        // at device init, not per queue.
         SetD3D12DebugName(m_pSamplerDescriptorHeap,       name, "Sampler_DescHeap");
         SetD3D12DebugName(m_pRTVDescriptorHeap,           name, "RTV_DescHeap");
         SetD3D12DebugName(m_pDSVDescriptorHeap,           name, "DSV_DescHeap");
@@ -236,6 +235,18 @@ CRenderQueue12::CRenderQueue12(Canvas::XCanvas* pCanvas, CDevice12 *pDevice, PCS
 
     // Per-queue upload ring (1 MB initial, grows on demand).
     m_UploadRing.Initialize(pDevice, 1 * 1024 * 1024);
+
+    // Fence-protected descriptor ring allocators.  They gate slot reuse on this queue's fence
+    // so wrap-around cannot overwrite descriptors still referenced by in-flight GPU work.
+    // RTV/DSV heaps are per-queue and fully ring-managed from slot 0.  The SRV ring carves
+    // only the transient upper partition of the shared device heap; the lower partition is the
+    // device's persistent per-resource allocator.  Claiming the transient partition throws if
+    // a second render queue is created on this device (see CDevice12::AcquireTransientSrvRange).
+    m_RTVRing.Initialize(0, NumRTVDescriptors);
+    m_DSVRing.Initialize(0, NumDSVDescriptors);
+    UINT srvBase = 0, srvCount = 0;
+    m_pDevice->AcquireTransientSrvRange(srvBase, srvCount);
+    m_SRVRing.Initialize(srvBase, srvCount);
 
     // Register this queue's fence with the device-level resource manager so
     // pooled buffers and deferred releases can be tracked queue-agnostically.
@@ -268,8 +279,7 @@ GEMMETHODIMP CRenderQueue12::CreateSwapChain(HWND hWnd, bool Windowed, Canvas::X
 //------------------------------------------------------------------------------------------------
 D3D12_CPU_DESCRIPTOR_HANDLE CRenderQueue12::CreateRenderTargetView(class CSurface12 *pSurface, UINT ArraySlice, UINT MipSlice, UINT PlaneSlice)
 {
-    UINT slot = m_NextRTVSlot;
-    m_NextRTVSlot = (m_NextRTVSlot + 1) % NumRTVDescriptors;
+    UINT slot = AllocateRTVSlots(1);
     CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_pRTVDescriptorHeap->GetCPUDescriptorHandleForHeapStart(), slot, m_RtvIncrement);
     D3D12_RENDER_TARGET_VIEW_DESC rtvDesc = {};
     rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2DARRAY;
@@ -294,7 +304,7 @@ void CRenderQueue12::Flush()
             m_pCommandQueue->Wait(pFence, token->Value);
     }
 
-    // Dispatch order: scene → UI
+    // Dispatch order: scene -> UI
     if (m_TaskGraphActive)
         m_GpuTaskGraph.Dispatch();
 
@@ -309,6 +319,13 @@ void CRenderQueue12::Flush()
 
     // Record ring buffer usage for this frame
     m_UploadRing.MarkSubmissionEnd(m_FenceValue);
+
+    // Tag this frame's descriptor slots with the fence just signalled; they become
+    // reclaimable once the GPU passes it.  All RTV/DSV (BeginFrame) and SRV (EndFrame)
+    // allocations for this frame are consumed by the scene + UI work signalled above.
+    m_RTVRing.MarkSubmissionEnd(m_FenceValue);
+    m_DSVRing.MarkSubmissionEnd(m_FenceValue);
+    m_SRVRing.MarkSubmissionEnd(m_FenceValue);
 
     // Reset scene and UI graphs for next frame
     UINT64 completedFenceValue = m_pFence->GetCompletedValue();
@@ -328,7 +345,7 @@ GEMMETHODIMP CRenderQueue12::FlushAndPresent(Canvas::XGfxSwapChain *pSwapChain)
         // Dispatch scene and UI graphs first
         Flush();
 
-        // Back buffer → COMMON for Present. Always dispatched last via the present graph.
+        // Back buffer -> COMMON for Present. Always dispatched last via the present graph.
         if (pIntSwapChain->m_BackBufferModified)
         {
             CSurface12* pBackBuffer = pIntSwapChain->m_pSurface;
@@ -384,12 +401,12 @@ void CRenderQueue12::Uninitialize()
         }
     }
 
-    // GPU is idle — drain any remaining deferred resources.
+    // GPU is idle - drain any remaining deferred resources.
     ProcessCompletedWork();
 
     // Unregister this queue's timeline from the device-level resource manager.
     // Drains and drops any retired buffers / deferred refs owned by this timeline.
-    // The shared bucketed pool stays alive — it is owned by the device and torn
+    // The shared bucketed pool stays alive - it is owned by the device and torn
     // down when the device is destroyed (or by the last surviving queue's release
     // chain via CDevice12::~CDevice12).
     if (m_TimelineId != FenceToken::kInvalidTimelineId)
@@ -400,6 +417,10 @@ void CRenderQueue12::Uninitialize()
 
     // Release the per-queue upload ring now that the GPU is idle.
     m_UploadRing.Shutdown();
+
+    // Release the shared heap's transient partition so a future render queue on this device
+    // can claim it.
+    m_pDevice->ReleaseTransientSrvRange();
 }
 
 //------------------------------------------------------------------------------------------------
@@ -506,6 +527,11 @@ void CRenderQueue12::ProcessCompletedWork()
     
     // Reclaim upload ring buffer space in bulk
     m_UploadRing.Reclaim(completedValue);
+
+    // Release descriptor slots whose referencing GPU work has retired.
+    m_RTVRing.Reclaim(completedValue);
+    m_DSVRing.Reclaim(completedValue);
+    m_SRVRing.Reclaim(completedValue);
 
     // Reclaim pooled buffers and (later) deferred releases across all timelines.
     m_pDevice->GetResourceManager().Reclaim();
@@ -788,9 +814,8 @@ void CRenderQueue12::EnsureGBuffers(UINT width, UINT height)
 D3D12_CPU_DESCRIPTOR_HANDLE CRenderQueue12::CreateDepthStencilView(CSurface12 *pSurface)
 {
     ID3D12Device *pD3DDevice = m_pDevice->GetD3DDevice();
-    UINT slot = m_NextDSVSlot;
-    m_NextDSVSlot = (m_NextDSVSlot + 1) % NumDSVDescriptors;
-    
+    UINT slot = AllocateDSVSlots(1);
+
     CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_pDSVDescriptorHeap->GetCPUDescriptorHandleForHeapStart(), slot, m_DsvIncrement);
     
     D3D12_DEPTH_STENCIL_VIEW_DESC dsvDesc = {};
@@ -811,9 +836,8 @@ D3D12_GPU_DESCRIPTOR_HANDLE CRenderQueue12::CreateShaderResourceView(
     ID3D12Resource* pResource, const D3D12_SHADER_RESOURCE_VIEW_DESC& srvDesc)
 {
     ID3D12Device *pD3DDevice = m_pDevice->GetD3DDevice();
-    UINT slot = m_NextSRVSlot;
-    m_NextSRVSlot = (m_NextSRVSlot + 1) % NumShaderResourceDescriptors;
-    
+    UINT slot = AllocateSRVSlots(1);
+
     CD3DX12_CPU_DESCRIPTOR_HANDLE cpuHandle(m_pShaderResourceDescriptorHeap->GetCPUDescriptorHandleForHeapStart(), slot, m_CbvSrvUavIncrement);
     
     pD3DDevice->CreateShaderResourceView(pResource, &srvDesc, cpuHandle);
@@ -919,7 +943,7 @@ void CRenderQueue12::EnsureDefaultPSO()
     // Blend state (opaque)
     psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
     
-    // Depth-stencil state (reverse-Z: near=1.0, far=0.0 → GREATER_EQUAL)
+    // Depth-stencil state (reverse-Z: near=1.0, far=0.0 -> GREATER_EQUAL)
     psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
     psoDesc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_GREATER_EQUAL;
     psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
@@ -927,7 +951,7 @@ void CRenderQueue12::EnsureDefaultPSO()
     psoDesc.SampleMask = UINT_MAX;
     psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
     
-    // MRT: five G-buffer render targets — Normals, Diffuse, WorldPos, PBR, Emissive
+    // MRT: five G-buffer render targets - Normals, Diffuse, WorldPos, PBR, Emissive
     psoDesc.NumRenderTargets = 5;
     psoDesc.RTVFormats[0] = CanvasFormatToDXGIFormat(m_GBufferNormalsFormat);
     psoDesc.RTVFormats[1] = CanvasFormatToDXGIFormat(m_GBufferDiffuseFormat);
@@ -1283,10 +1307,10 @@ void CRenderQueue12::EnsureTextPSO(DXGI_FORMAT rtvFormat)
     ID3D12Device* pD3DDevice = m_pDevice->GetD3DDevice();
 
     // Text root signature:
-    //   Slot 0: Root CBV(b0) – HlslTextConstants (screen size, offset, text color)
-    //   Slot 1: Root SRV(t0) – StructuredBuffer<HlslGlyphInstance>
-    //   Slot 2: Descriptor table with SRV[1] at t1 – SDFAtlas texture
-    //   Static sampler at s0 – linear, clamp
+    //   Slot 0: Root CBV(b0) - HlslTextConstants (screen size, offset, text color)
+    //   Slot 1: Root SRV(t0) - StructuredBuffer<HlslGlyphInstance>
+    //   Slot 2: Descriptor table with SRV[1] at t1 - SDFAtlas texture
+    //   Static sampler at s0 - linear, clamp
     CD3DX12_STATIC_SAMPLER_DESC linearSampler(
         0,                               // shader register s0
         D3D12_FILTER_MIN_MAG_MIP_LINEAR,
@@ -1380,8 +1404,8 @@ void CRenderQueue12::EnsureRectPSO(DXGI_FORMAT rtvFormat)
     ID3D12Device* pD3DDevice = m_pDevice->GetD3DDevice();
 
     // Rect root signature:
-    //   Slot 0: Root CBV(b0) – HlslRectConstants (screen size, element offset, rect size, fill color)
-    // No vertex buffer — the vertex shader derives the quad from SV_VertexID + constants.
+    //   Slot 0: Root CBV(b0) - HlslRectConstants (screen size, element offset, rect size, fill color)
+    // No vertex buffer - the vertex shader derives the quad from SV_VertexID + constants.
     std::vector<CD3DX12_ROOT_PARAMETER1> rectRootParams(1);
     rectRootParams[0].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_VOLATILE,
                                                D3D12_SHADER_VISIBILITY_VERTEX);
@@ -1961,7 +1985,7 @@ Gem::Result CRenderQueue12::DrawMesh(
         }
 
         // Build MaterialFlags. Texture flags are gated by mesh capability
-        // (no UV → no albedo/normal/emissive/PBR sampling; no tangent → no normal map).
+        // (no UV -> no albedo/normal/emissive/PBR sampling; no tangent -> no normal map).
         const bool hasUV      = (pUV0Buf  != nullptr);
         const bool hasTangent = (pTanBuf  != nullptr);
         const bool hasSkin    = (pBoneWBuf != nullptr) && (pBoneIBuf != nullptr) &&
@@ -1978,7 +2002,7 @@ Gem::Result CRenderQueue12::DrawMesh(
         if (hasUV && pTextures[5])               materialFlags |= MATERIAL_FLAG_HAS_AO_TEX;
 
         // Compute and upload bone matrices when skinning is active.
-        // Each matrix = InvBindPose[i] * boneNode[i].GetGlobalMatrix() — maps bind-pose
+        // Each matrix = InvBindPose[i] * boneNode[i].GetGlobalMatrix() - maps bind-pose
         // geometry space directly to world space for the current frame's bone pose.
         D3D12_GPU_VIRTUAL_ADDRESS boneMatricesGpuAddr = pPosBuf->GetD3DResource()->GetGPUVirtualAddress();
         if (hasSkin)
@@ -2029,10 +2053,7 @@ Gem::Result CRenderQueue12::DrawMesh(
         //                                    boneIndices, boneWeights)
         //   slots 13-14: UAV[2] @ u1, u2 (null)
         constexpr UINT kDescCount = 15;
-        if (m_NextSRVSlot + kDescCount > NumShaderResourceDescriptors)
-            m_NextSRVSlot = 0;
-        UINT baseSlot = m_NextSRVSlot;
-        m_NextSRVSlot += kDescCount;
+        UINT baseSlot = AllocateSRVSlots(kDescCount);
         
         const UINT incSize = m_CbvSrvUavIncrement;
         ID3D12Device *pD3DDevice = m_pDevice->GetD3DDevice();
@@ -2220,9 +2241,7 @@ Gem::Result CRenderQueue12::DrawUIText(
 
         ID3D12Device* pD3DDevice = m_pDevice->GetD3DDevice();
         const UINT incSize = m_CbvSrvUavIncrement;
-        if (m_NextSRVSlot + 1 > NumShaderResourceDescriptors)
-            m_NextSRVSlot = 0;
-        UINT srvSlot = m_NextSRVSlot++;
+        UINT srvSlot = AllocateSRVSlots(1);
 
         CD3DX12_CPU_DESCRIPTOR_HANDLE srvCpuHandle(m_pShaderResourceDescriptorHeap->GetCPUDescriptorHandleForHeapStart(), srvSlot, incSize);
         CD3DX12_GPU_DESCRIPTOR_HANDLE srvGpuHandle(m_pShaderResourceDescriptorHeap->GetGPUDescriptorHandleForHeapStart(), srvSlot, incSize);
@@ -2231,7 +2250,7 @@ Gem::Result CRenderQueue12::DrawUIText(
         D3D12_GPU_VIRTUAL_ADDRESS cbvAddr = hw.GpuAddress;
         D3D12_GPU_VIRTUAL_ADDRESS glyphAddr = pGlyphBuf->GetD3DResource()->GetGPUVirtualAddress() + glyphSRV.Offset;
 
-        // All resources ready — now create the GPU task
+        // All resources ready - now create the GPU task
         auto& drawTask = m_UIGpuTaskGraph.CreateTask("DrawUIText");
         m_UIGpuTaskGraph.DeclareTextureUsage(drawTask, pAtlas,
             D3D12_BARRIER_LAYOUT_SHADER_RESOURCE,
@@ -2344,7 +2363,7 @@ Gem::Result CRenderQueue12::DrawUIRect(
 
         D3D12_GPU_VIRTUAL_ADDRESS cbvAddr = hw.GpuAddress;
 
-        // All resources ready — now create the GPU task
+        // All resources ready - now create the GPU task
         auto& drawTask = m_UIGpuTaskGraph.CreateTask("DrawUIRect");
         m_UIGpuTaskGraph.DeclareTextureUsage(drawTask, pBackBuffer,
             D3D12_BARRIER_LAYOUT_RENDER_TARGET,
@@ -3019,7 +3038,7 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
             frameConstants.HasMoon = m_pMoonTexture ? 1u : 0u;
         }
 
-        // Add shadow-atlas global constants — composite needs the atlas
+        // Add shadow-atlas global constants - composite needs the atlas
         // size and texel step to do PCF.  These are 0 / 0 when no shadow
         // atlas was allocated this frame, which the composite treats as
         // "no shadows" and short-circuits the sample.
@@ -3145,7 +3164,7 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
         {
             EnsureDisplacedShadowPSO();
             // Re-create the atlas DSV every frame.  The DSV descriptor heap
-            // is round-robin (m_NextDSVSlot mod 64), and a cached handle
+            // is a fence-protected ring (m_DSVRing), and a cached handle
             // from a long-lived resource would eventually be overwritten by
             // a new DSV pointing to a different resource (m_pDepthBuffer in
             // particular) -- after that the shadow tasks would write the
@@ -3218,10 +3237,7 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
                     // tables index into the same block (t0 at base, CP
                     // streams at base+1..base+3).
                     constexpr UINT kShadowSRVCount = 4;
-                    if (m_NextSRVSlot + kShadowSRVCount > NumShaderResourceDescriptors)
-                        m_NextSRVSlot = 0u;
-                    const UINT baseSrvSlot = m_NextSRVSlot;
-                    m_NextSRVSlot += kShadowSRVCount;
+                    const UINT baseSrvSlot = AllocateSRVSlots(kShadowSRVCount);
                     {
                         ID3D12Resource* pRes = pMapSurf->GetD3DResource();
                         D3D12_RESOURCE_DESC desc = pRes->GetDesc();
@@ -3381,10 +3397,7 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
                 //   base+1..+3  -> t1..t3 atlases           (visibility PIXEL)
                 //   base+4..+6  -> t4..t6 pos / UV / normal (visibility VERTEX)
                 constexpr UINT kDisplacedSRVCount = 7;
-                if (m_NextSRVSlot + kDisplacedSRVCount > NumShaderResourceDescriptors)
-                    m_NextSRVSlot = 0;
-                UINT baseSrvSlot = m_NextSRVSlot;
-                m_NextSRVSlot += kDisplacedSRVCount;
+                UINT baseSrvSlot = AllocateSRVSlots(kDisplacedSRVCount);
 
                 CD3DX12_GPU_DESCRIPTOR_HANDLE mapGpu(
                     m_pShaderResourceDescriptorHeap->GetGPUDescriptorHandleForHeapStart(),
@@ -3501,10 +3514,7 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
             const UINT incSize = m_CbvSrvUavIncrement;
 
             constexpr UINT kCompositeSRVCount = 8;
-            if (m_NextSRVSlot + kCompositeSRVCount > NumShaderResourceDescriptors)
-                m_NextSRVSlot = 0;
-            UINT baseSlot = m_NextSRVSlot;
-            m_NextSRVSlot += kCompositeSRVCount;
+            UINT baseSlot = AllocateSRVSlots(kCompositeSRVCount);
 
             CD3DX12_CPU_DESCRIPTOR_HANDLE baseCpuHandle(m_pShaderResourceDescriptorHeap->GetCPUDescriptorHandleForHeapStart(), baseSlot, incSize);
             CD3DX12_GPU_DESCRIPTOR_HANDLE baseGpuHandle(m_pShaderResourceDescriptorHeap->GetGPUDescriptorHandleForHeapStart(), baseSlot, incSize);
@@ -3680,10 +3690,10 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
             m_GpuTaskGraph.InsertTask(compositeTask);
         }
 
-        // Flush pending glyph atlas uploads (SDF bitmaps → GPU texture)
+        // Flush pending glyph atlas uploads (SDF bitmaps -> GPU texture)
         FlushPendingGlyphUploads();
 
-        // Draw UI elements (pure draw — uploads already staged by SubmitRenderables)
+        // Draw UI elements (pure draw - uploads already staged by SubmitRenderables)
         for (auto* pNode : m_UIRenderableQueue)
         {
             UINT elemCount = pNode->GetBoundElementCount();
@@ -3774,3 +3784,4 @@ GEMMETHODIMP CRenderQueue12::EndFrame()
     m_HasVisibleLightFilter = false;
     return Gem::Result::Success;
 }
+

--- a/src/CanvasGfx12/Lib/RenderQueue12.h
+++ b/src/CanvasGfx12/Lib/RenderQueue12.h
@@ -10,6 +10,7 @@
 #include "CommandAllocatorPool.h"
 #include "ResourceManager.h"
 #include "UploadRing.h"
+#include "DescriptorRing.h"
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -522,7 +523,6 @@ public:
     Gem::TGemPtr<CSurface12> m_pDepthBuffer;
     UINT m_DepthBufferWidth = 0;
     UINT m_DepthBufferHeight = 0;
-    UINT m_NextDSVSlot = 0;
 
     // Shadow atlas.  One engine-internal R32_TYPELESS surface shared by
     // every shadow-casting directional light this frame.  Sub-allocated
@@ -682,15 +682,21 @@ public:
     // UI graph nodes enqueued during UI graph submission, dispatched during EndFrame
     std::vector<Canvas::XUIGraphNode*> m_UIRenderableQueue;
 
-    // SRV descriptor allocation for per-draw structured buffers
-    UINT m_NextSRVSlot = 0;
-
-    static const UINT NumShaderResourceDescriptors = 65536;
+    // The shader-visible CBV/SRV/UAV heap is device-owned (CDevice12) and shared across
+    // queues; its size and partitioning live there.  RTV/DSV heaps remain per-queue.
     static const UINT NumSamplerDescriptors = 1024;
     static const UINT NumRTVDescriptors = 64;
     static const UINT NumDSVDescriptors = 64;
 
-    UINT m_NextRTVSlot = 0;
+    // Fence-protected ring allocators.  Each hands out contiguous slot runs and refuses to
+    // reuse a slot until the GPU work that referenced it has retired, so wrap-around can no
+    // longer overwrite a descriptor still in flight.  Advanced one submission per frame
+    // (MarkSubmissionEnd in Flush, Reclaim in ProcessCompletedWork), mirroring m_UploadRing.
+    // m_RTVRing / m_DSVRing manage their whole per-queue heaps; m_SRVRing manages only the
+    // transient upper partition of the shared device heap.
+    CDescriptorRing m_RTVRing;
+    CDescriptorRing m_DSVRing;
+    CDescriptorRing m_SRVRing;
 
     UINT m_CbvSrvUavIncrement = 0;
     UINT m_SamplerIncrement   = 0;
@@ -760,6 +766,13 @@ public:
 
     D3D12_CPU_DESCRIPTOR_HANDLE CreateRenderTargetView(class CSurface12 *pSurface, UINT ArraySlice, UINT MipSlice, UINT PlaneSlice);
     D3D12_CPU_DESCRIPTOR_HANDLE CreateDepthStencilView(class CSurface12 *pSurface);
+
+    // Reserve a contiguous run of slots from a descriptor ring, blocking on this queue's
+    // fence (and reclaiming completed submissions) when a slot still referenced by in-flight
+    // GPU work would otherwise be overwritten.  Return the base slot index.
+    UINT AllocateRTVSlots(UINT count) { return m_RTVRing.Allocate(count, [this](UINT64 fv) { WaitForGpuFence(fv); }); }
+    UINT AllocateDSVSlots(UINT count) { return m_DSVRing.Allocate(count, [this](UINT64 fv) { WaitForGpuFence(fv); }); }
+    UINT AllocateSRVSlots(UINT count) { return m_SRVRing.Allocate(count, [this](UINT64 fv) { WaitForGpuFence(fv); }); }
     
     // Create or resize the depth buffer to match the given dimensions
     void EnsureDepthBuffer(UINT width, UINT height);

--- a/src/CanvasGfx12/Lib/UITextElement12.cpp
+++ b/src/CanvasGfx12/Lib/UITextElement12.cpp
@@ -4,6 +4,8 @@
 
 #include "pch.h"
 #include "UITextElement12.h"
+#include "Device12.h"
+#include "RenderQueue12.h"
 
 //------------------------------------------------------------------------------------------------
 void CUITextElement12::SetText(PCSTR utf8Text)
@@ -15,7 +17,7 @@ void CUITextElement12::SetText(PCSTR utf8Text)
         return;
 
     m_Text = utf8Text;
-    m_Dirty = true;
+    m_GlyphState = GlyphState::RegeneratePending;
 }
 
 //------------------------------------------------------------------------------------------------
@@ -25,7 +27,7 @@ void CUITextElement12::SetFont(Canvas::XFont* pFont)
         return;
 
     m_pFont = pFont;
-    m_Dirty = true;
+    m_GlyphState = GlyphState::RegeneratePending;
 }
 
 //------------------------------------------------------------------------------------------------
@@ -38,7 +40,7 @@ void CUITextElement12::SetLayoutConfig(const Canvas::TextLayoutConfig& config)
     m_Config = config;
 
     if (geometryChanged)
-        m_Dirty = true;
+        m_GlyphState = GlyphState::RegeneratePending;
 }
 
 //------------------------------------------------------------------------------------------------
@@ -51,7 +53,7 @@ GEMMETHODIMP CUITextElement12::Detach()
 //------------------------------------------------------------------------------------------------
 GEMMETHODIMP CUITextElement12::Update()
 {
-    if (!m_Dirty)
+    if (m_GlyphState != GlyphState::RegeneratePending)
         return Gem::Result::Success;
 
     return RegenerateGlyphs();
@@ -61,7 +63,7 @@ GEMMETHODIMP CUITextElement12::Update()
 Gem::Result CUITextElement12::RegenerateGlyphs()
 {
     m_CachedGlyphs.clear();
-    m_Dirty = false;
+    m_GlyphState = GlyphState::UploadPending;
 
     if (m_Text.empty())
         return Gem::Result::Success;
@@ -134,4 +136,16 @@ Gem::Result CUITextElement12::RegenerateGlyphs()
     }
 
     return Gem::Result::Success;
+}
+
+//------------------------------------------------------------------------------------------------
+void CUITextElement12::EnsureGlyphBufferUploaded(CDevice12 *pDevice, CRenderQueue12 *pRQ)
+{
+    if (m_GlyphState == GlyphState::UploadPending)
+    {
+        Gem::ThrowGemError(pDevice->AllocateStructuredBuffer(
+            GetGlyphCount(), sizeof(HlslTypes::HlslGlyphInstance),
+            GetGlyphData(), pRQ, m_GlyphSRV));
+        m_GlyphState = GlyphState::Ready;
+    }
 }

--- a/src/CanvasGfx12/Lib/UITextElement12.h
+++ b/src/CanvasGfx12/Lib/UITextElement12.h
@@ -17,6 +17,9 @@
 
 using GlyphInstance = HlslTypes::HlslGlyphInstance;
 
+class CDevice12;
+class CRenderQueue12;
+
 class CUITextElement12 : public TGfxElement<Canvas::XUITextElement>
 {
     // Content
@@ -31,7 +34,15 @@ class CUITextElement12 : public TGfxElement<Canvas::XUITextElement>
     Canvas::Math::FloatVector2 m_LocalOffset = {};
     Canvas::GfxResourceAllocation m_GlyphSRV;
     bool m_Visible = true;
-    bool m_Dirty = true;
+
+    enum class GlyphState
+    {
+        Ready,
+        RegeneratePending,
+        UploadPending,
+    };
+
+    GlyphState m_GlyphState = GlyphState::Ready;
 
 public:
     BEGIN_GEM_INTERFACE_MAP()
@@ -74,7 +85,8 @@ public:
     uint32_t GetGlyphCount() const { return static_cast<uint32_t>(m_CachedGlyphs.size()); }
     const void* GetGlyphData() const { return m_CachedGlyphs.data(); }
     const Canvas::GfxResourceAllocation& GetGlyphBuffer() const { return m_GlyphSRV; }
-    void SetGlyphBuffer(const Canvas::GfxResourceAllocation& buffer) { m_GlyphSRV = buffer; }
+
+    void EnsureGlyphBufferUploaded(CDevice12 *pDevice, CRenderQueue12 *pRQ);
 
 private:
     Gem::Result RegenerateGlyphs();

--- a/src/CanvasGfx12/README.md
+++ b/src/CanvasGfx12/README.md
@@ -350,18 +350,35 @@ The split into three graphs is a design choice, not a correctness requirement. E
 
 ### Descriptor Heap Management
 
-Four descriptor heaps are created at initialization:
+The shader-visible **CBV/SRV/UAV heap is owned by the device** (`CDevice12`) and shared across all render queues, so per-resource descriptors have a single stable home that any queue can bind. The sampler, RTV, and DSV heaps remain per-render-queue.
 
-| Heap | Type | Count | Visibility |
+| Heap | Type | Count | Visibility | Owner |
+|---|---|---|---|---|
+| CBV/SRV/UAV | Shader resource | 65,536 | Shader-visible | Device (shared) |
+| Sampler | Sampler | 1,024 | Shader-visible | Render queue |
+| RTV | Render target view | 64 | CPU-only | Render queue |
+| DSV | Depth stencil view | 64 | CPU-only | Render queue |
+
+#### Shared CBV/SRV/UAV heap partitioning
+
+The shared heap is split into two regions managed by different allocators:
+
+| Region | Slots | Allocator | Lifetime |
 |---|---|---|---|
-| CBV/SRV/UAV | Shader resource | 65,536 | Shader-visible |
-| Sampler | Sampler | 1,024 | Shader-visible |
-| RTV | Render target view | 64 | CPU-only |
-| DSV | Depth stencil view | 64 | CPU-only |
+| Persistent | `[0, 32768)` | `CDescriptorHeapAllocator` (free-list) | Per-resource — freed when the resource is destroyed |
+| Transient | `[32768, 65536)` | `CDescriptorRing` (per queue) | Per-frame — recycled once the GPU retires the frame |
 
-The shader-visible heap is used as a cycling allocator: `m_NextSRVSlot` advances with each draw and wraps at 65,536. Each mesh draw allocates 13 contiguous descriptors: 2 CBVs, 9 SRVs, and 2 UAVs. RTV and DSV slots wrap at 64.
+The split is a tunable constant (`CDevice12::kNumPersistentSrvDescriptors`).
 
-The cycling allocator does not check for overflow within a single frame. If a frame exceeds roughly 5,000 mesh draws the slot counter wraps and overwrites descriptors from earlier in the same frame. In practice this has not been an issue at current scene complexity, but it is a known limitation. A future improvement could add a per-frame high-water-mark check or switch to a more robust ring allocator.
+**Persistent region** (`CDescriptorHeapAllocator`): size-segregated free lists (one per block size) plus a bump pointer, giving O(1) allocate/free with exact-fit reuse and no rounding waste. It hands out contiguous slot runs which live until explicitly freed, and is the home for descriptors that are created once and bound by GPU handle every draw — vertex-stream and material-texture SRVs that scale with the number of *live resources*, not draw calls.
+
+**Transient region** (`CDescriptorRing`): a fence-protected ring for dynamic per-draw / per-frame descriptors. Slots are handed out as contiguous runs and advance through the region as a ring; a slot is not reused until the GPU work that referenced it has retired. The ring records a per-submission `{fenceValue, slotCount}` marker each frame (`MarkSubmissionEnd` in `Flush`) and releases completed submissions in `ProcessCompletedWork` (`Reclaim`), mirroring `CUploadRing`. The RTV and DSV heaps are each managed by their own `CDescriptorRing` over the whole per-queue heap (base slot 0); the SRV ring is given a base offset so it manages only the transient partition of the shared heap.
+
+When wrap-around would overwrite a slot still referenced by in-flight GPU work, the ring blocks on this queue's fence and reclaims completed submissions before reusing those slots, so a descriptor in flight can never be overwritten. Because a descriptor heap cannot be resized, a single frame that demands more transient slots than the partition holds cannot be satisfied and raises `OutOfMemory` rather than silently corrupting in-flight descriptors.
+
+The transient partition is owned by a **single render queue**, claimed via `CDevice12::AcquireTransientSrvRange` when the queue is created and released at teardown. A GPU has one rendering engine, so there is never a second render queue in practice; creating one on the same device fails fast (`Gem::Result::Unavailable`) rather than letting two rings hand out overlapping slots. Future compute queues (physics, work graphs) are expected to address resources through the persistent region or root descriptors, not this transient ring — sharing it could let a long-running compute submission stall rendering or create a render/compute fence lock inversion.
+
+> Migration in progress: per-resource residency (moving mesh vertex-stream and material-texture SRVs into the persistent region, and the per-object constant buffer to a root CBV) is being wired up. Until it lands, the geometry path still allocates its per-draw descriptor table from the transient ring, so the transient `OutOfMemory` ceiling above still bounds draws per frame. Persistent residency removes that ceiling because geometry stops consuming transient slots entirely.
 
 ### Root Signatures and Pipeline States
 

--- a/src/CanvasLightGarden/CanvasLightGarden.cpp
+++ b/src/CanvasLightGarden/CanvasLightGarden.cpp
@@ -527,6 +527,7 @@ class CApp
     GardenConfig m_GardenConfig;
     int m_exitFrameCount;
     bool m_startFullscreen;
+    Canvas::GfxDebugSeverity m_gfxDebugSeverity = Canvas::GfxDebugSeverity::Warning;
     bool m_cameraActive = true;
     int m_lastClientW = 0, m_lastClientH = 0;
 
@@ -539,10 +540,12 @@ public:
     CApp(HINSTANCE hInstance, PCSTR title,
          Gem::TGemPtr<Canvas::XLogger> pLogger,
          const GardenConfig& gardenConfig,
-         int exitFrameCount, bool fullscreen)
+         int exitFrameCount, bool fullscreen,
+         Canvas::GfxDebugSeverity gfxDebugSeverity = Canvas::GfxDebugSeverity::Warning)
         : m_Title(title), m_hInstance(hInstance), m_pLogger(std::move(pLogger)),
           m_GardenConfig(gardenConfig),
-          m_exitFrameCount(exitFrameCount), m_startFullscreen(fullscreen) {}
+          m_exitFrameCount(exitFrameCount), m_startFullscreen(fullscreen),
+          m_gfxDebugSeverity(gfxDebugSeverity) {}
 
     bool Initialize(int nCmdShow)
     {
@@ -571,6 +574,10 @@ public:
                 m_pCanvas, Canvas::TypeId::TypeId_GfxDevice,
                 "MainDevice", Canvas::XGfxDevice::IId,
                 reinterpret_cast<void**>(&m_pDevice)));
+
+            // Cap graphics debug-layer verbosity per the --gfx-max-sev option
+            // (no-op in release builds / on backends without a debug layer).
+            m_pDevice->SetDebugMessageSeverity(m_gfxDebugSeverity);
 
             step = "create_scene";
             Gem::ThrowGemError(m_pCanvas->CreateScene(m_pDevice, &m_pScene, "LightGarden"));
@@ -884,6 +891,7 @@ int APIENTRY WinMain(_In_ HINSTANCE hInstance,
     bool fullscreen = false;
     bool logConsole = false;
     std::string logLevel = "warn";
+    std::string gfxMaxSev = "warning";
 
     try
     {
@@ -910,6 +918,10 @@ int APIENTRY WinMain(_In_ HINSTANCE hInstance,
         logCmd.AddOption(InCommand::OptionType::Variable, "level", 'l')
             .SetDomain({"trace","debug","info","warn","error","critical","off"}).BindTo(logLevel);
         logCmd.AddOption(InCommand::OptionType::Switch, "console", 'c').BindTo(logConsole);
+        logCmd.AddOption(InCommand::OptionType::Variable, "gfx-max-sev")
+            .SetDescription("Cap graphics debug-layer verbosity, independent of the Canvas log level (debug builds only)")
+            .SetDomain({"off", "corruption", "error", "warning", "info", "verbose"})
+            .BindTo(gfxMaxSev);
 
         std::ostringstream helpStream;
         parser.EnableAutoHelp("help", 'h', helpStream);
@@ -949,6 +961,14 @@ int APIENTRY WinMain(_In_ HINSTANCE hInstance,
     else if (logLevel == "critical") qlogLevel = QLog::Level::Critical;
     else if (logLevel == "off")      qlogLevel = QLog::Level::Off;
 
+    Canvas::GfxDebugSeverity gfxDebugSeverity = Canvas::GfxDebugSeverity::Warning;
+    if      (gfxMaxSev == "off")        gfxDebugSeverity = Canvas::GfxDebugSeverity::Off;
+    else if (gfxMaxSev == "corruption") gfxDebugSeverity = Canvas::GfxDebugSeverity::Corruption;
+    else if (gfxMaxSev == "error")      gfxDebugSeverity = Canvas::GfxDebugSeverity::Error;
+    else if (gfxMaxSev == "warning")    gfxDebugSeverity = Canvas::GfxDebugSeverity::Warning;
+    else if (gfxMaxSev == "info")       gfxDebugSeverity = Canvas::GfxDebugSeverity::Info;
+    else if (gfxMaxSev == "verbose")    gfxDebugSeverity = Canvas::GfxDebugSeverity::Verbose;
+
     wchar_t exeBuf[MAX_PATH] = {};
     GetModuleFileNameW(nullptr, exeBuf, MAX_PATH);
     auto now = std::chrono::system_clock::now();
@@ -976,7 +996,7 @@ int APIENTRY WinMain(_In_ HINSTANCE hInstance,
     int result = 0;
     {
         CApp app(hInstance, "CanvasLightGarden",
-                 pLogger, gardenConfig, exitFrameCount, fullscreen);
+                 pLogger, gardenConfig, exitFrameCount, fullscreen, gfxDebugSeverity);
         if (!app.Initialize(nCmdShow))
         {
             MessageBoxA(nullptr, "Initialization failed; see log for details.",

--- a/src/CanvasModelViewer/CanvasModelViewer.cpp
+++ b/src/CanvasModelViewer/CanvasModelViewer.cpp
@@ -192,6 +192,7 @@ class CApp
     int m_exitFrameCount;  // -1 means don't exit automatically; >= 0 means exit after N frames
     bool m_logFps;
     bool m_startFullscreen = false;
+    Canvas::GfxDebugSeverity m_gfxDebugSeverity = Canvas::GfxDebugSeverity::Warning;
     bool m_cameraActive = true;   // true: cursor hidden + camera control; false: cursor free
     std::string m_modeString;
     float m_fps = 0.0f;
@@ -587,13 +588,15 @@ public:
         int exitFrameCount = -1,
         bool logFps = false,
         std::filesystem::path modelPath = {},
-        bool startFullscreen = false) :
+        bool startFullscreen = false,
+        Canvas::GfxDebugSeverity gfxDebugSeverity = Canvas::GfxDebugSeverity::Warning) :
         m_pLogger(pLogger),
         m_Title(szTitle),
         m_hInstance(hInstance),
         m_exitFrameCount(exitFrameCount),
         m_logFps(logFps),
         m_startFullscreen(startFullscreen),
+        m_gfxDebugSeverity(gfxDebugSeverity),
         m_ModelPath(std::move(modelPath))
         {
         }
@@ -644,6 +647,10 @@ public:
                 "MainDevice",
                 Canvas::XGfxDevice::IId,
                 (void**)&pDevice));
+
+            // Cap graphics debug-layer verbosity per the --gfx-max-sev option
+            // (no-op in release builds / on backends without a debug layer).
+            pDevice->SetDebugMessageSeverity(m_gfxDebugSeverity);
 
             initStep = "create_scene";
             Gem::TGemPtr<Canvas::XScene> pScene;
@@ -1130,6 +1137,7 @@ int APIENTRY WinMain(_In_ HINSTANCE hInstance,
     std::string logFile;
     bool logConsole = false;
     bool logFps = false;
+    std::string gfxMaxSev = "warning";
     std::string fbxPath;
     int exitFrameCount = -1;  // -1 means don't exit automatically
     bool fullscreen = false;
@@ -1174,6 +1182,11 @@ int APIENTRY WinMain(_In_ HINSTANCE hInstance,
         logCmd.AddOption(InCommand::OptionType::Switch, "fps")
             .SetDescription("Log FPS to the log output")
             .BindTo(logFps);
+
+        logCmd.AddOption(InCommand::OptionType::Variable, "gfx-max-sev")
+            .SetDescription("Cap graphics debug-layer verbosity, independent of the Canvas log level (debug builds only)")
+            .SetDomain({"off", "corruption", "error", "warning", "info", "verbose"})
+            .BindTo(gfxMaxSev);
 
         // Capture help text to a stream - no console is attached to write to directly
         std::ostringstream helpStream;
@@ -1234,6 +1247,21 @@ int APIENTRY WinMain(_In_ HINSTANCE hInstance,
     else if (logLevel == "off")
         qlogLevel = QLog::Level::Off;
 
+    // Map the graphics debug-layer verbosity cap to the engine enum.
+    Canvas::GfxDebugSeverity gfxDebugSeverity = Canvas::GfxDebugSeverity::Warning;
+    if (gfxMaxSev == "off")
+        gfxDebugSeverity = Canvas::GfxDebugSeverity::Off;
+    else if (gfxMaxSev == "corruption")
+        gfxDebugSeverity = Canvas::GfxDebugSeverity::Corruption;
+    else if (gfxMaxSev == "error")
+        gfxDebugSeverity = Canvas::GfxDebugSeverity::Error;
+    else if (gfxMaxSev == "warning")
+        gfxDebugSeverity = Canvas::GfxDebugSeverity::Warning;
+    else if (gfxMaxSev == "info")
+        gfxDebugSeverity = Canvas::GfxDebugSeverity::Info;
+    else if (gfxMaxSev == "verbose")
+        gfxDebugSeverity = Canvas::GfxDebugSeverity::Verbose;
+
     // Determine log file path - default to a timestamped file next to the executable
     wchar_t exePathBuf[MAX_PATH] = {};
     GetModuleFileNameW(nullptr, exePathBuf, MAX_PATH);
@@ -1285,7 +1313,7 @@ int APIENTRY WinMain(_In_ HINSTANCE hInstance,
     if (!fbxPath.empty())
         modelPath = std::filesystem::u8path(fbxPath);
 
-    std::unique_ptr<CApp> pApp(std::make_unique<CApp>(hInstance, szTitle, pLogger, exitFrameCount, logFps, modelPath, fullscreen));
+    std::unique_ptr<CApp> pApp(std::make_unique<CApp>(hInstance, szTitle, pLogger, exitFrameCount, logFps, modelPath, fullscreen, gfxDebugSeverity));
 
     // Initialize the application
     if (!pApp->Initialize(nCmdShow))

--- a/src/CanvasTerrainViewer/CanvasTerrainViewer.cpp
+++ b/src/CanvasTerrainViewer/CanvasTerrainViewer.cpp
@@ -374,6 +374,7 @@ class CTerrainApp
     int               m_exitFrameCount;
     bool              m_logFps;
     bool              m_startFullscreen = false;
+    Canvas::GfxDebugSeverity m_gfxDebugSeverity = Canvas::GfxDebugSeverity::Warning;
     bool              m_cameraActive = true;   // ACTIVE: cursor hidden + camera control; FREE: cursor visible
     std::string       m_modeString;
     int               m_lastClientW = 0;
@@ -852,13 +853,15 @@ public:
         bool      logFps,
         Canvas::TerrainViewer::SceneConfig scene,
         float     cycleSeconds,
-        bool      startFullscreen = false)
+        bool      startFullscreen = false,
+        Canvas::GfxDebugSeverity gfxDebugSeverity = Canvas::GfxDebugSeverity::Warning)
         : m_Title(szTitle)
         , m_hInstance(hInstance)
         , m_pLogger(pLogger)
         , m_exitFrameCount(exitFrameCount)
         , m_logFps(logFps)
         , m_startFullscreen(startFullscreen)
+        , m_gfxDebugSeverity(gfxDebugSeverity)
         , m_SceneConfig(std::move(scene))
         , m_CycleSeconds(cycleSeconds)
     {
@@ -901,6 +904,10 @@ public:
                 pCanvas, Canvas::TypeId::TypeId_GfxDevice,
                 "TerrainDevice", Canvas::XGfxDevice::IId,
                 reinterpret_cast<void**>(&pDevice)));
+
+            // Cap graphics debug-layer verbosity per the --gfx-max-sev option
+            // (no-op in release builds / on backends without a debug layer).
+            pDevice->SetDebugMessageSeverity(m_gfxDebugSeverity);
 
             initStep = "create_scene";
             Gem::TGemPtr<Canvas::XScene> pScene;
@@ -1274,6 +1281,7 @@ int APIENTRY WinMain(_In_ HINSTANCE hInstance,
     std::string logFile;
     bool        logConsole = false;
     bool        logFps     = false;
+    std::string gfxMaxSev  = "warning";
     std::string scenePath;
     std::string heightmapPath;
     std::string atlasAlbedoPath;
@@ -1344,6 +1352,10 @@ int APIENTRY WinMain(_In_ HINSTANCE hInstance,
         logCmd.AddOption(InCommand::OptionType::Switch, "fps")
             .SetDescription("Log FPS to log output")
             .BindTo(logFps);
+        logCmd.AddOption(InCommand::OptionType::Variable, "gfx-max-sev")
+            .SetDescription("Cap graphics debug-layer verbosity, independent of the Canvas log level (debug builds only)")
+            .SetDomain({"off", "corruption", "error", "warning", "info", "verbose"})
+            .BindTo(gfxMaxSev);
 
         std::ostringstream helpStream;
         cmdParser.EnableAutoHelp("help", 'h', helpStream);
@@ -1388,6 +1400,14 @@ int APIENTRY WinMain(_In_ HINSTANCE hInstance,
     else if (logLevel == "error")    qlogLevel = QLog::Level::Error;
     else if (logLevel == "critical") qlogLevel = QLog::Level::Critical;
     else if (logLevel == "off")      qlogLevel = QLog::Level::Off;
+
+    Canvas::GfxDebugSeverity gfxDebugSeverity = Canvas::GfxDebugSeverity::Warning;
+    if      (gfxMaxSev == "off")        gfxDebugSeverity = Canvas::GfxDebugSeverity::Off;
+    else if (gfxMaxSev == "corruption") gfxDebugSeverity = Canvas::GfxDebugSeverity::Corruption;
+    else if (gfxMaxSev == "error")      gfxDebugSeverity = Canvas::GfxDebugSeverity::Error;
+    else if (gfxMaxSev == "warning")    gfxDebugSeverity = Canvas::GfxDebugSeverity::Warning;
+    else if (gfxMaxSev == "info")       gfxDebugSeverity = Canvas::GfxDebugSeverity::Info;
+    else if (gfxMaxSev == "verbose")    gfxDebugSeverity = Canvas::GfxDebugSeverity::Verbose;
 
     wchar_t exePathBuf[MAX_PATH] = {};
     GetModuleFileNameW(nullptr, exePathBuf, MAX_PATH);
@@ -1482,7 +1502,7 @@ int APIENTRY WinMain(_In_ HINSTANCE hInstance,
     auto pApp = std::make_unique<CTerrainApp>(
         hInstance, "CanvasTerrainViewer", pLogger,
         exitFrameCount, logFps,
-        std::move(scene), cycleSeconds, fullscreen);
+        std::move(scene), cycleSeconds, fullscreen, gfxDebugSeverity);
 
     if (!pApp->Initialize(nCmdShow))
     {

--- a/src/Inc/CanvasGfx.h
+++ b/src/Inc/CanvasGfx.h
@@ -511,6 +511,23 @@ namespace Canvas
     };
 
     //------------------------------------------------------------------------------------------------
+    // Verbosity threshold for a backend's debug / validation layer, ordered from
+    // least to most verbose.  A given level reports messages of that severity and
+    // all more-severe ones; e.g. Warning reports Warning/Error/Corruption and
+    // suppresses Info/Verbose.  This is independent of the Canvas log level - it
+    // caps how much the underlying graphics debug layer emits in the first place.
+    // Backends without a debug layer treat SetDebugMessageSeverity as a no-op.
+    enum class GfxDebugSeverity
+    {
+        Off,         // suppress all debug-layer messages
+        Corruption,  // report corruption only (most severe)
+        Error,       // report error and above
+        Warning,     // report warning and above (default)
+        Info,        // report info and above
+        Verbose,     // report everything the debug layer emits
+    };
+
+    //------------------------------------------------------------------------------------------------
     // Interface to a graphics device
     struct XGfxDevice : public XCanvasElement
     {
@@ -586,6 +603,12 @@ namespace Canvas
         // UI element creation (device wires GPU resources internally)
         GEMMETHOD(CreateTextElement)(XUITextElement **ppElement) = 0;
         GEMMETHOD(CreateRectElement)(XUIRectElement **ppElement) = 0;
+
+        // Cap the verbosity of the backend's debug / validation layer (see
+        // GfxDebugSeverity).  Best-effort: a no-op on backends with no debug
+        // layer or in builds where one is not active.  May be called any time
+        // after device creation.
+        GEMMETHOD_(void, SetDebugMessageSeverity)(GfxDebugSeverity maxSeverity) = 0;
     };
 }
 


### PR DESCRIPTION
This pull request introduces a new system for managing Direct3D 12 descriptor heaps, splitting responsibilities between persistent and transient allocations. It adds two new allocator classes—`CDescriptorHeapAllocator` for persistent, per-resource descriptors, and `CDescriptorRing` for transient, per-frame allocations—along with their integration into the device and queue initialization code. Additionally, it improves command list management in the copy queue and makes minor adjustments to debug message handling.

**Descriptor Heap Management System:**

* Introduced `CDescriptorHeapAllocator` for persistent allocation and freeing of descriptor heap slots, designed for per-resource descriptors that must persist for the resource's lifetime. [[1]](diffhunk://#diff-0c8d970a8e9b488c66799dcde3db09ccd6b38b967ad9f5a0286fd2f0f50c95fbR1-R60) [[2]](diffhunk://#diff-5c48483ff99ccfe8fe34261655db28ad8e1b83aa0027799f821644be1ceedbecR1-R54) [[3]](diffhunk://#diff-29a77f9b74d3a2c2668c8a9244429f9ee38a81ac73a77ca12b69ad880f536bbdR9-R10)
* Added `CDescriptorRing`, a ring-buffer allocator for transient, per-frame descriptor allocations, with logic for safe reuse of slots only after GPU work completes. [[1]](diffhunk://#diff-a862e8f2df96102413ff455fd94afc70d9e980d92f1b0a9ceaad7db5da3c0840R1-R90) [[2]](diffhunk://#diff-b7a09202dc4ae475a7f37668c3ad5ab803a8cc8aa280413fae56b3bd48b4d0bdR1-R133) [[3]](diffhunk://#diff-29a77f9b74d3a2c2668c8a9244429f9ee38a81ac73a77ca12b69ad880f536bbdR9-R10)
* Integrated the new descriptor heap system into device initialization (`CDevice12::InitializeDescriptorHeap`), partitioning the heap into persistent and transient regions, and providing utility methods for descriptor handle access and SRV writing.

**Copy Queue Improvements:**

* Changed the copy queue to create and reuse a single command list, resetting it each flush instead of creating a new one every time, improving performance and resource usage. [[1]](diffhunk://#diff-db2bb6401d902dbd53c1b5b0d3f38a86e35ee925b72000c341490a0b13ce0a42R33-R36) [[2]](diffhunk://#diff-db2bb6401d902dbd53c1b5b0d3f38a86e35ee925b72000c341490a0b13ce0a42L151-R157) [[3]](diffhunk://#diff-8b9783cc2940a8483fd5fbc87f074499dae70cc460eb493d72957a561c58340dR113) [[4]](diffhunk://#diff-db2bb6401d902dbd53c1b5b0d3f38a86e35ee925b72000c341490a0b13ce0a42R62)

**Debug and Miscellaneous:**

* Adjusted debug message callback registration to use the correct flag and set the default message severity to "warning and above".

These changes collectively improve descriptor management efficiency, safety, and performance, and lay the groundwork for more robust resource binding in the rendering pipeline.