### PR TITLE
Ascii cleanup and minor bug fixes

### DIFF
--- a/src/CanvasCore/Animation.cpp
+++ b/src/CanvasCore/Animation.cpp
@@ -12,7 +12,7 @@ namespace Canvas
 {
 
 //================================================================================================
-// CAnimationController — helpers
+// CAnimationController - helpers
 //================================================================================================
 
 // Spherical-linear interpolation between two unit quaternions.
@@ -178,7 +178,7 @@ void CAnimationController::BuildFromModel(
     m_BoundClips.clear();
     m_BindPose.clear();
 
-    // Build a name→cloned-node lookup from cloneMap
+    // Build a name->cloned-node lookup from cloneMap
     std::unordered_map<std::string, XSceneGraphNode*> nodeByName;
     for (const auto& kv : cloneMap)
     {
@@ -190,7 +190,7 @@ void CAnimationController::BuildFromModel(
         }
     }
 
-    // Bind pose snapshot — collect all uniquely animated nodes first
+    // Bind pose snapshot - collect all uniquely animated nodes first
     std::unordered_map<XSceneGraphNode*, bool> seenForBindPose;
 
     for (const CAnimationClip& def : clipDefs)
@@ -326,7 +326,7 @@ GEMMETHODIMP_(void) CAnimationController::ResetToBindPose()
 }
 
 //================================================================================================
-// Update — called each frame by CSceneGraphNode::Update
+// Update - called each frame by CSceneGraphNode::Update
 //================================================================================================
 
 GEMMETHODIMP CAnimationController::Update(float dtime)
@@ -372,3 +372,4 @@ GEMMETHODIMP CAnimationController::Update(float dtime)
 }
 
 } // namespace Canvas
+

--- a/src/CanvasCore/Animation.h
+++ b/src/CanvasCore/Animation.h
@@ -1,5 +1,5 @@
 //================================================================================================
-// Animation — runtime clip storage and per-instance animation controller
+// Animation - runtime clip storage and per-instance animation controller
 //
 // CAnimationClip   : immutable, shared clip data stored on CModel (one per FBX AnimationStack
 //                    / Blender Action).  All instances of a model share the same clip data.
@@ -24,7 +24,7 @@ namespace Canvas
 {
 
 //================================================================================================
-// CAnimationClip — immutable clip data (shared across instances)
+// CAnimationClip - immutable clip data (shared across instances)
 //================================================================================================
 
 struct AnimNodeTrack
@@ -41,7 +41,7 @@ struct CAnimationClip
 };
 
 //================================================================================================
-// CAnimationController — per-instance evaluator
+// CAnimationController - per-instance evaluator
 //================================================================================================
 
 class CAnimationController :
@@ -186,3 +186,4 @@ public:
 };
 
 } // namespace Canvas
+

--- a/src/CanvasCore/Model.cpp
+++ b/src/CanvasCore/Model.cpp
@@ -132,7 +132,7 @@ GEMMETHODIMP CModel::Instantiate(XSceneGraphNode *pTargetParent, ModelInstantiat
             Gem::ThrowGemError(m_pCanvas->CreateSceneGraphNode(&pInstanceRoot, instanceName.c_str()));
         }
 
-        // Map from model node → cloned node (for parent-child wiring and active camera lookup)
+        // Map from model node -> cloned node (for parent-child wiring and active camera lookup)
         std::unordered_map<XSceneGraphNode *, Gem::TGemPtr<XSceneGraphNode>> cloneMap;
 
         // Cloned camera that corresponds to the active camera node (if any)
@@ -245,7 +245,7 @@ GEMMETHODIMP CModel::Instantiate(XSceneGraphNode *pTargetParent, ModelInstantiat
                     continue;
                 }
 
-                // Unknown element type — warn and skip
+                // Unknown element type - warn and skip
                 Canvas::LogWarn(m_pCanvas->GetLogger(),
                     "XModel::Instantiate: unsupported element type '%s' on node '%s'; skipping",
                     pElement->GetTypeName(),
@@ -380,3 +380,4 @@ GEMMETHODIMP CModel::AddMeshSkin(const MeshSkinDesc *pDesc)
 }
 
 }
+

--- a/src/CanvasCore/Model.h
+++ b/src/CanvasCore/Model.h
@@ -19,7 +19,7 @@ class CModel :
     Gem::TGemPtr<XGfxDevice> m_pDevice;
     Gem::TGemPtr<XSceneGraphNode> m_pRoot;
 
-    // Shared GPU resource libraries — kept alive by the model,
+    // Shared GPU resource libraries - kept alive by the model,
     // shared across all instantiated copies.
     std::vector<Gem::TGemPtr<XGfxMeshData>> m_MeshData;
     std::vector<Gem::TGemPtr<XGfxMaterial>> m_Materials;
@@ -102,7 +102,7 @@ public: // XModel methods
 
     GEMMETHOD(AddTexture)(XGfxSurface *pTexture) final;
 
-    // Active camera node — must be a node within this model's hierarchy.
+    // Active camera node - must be a node within this model's hierarchy.
     // Passing a node that is not a descendant of GetRootNode() is
     // undefined; a debug assertion guards against this.
     GEMMETHOD_(void, SetActiveCameraNode)(XSceneGraphNode *pNode) final
@@ -166,3 +166,4 @@ public: // XModel methods
 };
 
 }
+

--- a/src/CanvasCore/UIElement.h
+++ b/src/CanvasCore/UIElement.h
@@ -1,7 +1,7 @@
 //================================================================================================
 // UIElement - UI graph node implementation
 //
-// CUIGraphNodeImpl: XUIGraphNode implementation — tree structure and screen-space position
+// CUIGraphNodeImpl: XUIGraphNode implementation - tree structure and screen-space position
 //================================================================================================
 
 #pragma once
@@ -73,3 +73,4 @@ private:
 };
 
 } // namespace Canvas
+

--- a/src/CanvasCore/UIGraph.cpp
+++ b/src/CanvasCore/UIGraph.cpp
@@ -43,7 +43,7 @@ Gem::Result CUIGraph::RemoveElement(XUIElement* pElement)
     if (!pElement)
         return Gem::Result::BadPointer;
 
-    // Unbind from node — vertex allocation stays with the element
+    // Unbind from node - vertex allocation stays with the element
     XUIGraphNode* pNode = pElement->GetAttachedNode();
     if (pNode)
     {
@@ -130,3 +130,4 @@ Gem::Result CUIGraph::SubmitRenderables(XGfxRenderQueue* pRenderQueue)
 }
 
 } // namespace Canvas
+

--- a/src/CanvasFbx/CanvasFbx.cpp
+++ b/src/CanvasFbx/CanvasFbx.cpp
@@ -940,7 +940,7 @@ void ImportAnimationClips(
     _In_ const std::unordered_map<const ufbx_node*, int32_t>& nodeMap,
     _Inout_ ImportedScene* pScene)
 {
-    // Pass 1 — group stacks by action name and create one ImportedAnimationClip per action.
+    // Pass 1 - group stacks by action name and create one ImportedAnimationClip per action.
     std::unordered_map<std::string, size_t> clipIndexByAction;
 
     AddDiag(pScene, DiagLevel::Info,
@@ -963,7 +963,7 @@ void ImportAnimationClips(
         }
     }
 
-    // Pass 2 — bake each stack and append its tracks to the matching clip.
+    // Pass 2 - bake each stack and append its tracks to the matching clip.
     for (size_t si = 0; si < pLoaded->anim_stacks.count; ++si)
     {
         const ufbx_anim_stack* pStack = pLoaded->anim_stacks.data[si];
@@ -1330,14 +1330,14 @@ HRESULT ImportScene(
 
     (void)options;
     *pScene = {};
-    pScene->Diagnostics.push_back({ DiagLevel::Error, "CanvasFbx built without ufbx — import unavailable" });
+    pScene->Diagnostics.push_back({ DiagLevel::Error, "CanvasFbx built without ufbx - import unavailable" });
     return E_NOTIMPL;
 }
 
 #endif
 
 //================================================================================================
-// BuildModel — convert an ImportedScene into a fully populated XModel
+// BuildModel - convert an ImportedScene into a fully populated XModel
 //================================================================================================
 
 Gem::Result BuildModel(
@@ -1478,7 +1478,7 @@ Gem::Result BuildModel(
                 group.pMaterial = materials[static_cast<size_t>(part.MaterialIndex)].Get();
             }
 
-            // Bone weight streams — convert uint8 indices to uint32 for GPU upload
+            // Bone weight streams - convert uint8 indices to uint32 for GPU upload
             allBoneIndices.emplace_back();
             allBoneWeights.emplace_back();
             if (srcMesh.Skin.HasSkin && part.SkinVertices.size() == vertexCount)
@@ -1683,7 +1683,7 @@ Gem::Result BuildModel(
         }
     }
 
-    // Register skin bindings — now that all nodes exist, resolve bone node ptrs and
+    // Register skin bindings - now that all nodes exist, resolve bone node ptrs and
     // register each skinned mesh's skin descriptor with the model so Instantiate()
     // can wire up cloned bone nodes at runtime.
     for (size_t meshIndex = 0; meshIndex < scene.Meshes.size(); ++meshIndex)
@@ -1727,7 +1727,7 @@ Gem::Result BuildModel(
         // so the rest global matrix is the bind matrix.
         //
         // InvBind[i] = G_mesh_canvas * inverse(G_bone_canvas_bindpose)
-        // → at bind pose: InvBind[i] * G_bone_canvas = G_mesh_canvas ✓
+        // -> at bind pose: InvBind[i] * G_bone_canvas = G_mesh_canvas ✓
         //
         // (Using the FBX cluster geometry_to_bone directly was tried and broke the static
         // pose: it is authored in a frame that does not match Canvas node-world space.)
@@ -1806,3 +1806,4 @@ Gem::Result BuildModel(
 
 } // namespace Fbx
 } // namespace Canvas
+

--- a/src/CanvasFbx/Inc/CanvasFbx.h
+++ b/src/CanvasFbx/Inc/CanvasFbx.h
@@ -1,5 +1,5 @@
 //================================================================================================
-// CanvasFbx — Scene importer interface
+// CanvasFbx - Scene importer interface
 //
 // Defines the data contracts returned by the importer so that consumers (e.g.
 // CanvasModelViewer) can create Canvas scene-graph objects without knowing
@@ -128,7 +128,7 @@ struct ImportedMeshPart
 //------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------
 // Skinning binding for one mesh: bone list + inverse bind-pose matrices.
-// BoneNodeIndices[i] → ImportedScene::Nodes[i] (the scene node that is the bone).
+// BoneNodeIndices[i] -> ImportedScene::Nodes[i] (the scene node that is the bone).
 // InvBindPoses[i]   transforms a vertex from mesh/geometry space into bone i's local space
 //                   at the time the skin was bound.
 // When HasSkin == false the vectors are empty and SkinVertices in each mesh part is empty.
@@ -211,15 +211,15 @@ struct ImportedNode
     Math::FloatVector4      Scale           = { 1.0f, 1.0f, 1.0f, 0.0f };
 
     // Payload binding (-1 = none)
-    int32_t                 MeshIndex       = -1;       // → ImportedScene::Meshes[i]
-    int32_t                 LightIndex      = -1;       // → ImportedScene::Lights[i]
-    int32_t                 CameraIndex     = -1;       // → ImportedScene::Cameras[i]
+    int32_t                 MeshIndex       = -1;       // -> ImportedScene::Meshes[i]
+    int32_t                 LightIndex      = -1;       // -> ImportedScene::Lights[i]
+    int32_t                 CameraIndex     = -1;       // -> ImportedScene::Cameras[i]
 };
 #pragma warning(pop)
 
 //------------------------------------------------------------------------------------------------
 // One TRS keyframe, sampled from FBX FCurves at an authored key time.
-// Rotation is always stored as a quaternion (ufbx converts Euler→quat internally).
+// Rotation is always stored as a quaternion (ufbx converts Euler->quat internally).
 //------------------------------------------------------------------------------------------------
 #pragma warning(push)
 #pragma warning(disable: 4324)
@@ -239,7 +239,7 @@ struct ImportedAnimationKeyframe
 //------------------------------------------------------------------------------------------------
 struct ImportedAnimationTrack
 {
-    int32_t                                 NodeIndex;   // → ImportedScene::Nodes
+    int32_t                                 NodeIndex;   // -> ImportedScene::Nodes
     std::vector<ImportedAnimationKeyframe>  Keyframes;   // sorted ascending by Time
 };
 
@@ -300,7 +300,7 @@ CANVASFBX_API HRESULT ImportScene(
 );
 
 //================================================================================================
-// BuildModel — convert an ImportedScene into a fully populated XModel
+// BuildModel - convert an ImportedScene into a fully populated XModel
 //
 // Creates an XModel containing GPU mesh data, materials, textures, lights,
 // cameras, and the full node hierarchy from the imported scene.  The caller
@@ -335,8 +335,8 @@ using TextureLoadFn = std::function<bool(
 //------------------------------------------------------------------------------------------------
 struct BuildModelOptions
 {
-    TextureLoadFn       TextureLoader;              // optional; null → textures are not loaded
-    const char         *pModelName      = nullptr;  // optional; name given to the XModel (nullptr → "ImportedModel")
+    TextureLoadFn       TextureLoader;              // optional; null -> textures are not loaded
+    const char         *pModelName      = nullptr;  // optional; name given to the XModel (nullptr -> "ImportedModel")
     Canvas::XLogger    *pLogger         = nullptr;  // optional; receives warnings for skipped data
 };
 
@@ -350,3 +350,4 @@ CANVASFBX_API Gem::Result BuildModel(
 
 } // namespace Fbx
 } // namespace Canvas
+

--- a/src/CanvasGfx12/D3D12ResourceUtils/D3D12ResourceUtils.h
+++ b/src/CanvasGfx12/D3D12ResourceUtils/D3D12ResourceUtils.h
@@ -77,7 +77,7 @@ struct SubresourceLayout
     }
 
     // Set layout for a subresource, or 0xFFFFFFFF for all subresources.
-    // Handles uniform→per-subresource expansion transparently.
+    // Handles uniform->per-subresource expansion transparently.
     // numSubresources is required when setting an individual subresource (for expansion).
     void SetLayout(UINT Subresource, D3D12_BARRIER_LAYOUT Layout, UINT numSubresources = 0)
     {
@@ -191,3 +191,4 @@ public:
         return m_CurrentLayout.GetLayout(Subresource);
     }
 };
+

--- a/src/CanvasGfx12/Lib/CanvasGfx12.h
+++ b/src/CanvasGfx12/Lib/CanvasGfx12.h
@@ -37,7 +37,7 @@ inline Gem::Result ResultFromHRESULT(HRESULT hr)
 }
 
 //================================================================================================
-// D3D12 debug naming — UTF-8 via SetPrivateData(WKPDID_D3DDebugObjectName)
+// D3D12 debug naming - UTF-8 via SetPrivateData(WKPDID_D3DDebugObjectName)
 //================================================================================================
 
 inline void SetD3D12DebugName(ID3D12Object* pObject, const char* name)

--- a/src/CanvasGfx12/Lib/CopyQueue.cpp
+++ b/src/CanvasGfx12/Lib/CopyQueue.cpp
@@ -34,7 +34,7 @@ void CCopyQueue::Initialize(CDevice12* pDevice)
         0, D3D12_COMMAND_LIST_TYPE_COPY, D3D12_COMMAND_LIST_FLAG_NONE, IID_PPV_ARGS(&m_pCommandList))));
     SetD3D12DebugName(m_pCommandList, "CopyQueue_CommandList");
 
-    // 1 MB initial — same as the render queue's ring; grows on demand.
+    // 1 MB initial - same as the render queue's ring; grows on demand.
     m_UploadRing.Initialize(pDevice, 1 * 1024 * 1024);
 
     m_TimelineId = pDevice->GetResourceManager().RegisterTimeline(m_pFence);
@@ -233,3 +233,4 @@ std::optional<FenceToken> CCopyQueue::FlushIfPending()
 
     return token;
 }
+

--- a/src/CanvasGfx12/Lib/Device12.cpp
+++ b/src/CanvasGfx12/Lib/Device12.cpp
@@ -64,7 +64,7 @@ CDevice12::CDevice12(Canvas::XCanvas* pCanvas, PCSTR name) :
 CDevice12::~CDevice12()
 {
 #if defined(_DEBUG)
-    // Unregister the debug callback first — the spec guarantees this will not
+    // Unregister the debug callback first - the spec guarantees this will not
     // return until any outstanding callbacks have completed, so it is safe to
     // release the cached logger immediately afterwards.
     if (m_pInfoQueue1 && m_debugCallbackCookie != 0)
@@ -77,7 +77,7 @@ CDevice12::~CDevice12()
 #endif
 
     // Drain the copy queue and unregister its timeline before tearing down the
-    // resource manager — the copy queue defers releases through the manager's
+    // resource manager - the copy queue defers releases through the manager's
     // per-timeline queues which Shutdown() will then drain.
     m_CopyQueue.Shutdown();
 
@@ -136,7 +136,7 @@ Gem::Result CDevice12::Initialize()
 
 #if defined(_DEBUG)
         // Register a debug layer message callback so D3D12 validation messages
-        // are routed through the Canvas logger. This is best-effort — older
+        // are routed through the Canvas logger. This is best-effort - older
         // runtimes that lack ID3D12InfoQueue1 will simply skip registration.
         CComPtr<ID3D12InfoQueue1> pInfoQueue1;
         if (SUCCEEDED(m_pD3DDevice->QueryInterface(IID_PPV_ARGS(&pInfoQueue1))))
@@ -810,7 +810,7 @@ GEMMETHODIMP CDevice12::AllocateStructuredBuffer(uint32_t elementCount, uint32_t
         // Try to reuse a pooled buffer.
         if (!m_ResourceManager.AcquireBuffer(dataSize, inOut))
         {
-            // Pool miss — allocate a new buffer.  Use power-of-2 capacity for
+            // Pool miss - allocate a new buffer.  Use power-of-2 capacity for
             // poolable sizes so the buffer fits a bucket exactly when retired.
             uint64_t capacity = dataSize;
             if (CResourceManager::IsPoolableSize(dataSize))
@@ -1025,3 +1025,4 @@ GEMMETHODIMP_(void) CDevice12::SetDebugMessageSeverity(Canvas::GfxDebugSeverity 
     (void)maxSeverity;
 #endif
 }
+

--- a/src/CanvasGfx12/Lib/Device12.h
+++ b/src/CanvasGfx12/Lib/Device12.h
@@ -104,16 +104,16 @@ public:
 
     // Flush any pending upload work on the device's copy queue and return the
     // FenceToken consumers must Wait() on before reading the destinations.
-    // Returns nullopt when no upload work is pending — the fast path on every
+    // Returns nullopt when no upload work is pending - the fast path on every
     // frame after the first.
     std::optional<FenceToken> EnsureUploadsRetired() { return m_CopyQueue.FlushIfPending(); }
 
-    // Vertex buffer suballocation (XGfxDevice interface — alloc + upload)
+    // Vertex buffer suballocation (XGfxDevice interface - alloc + upload)
     GEMMETHOD(AllocateStructuredBuffer)(uint32_t elementCount, uint32_t elementStride, const void* pInitialData, Canvas::XGfxRenderQueue* pRQ, Canvas::GfxResourceAllocation& inOut) final;
 
     GEMMETHOD(FlushUploads)() final;
 
-    // Texture upload (XGfxDevice interface — copy queue staging)
+    // Texture upload (XGfxDevice interface - copy queue staging)
     GEMMETHOD(UploadTextureRegion)(
         Canvas::XGfxSurface *pDstSurface,
         uint32_t subresourceIndex,
@@ -206,3 +206,4 @@ private:
     Canvas::CGlyphCache m_GlyphCache;
     Gem::TGemPtr<Canvas::XGfxSurface> m_pGlyphAtlasSurface;
 };
+

--- a/src/CanvasGfx12/Lib/GpuTask.cpp
+++ b/src/CanvasGfx12/Lib/GpuTask.cpp
@@ -290,7 +290,7 @@ const TaskBarriers& CGpuTaskGraph::PrepareTask(CGpuTask& taskData)
             auto& assumed = m_ExpectedInitialLayouts[pD3DResource];
             if (assumed.m_UniformLayout == D3D12_BARRIER_LAYOUT_UNDEFINED && assumed.m_AllSame)
             {
-                // First time seeing this resource — initialize from required layout
+                // First time seeing this resource - initialize from required layout
                 assumed = SubresourceLayout(texUsage.RequiredLayout, texUsage.pSurface->m_NumSubresources);
             }
             else if (texUsage.Subresources != 0xFFFFFFFF)
@@ -502,7 +502,7 @@ void CGpuTaskGraph::Dispatch()
     if (m_pWorkCL)
         m_pWorkCL->Close();
 
-    // Compute fixup barriers FIRST — before ComputeFinalLayouts overwrites committed state.
+    // Compute fixup barriers FIRST - before ComputeFinalLayouts overwrites committed state.
     // The fixup CL bridges the gap between actual committed layout (on CSurface12) and the
     // assumed initial layout that the work CL was recorded against.
     std::vector<D3D12_TEXTURE_BARRIER> d3dBarriers;
@@ -534,7 +534,7 @@ void CGpuTaskGraph::Dispatch()
 
         if (committed.m_AllSame && assumedLayouts.m_AllSame)
         {
-            // Both uniform — at most one barrier for all subresources
+            // Both uniform - at most one barrier for all subresources
             if (committed.m_UniformLayout != assumedLayouts.m_UniformLayout)
             {
                 D3D12_TEXTURE_BARRIER tb = {};
@@ -552,7 +552,7 @@ void CGpuTaskGraph::Dispatch()
         }
         else
         {
-            // At least one side is per-subresource — compare each subresource
+            // At least one side is per-subresource - compare each subresource
             UINT numSub = pSurface->m_NumSubresources;
             for (UINT sub = 0; sub < numSub; ++sub)
             {
@@ -641,7 +641,7 @@ void CGpuTaskGraph::ComputeFinalLayouts()
                 // Per-subresource usage: update only the targeted subresource
                 if (it == finals.end())
                 {
-                    // First time seeing this resource — start from committed state
+                    // First time seeing this resource - start from committed state
                     finals[pD3DResource] = { tex.pSurface, tex.pSurface->m_CurrentLayout };
                     it = finals.find(pD3DResource);
                 }
@@ -683,9 +683,9 @@ void CGpuTaskGraph::Reset(UINT64 fenceValue, UINT64 completedFenceValue)
     {
         if (!m_Dispatched)
         {
-            // Work CL was never dispatched — logic error in the caller's frame lifecycle.
+            // Work CL was never dispatched - logic error in the caller's frame lifecycle.
             m_pWorkCL->Close();
-            assert(false && "CGpuTaskGraph::Reset called without Dispatch — work CL was still open");
+            assert(false && "CGpuTaskGraph::Reset called without Dispatch - work CL was still open");
         }
         // Reset allocator + CL, then close. CL opened lazily before first InsertTask.
         m_pWorkAllocator->Reset();
@@ -717,3 +717,4 @@ void CGpuTaskGraph::ReleaseMemory()
 }
 
 } // namespace Canvas
+

--- a/src/CanvasGfx12/Lib/GpuTask.cpp
+++ b/src/CanvasGfx12/Lib/GpuTask.cpp
@@ -664,6 +664,13 @@ void CGpuTaskGraph::ComputeFinalLayouts()
 
 void CGpuTaskGraph::Reset(UINT64 fenceValue, UINT64 completedFenceValue)
 {
+    // Release each active task's recording function so any objects it captured are
+    // freed at the frame boundary. The task deque is grow-only, so without this a
+    // lambda (and anything it captured) would survive until its slot is reused by a
+    // later CreateTask or until the graph is destroyed.
+    for (uint32_t i = 0; i < m_TaskCount; ++i)
+        m_Tasks[i].RecordFunc = nullptr;
+
     m_TaskCount = 0;
     m_Surfaces.clear();
     m_ExpectedInitialLayouts.clear();

--- a/src/CanvasGfx12/Lib/GpuTask.h
+++ b/src/CanvasGfx12/Lib/GpuTask.h
@@ -166,8 +166,6 @@ struct CGpuTask
     // IMPORTANT: Capture only raw pointers and plain-old-data (GPU addresses, offsets, counts).
     // Do NOT capture ref-counting smart pointers (TGemPtr, GfxResourceAllocation, etc.).
     // The lambda is invoked inline by InsertTask - the caller's stack keeps objects alive.
-    // Captured TGemPtrs create hidden refs that survive in the task deque after Reset(),
-    // causing resource leaks.
     //
     // May be null for transition-only tasks (e.g. PresentTransition).
     std::function<void(ID3D12GraphicsCommandList*)> RecordFunc;

--- a/src/CanvasGfx12/Lib/GpuTask.h
+++ b/src/CanvasGfx12/Lib/GpuTask.h
@@ -7,7 +7,7 @@
 // resource usage transitions.
 //
 // Key properties:
-//   - Tasks are purely declarative — they describe resource usage, not commands
+//   - Tasks are purely declarative - they describe resource usage, not commands
 //   - Tasks CAN be recorded into separate command lists, provided the caller executes
 //     them in task creation order within the same ECL call
 //   - Dependencies must reference tasks already created in the same graph
@@ -18,7 +18,7 @@
 //   CGpuTaskGraph graph;
 //   graph.SetInitialLayout(pShadowMap, committedLayout);
 //
-//   // Shadow pass — writes shadow map
+//   // Shadow pass - writes shadow map
 //   auto& shadowPass = graph.CreateTask("ShadowMap");
 //   graph.DeclareTextureUsage(shadowPass, pShadowMap,
 //       D3D12_BARRIER_LAYOUT_DEPTH_STENCIL_WRITE,
@@ -28,7 +28,7 @@
 //   EmitBarriers(pCL, barriers);
 //   RecordShadowPass(pCL);
 //
-//   // Main pass — reads shadow map, depends on shadow pass
+//   // Main pass - reads shadow map, depends on shadow pass
 //   auto& mainPass = graph.CreateTask("MainPass");
 //   graph.AddDependency(mainPass, shadowPass);
 //   graph.DeclareTextureUsage(mainPass, pShadowMap,
@@ -39,7 +39,7 @@
 //   EmitBarriers(pCL, barriers2);
 //   RecordMainPass(pCL);
 //
-//   // Finalize — update committed state
+//   // Finalize - update committed state
 //   graph.ComputeFinalLayouts();
 //   UpdateCommittedState(graph.GetFinalLayouts());
 //   graph.Reset();
@@ -88,7 +88,7 @@ struct GpuTextureUsage
 
     bool IsRead() const
     {
-        // ACCESS_COMMON (0) is a wildcard — treat as read for barrier resolution
+        // ACCESS_COMMON (0) is a wildcard - treat as read for barrier resolution
         if (Access == D3D12_BARRIER_ACCESS_COMMON)
             return true;
         return (Access & (D3D12_BARRIER_ACCESS_SHADER_RESOURCE |
@@ -119,7 +119,7 @@ struct GpuBufferUsage
 
     bool IsRead() const
     {
-        // ACCESS_COMMON (0) is a wildcard — treat as read for barrier resolution
+        // ACCESS_COMMON (0) is a wildcard - treat as read for barrier resolution
         if (Access == D3D12_BARRIER_ACCESS_COMMON)
             return true;
         return (Access & (D3D12_BARRIER_ACCESS_SHADER_RESOURCE |
@@ -131,7 +131,7 @@ struct GpuBufferUsage
 };
 
 //------------------------------------------------------------------------------------------------
-// Inherited resource state entry — tracks the last known sync/access/layout for a
+// Inherited resource state entry - tracks the last known sync/access/layout for a
 // specific subresource through a task's dependency chain. Keyed by (pResource, Subresource).
 // Subresource 0xFFFFFFFF means "all subresources not otherwise specified" (uniform default).
 // Table invariant: entries are kept sorted by (pResource, Subresource) ascending.
@@ -148,7 +148,7 @@ struct ResourceStateEntry
 };
 
 //------------------------------------------------------------------------------------------------
-// A single GPU task — a discrete GPU operation with declared resource usage and dependencies
+// A single GPU task - a discrete GPU operation with declared resource usage and dependencies
 //
 // Each task has a recording function that records GPU commands into the graph's work CL.
 // The graph resolves barriers and invokes the recording function atomically at insertion time.
@@ -160,19 +160,19 @@ struct CGpuTask
     std::vector<GpuTextureUsage> TextureUsages;
     std::vector<GpuBufferUsage> BufferUsages;
 
-    // Recording function — invoked synchronously by InsertTask after barriers are emitted.
+    // Recording function - invoked synchronously by InsertTask after barriers are emitted.
     // Receives the graph's work CL for command recording.
     //
     // IMPORTANT: Capture only raw pointers and plain-old-data (GPU addresses, offsets, counts).
     // Do NOT capture ref-counting smart pointers (TGemPtr, GfxResourceAllocation, etc.).
-    // The lambda is invoked inline by InsertTask — the caller's stack keeps objects alive.
+    // The lambda is invoked inline by InsertTask - the caller's stack keeps objects alive.
     // Captured TGemPtrs create hidden refs that survive in the task deque after Reset(),
     // causing resource leaks.
     //
     // May be null for transition-only tasks (e.g. PresentTransition).
     std::function<void(ID3D12GraphicsCommandList*)> RecordFunc;
 
-    // Inherited resource state table — populated by PrepareTask/InsertTask().
+    // Inherited resource state table - populated by PrepareTask/InsertTask().
     std::vector<ResourceStateEntry> ResourceStates;
 };
 
@@ -225,12 +225,12 @@ struct TaskBarriers
 // At dispatch time, fixup barriers bridge committed device state to assumed initial layouts.
 //
 // Lifecycle:
-//   1. Init(device, workAllocator, fixupAllocator) — creates owned CLs
+//   1. Init(device, workAllocator, fixupAllocator) - creates owned CLs
 //   2. For each operation:
 //      a. CreateTask() + AddDependency() + DeclareTextureUsage/DeclareBufferUsage()
 //      b. Set task.RecordFunc (optional for transition-only tasks)
-//      c. InsertTask() — resolves barriers, emits, invokes recording function
-//   3. Dispatch(committedLayouts) — closes work CL, fixup barriers, closes fixup CL
+//      c. InsertTask() - resolves barriers, emits, invokes recording function
+//   3. Dispatch(committedLayouts) - closes work CL, fixup barriers, closes fixup CL
 //   4. Caller submits [GetFixupCommandList(), GetWorkCommandList()] via ECL
 //   5. Caller updates committed state from GetFinalLayouts()
 //   6. Reset(workAlloc, fixupAlloc) for next frame
@@ -359,23 +359,23 @@ private:
     CComPtr<ID3D12GraphicsCommandList> m_pFixupCL;
     CComPtr<ID3D12GraphicsCommandList7> m_pFixupCL7;
 
-    // Command queue for ECL submission (not owned — provided at Init)
+    // Command queue for ECL submission (not owned - provided at Init)
     ID3D12CommandQueue* m_pCommandQueue = nullptr;
 
-    // Allocator pool (not owned — provided at Init, used at Reset/Dispatch)
+    // Allocator pool (not owned - provided at Init, used at Reset/Dispatch)
     CCommandAllocatorPool* m_pAllocatorPool = nullptr;
 
     // Current allocators (pulled from pools)
     CComPtr<ID3D12CommandAllocator> m_pWorkAllocator;
     CComPtr<ID3D12CommandAllocator> m_pFixupAllocator;
 
-    // Task pool — grow-only deque (references remain valid across push_back).
+    // Task pool - grow-only deque (references remain valid across push_back).
     // Reused across frames via m_TaskCount.
     std::deque<CGpuTask> m_Tasks;
     uint32_t m_TaskCount = 0;
 
     // Surfaces used by this graph (for initial/final layout tracking)
-    // Maps ID3D12Resource* → CSurface12* for committed layout access.
+    // Maps ID3D12Resource* -> CSurface12* for committed layout access.
     std::unordered_map<ID3D12Resource*, CSurface12*> m_Surfaces;
 
     // Initial assumed layouts (recorded by first-use semantics for fixup barrier computation).
@@ -433,7 +433,7 @@ private:
 };
 
 //------------------------------------------------------------------------------------------------
-// Predefined usage helpers — correct sync/access/layout for common patterns.
+// Predefined usage helpers - correct sync/access/layout for common patterns.
 // Prefer DIRECT_QUEUE-specific layouts for optimal performance on direct queues.
 //------------------------------------------------------------------------------------------------
 
@@ -493,3 +493,4 @@ inline GpuBufferUsage BufferUsageIndirectArgument(CBuffer12* p) {
 }
 
 } // namespace Canvas
+

--- a/src/CanvasGfx12/Lib/Material12.h
+++ b/src/CanvasGfx12/Lib/Material12.h
@@ -2,7 +2,7 @@
 // Material12 - XGfxMaterial implementation for the D3D12 backend.
 //
 // Phase 3 scope: pure CPU-side property bag (textures + factors). The
-// RenderQueue does not yet read these into GPU descriptor tables — that
+// RenderQueue does not yet read these into GPU descriptor tables - that
 // plumbing is paired with the HLSL changes in Phase 4.
 //================================================================================================
 
@@ -133,3 +133,4 @@ private:
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
+

--- a/src/CanvasGfx12/Lib/RenderQueue12.cpp
+++ b/src/CanvasGfx12/Lib/RenderQueue12.cpp
@@ -130,19 +130,19 @@ CRenderQueue12::CRenderQueue12(Canvas::XCanvas* pCanvas, CDevice12 *pDevice, PCS
     D3D12_DESCRIPTOR_HEAP_DESC DHDesc = {};
     DHDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
     DHDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
-    DHDesc.NumDescriptors = NumSamplerDescriptors; // BUGBUG: This needs to be a well-known constant
+    DHDesc.NumDescriptors = NumSamplerDescriptors;
     Gem::ThrowGemError(ResultFromHRESULT(pD3DDevice->CreateDescriptorHeap(&DHDesc, IID_PPV_ARGS(&pSamplerDH))));
 
     CComPtr<ID3D12DescriptorHeap> pRTVDH;
     DHDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
     DHDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-    DHDesc.NumDescriptors = NumRTVDescriptors; // BUGBUG: This needs to be a well-known constant
+    DHDesc.NumDescriptors = NumRTVDescriptors;
     Gem::ThrowGemError(ResultFromHRESULT(pD3DDevice->CreateDescriptorHeap(&DHDesc, IID_PPV_ARGS(&pRTVDH))));
 
     CComPtr<ID3D12DescriptorHeap> pDSVDH;
     DHDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
     DHDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-    DHDesc.NumDescriptors = NumDSVDescriptors; // BUGBUG: This needs to be a well-known constant
+    DHDesc.NumDescriptors = NumDSVDescriptors;
     Gem::ThrowGemError(ResultFromHRESULT(pD3DDevice->CreateDescriptorHeap(&DHDesc, IID_PPV_ARGS(&pDSVDH))));
 
     CComPtr<ID3D12Fence> pFence;

--- a/src/CanvasGfx12/Lib/RenderQueue12.h
+++ b/src/CanvasGfx12/Lib/RenderQueue12.h
@@ -513,7 +513,7 @@ public:
     FenceToken MakeFenceToken() const { return FenceToken{ m_TimelineId, m_FenceValue }; }
 
     // Per-queue upload ring for host-write staging (UPLOAD heap).
-    // Private to this queue — only touched by this queue's thread — so its
+    // Private to this queue - only touched by this queue's thread - so its
     // fence-value markers are unambiguous bare UINT64s on this fence.
     CUploadRing m_UploadRing;
 
@@ -865,7 +865,7 @@ public:
     //
     // Tasks are GPU operations (render passes). Each has a recording function and declares
     // resource usage. InsertGpuTask resolves barriers, emits them into the work CL, and
-    // invokes the recording function — all atomically.
+    // invokes the recording function - all atomically.
     //
     // Usage:
     //   auto& task = CreateGpuTask("ShadowPass");
@@ -990,7 +990,7 @@ private:
         const Canvas::Math::AABB&         sceneBounds,
         UINT                              resolution);
     
-    // GPU Task Graphs — three graphs dispatched in order: scene → UI → present
+    // GPU Task Graphs - three graphs dispatched in order: scene -> UI -> present
     Canvas::CGpuTaskGraph m_GpuTaskGraph;        // Scene: geometry, composite
     Canvas::CGpuTaskGraph m_UIGpuTaskGraph;       // UI: text, HUD overlays
     Canvas::CGpuTaskGraph m_PresentGpuTaskGraph;  // Present: back buffer -> COMMON
@@ -1000,3 +1000,4 @@ private:
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
+

--- a/src/CanvasGfx12/Lib/ResourceAllocator.cpp
+++ b/src/CanvasGfx12/Lib/ResourceAllocator.cpp
@@ -6,6 +6,14 @@
 #include "ResourceAllocator.h"
 #include "Device12.h"
 
+namespace
+{
+    constexpr uint32_t kSmallTightUnitSize    = 256;
+    constexpr uint64_t kSmallTightHeapSize    = 512 * 1024;
+    constexpr uint64_t kSmallStandardHeapSize = 4 * 1024 * 1024;
+    constexpr uint64_t kLargeHeapSize         = 64 * 1024 * 1024;
+}
+
 //------------------------------------------------------------------------------------------------
 CResourceAllocator::~CResourceAllocator()
 {
@@ -50,20 +58,20 @@ void CResourceAllocator::Initialize(CDevice12* pDevice)
     // Small pool: 256B units / 512KB heaps when tight, else 64KB units / 4MB heaps
     if (m_TightAlignmentSupported)
     {
-        m_SmallPool.UnitSize        = 256;
-        m_SmallPool.HeapSizeInBytes = 512 * 1024;
+        m_SmallPool.UnitSize        = kSmallTightUnitSize;
+        m_SmallPool.HeapSizeInBytes = kSmallTightHeapSize;
     }
     else
     {
-        m_SmallPool.UnitSize        = 65536;
-        m_SmallPool.HeapSizeInBytes = 4 * 1024 * 1024;
+        m_SmallPool.UnitSize        = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
+        m_SmallPool.HeapSizeInBytes = kSmallStandardHeapSize;
     }
     m_SmallPool.HeapCapacityInUnits = static_cast<uint32_t>(
         m_SmallPool.HeapSizeInBytes / m_SmallPool.UnitSize);
 
     // Large pool: 64KB units / 64MB heaps
-    m_LargePool.UnitSize            = 65536;
-    m_LargePool.HeapSizeInBytes     = 64 * 1024 * 1024;
+    m_LargePool.UnitSize            = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
+    m_LargePool.HeapSizeInBytes     = kLargeHeapSize;
     m_LargePool.HeapCapacityInUnits = static_cast<uint32_t>(
         m_LargePool.HeapSizeInBytes / m_LargePool.UnitSize);
 

--- a/src/CanvasGfx12/Lib/ResourceAllocator.cpp
+++ b/src/CanvasGfx12/Lib/ResourceAllocator.cpp
@@ -92,7 +92,7 @@ Gem::Result CResourceAllocator::Alloc(
         uint64_t size      = allocInfo.SizeInBytes;
         uint64_t alignment = allocInfo.Alignment;
 
-        // Route: small pool → large pool → committed
+        // Route: small pool -> large pool -> committed
         if (size <= m_SmallPool.HeapSizeInBytes && alignment <= m_SmallPool.UnitSize)
         {
             out.AllocatorTier = 1;
@@ -226,7 +226,7 @@ void CResourceAllocator::Free(ResourceAllocation& allocation)
     allocation.pResource = nullptr;
 
     if (allocation.AllocationKey == 0)
-        return;     // Committed — heap freed implicitly with resource
+        return;     // Committed - heap freed implicitly with resource
 
     uint32_t blockStart, tier, sizeInUnits;
     ResourceAllocation::DecodeKey(allocation.AllocationKey, blockStart, tier, sizeInUnits);
@@ -307,3 +307,4 @@ void CResourceAllocator::SetResourceName(ID3D12Resource* pResource, const char* 
 {
     SetD3D12DebugName(pResource, name);
 }
+

--- a/src/CanvasGfx12/Lib/ResourceManager.cpp
+++ b/src/CanvasGfx12/Lib/ResourceManager.cpp
@@ -14,7 +14,7 @@ CResourceManager::~CResourceManager()
     // Safety net: if someone forgot to call Shutdown explicitly, clear here.
     // At this point the device is being destroyed, so every queue must already
     // have been uninitialized and drained.  Move out under the lock then drop
-    // the lock before destroying contents — CBuffer12 dtors call back into
+    // the lock before destroying contents - CBuffer12 dtors call back into
     // Free() which takes the same mutex.
     std::vector<std::unique_ptr<FenceTimeline>> timelines;
     std::vector<Canvas::GfxResourceAllocation> available[kNumBuckets];
@@ -39,7 +39,7 @@ void CResourceManager::Shutdown()
 {
     // Move state out while holding the lock, then drop the lock before the
     // destructors run.  CBuffer12::~CBuffer12 calls back into Free() which
-    // takes m_Mutex — destructing under the lock would deadlock.
+    // takes m_Mutex - destructing under the lock would deadlock.
     std::vector<std::unique_ptr<FenceTimeline>> timelines;
     std::vector<Canvas::GfxResourceAllocation> available[kNumBuckets];
     {
@@ -93,7 +93,7 @@ void CResourceManager::UnregisterTimeline(uint32_t timelineId)
         if (timelineId >= m_Timelines.size() || !m_Timelines[timelineId])
             return;
 
-        // Detach — caller guarantees the GPU is idle on this timeline.
+        // Detach - caller guarantees the GPU is idle on this timeline.
         dead = std::move(m_Timelines[timelineId]);
     }
     // dead's RetiredBuffers destruct here without the lock held (Free reentrancy safe).
@@ -119,7 +119,7 @@ void CResourceManager::Reclaim()
             const UINT64 completed = pTimeline->pFence->GetCompletedValue();
             pTimeline->CompletedValue = completed;
 
-            // Drain retired buffers — recycle into the available pool when there's room.
+            // Drain retired buffers - recycle into the available pool when there's room.
             while (!pTimeline->RetiredBuffers.empty()
                 && pTimeline->RetiredBuffers.front().Value <= completed)
             {
@@ -131,7 +131,7 @@ void CResourceManager::Reclaim()
                 pTimeline->RetiredBuffers.pop_front();
             }
 
-            // Drain deferred resources — move refs out, destruct outside the lock.
+            // Drain deferred resources - move refs out, destruct outside the lock.
             while (!pTimeline->DeferredResources.empty()
                 && pTimeline->DeferredResources.front().Value <= completed)
             {
@@ -201,13 +201,13 @@ void CResourceManager::RetireBuffer(Canvas::GfxResourceAllocation&& alloc, Fence
     uint32_t bucket = BucketIndex(capacity);
 
     if (bucket >= kNumBuckets)
-        return;  // Too large to pool — drop the ref; CBuffer12 destructor frees the allocator block.
+        return;  // Too large to pool - drop the ref; CBuffer12 destructor frees the allocator block.
 
     std::lock_guard<std::mutex> lock(m_Mutex);
 
     if (!token.IsValid() || token.TimelineId >= m_Timelines.size() || !m_Timelines[token.TimelineId])
     {
-        // No valid timeline (or timeline already torn down) — drop the buffer immediately.
+        // No valid timeline (or timeline already torn down) - drop the buffer immediately.
         // Caller is responsible for having drained the GPU before unregistering a timeline.
         return;
     }
@@ -226,7 +226,7 @@ void CResourceManager::DeferRelease(Gem::TGemPtr<Gem::XGeneric>&& pResource, Fen
 
     if (!token.IsValid() || token.TimelineId >= m_Timelines.size() || !m_Timelines[token.TimelineId])
     {
-        // No valid timeline — drop the ref immediately.  Caller is responsible
+        // No valid timeline - drop the ref immediately.  Caller is responsible
         // for draining before tearing down the timeline.
         return;
     }
@@ -242,7 +242,7 @@ Gem::Result CResourceManager::Alloc(
     ResourceAllocation& out,
     const char* name)
 {
-    // CResourceAllocator is unsynchronized (matches pre-migration behavior —
+    // CResourceAllocator is unsynchronized (matches pre-migration behavior -
     // callers must external-serialize Alloc/Free, typically on the device init
     // thread for persistent buffers).
     return m_Allocator.Alloc(desc, initialLayout, out, name);
@@ -253,3 +253,4 @@ void CResourceManager::Free(ResourceAllocation& allocation)
 {
     m_Allocator.Free(allocation);
 }
+

--- a/src/CanvasGfx12/Lib/ResourceManager.h
+++ b/src/CanvasGfx12/Lib/ResourceManager.h
@@ -63,7 +63,7 @@ public:
     CResourceManager() = default;
     ~CResourceManager();
 
-    // Non-copyable / non-movable — pinned by pointer from CDevice12.
+    // Non-copyable / non-movable - pinned by pointer from CDevice12.
     CResourceManager(const CResourceManager&) = delete;
     CResourceManager& operator=(const CResourceManager&) = delete;
 
@@ -95,7 +95,7 @@ public:
     //--------------------------------------------------------------------------------------------
     // Buffer pool (power-of-2 bucketed recycling for short-lived buffers).
     //
-    // Pooled allocations are buffers only — textures must use placed/committed allocation.
+    // Pooled allocations are buffers only - textures must use placed/committed allocation.
     //--------------------------------------------------------------------------------------------
 
     // Try to acquire a buffer with capacity >= sizeInBytes from the available pool.
@@ -147,8 +147,9 @@ private:
 
     std::vector<std::unique_ptr<FenceTimeline>> m_Timelines;  // indexed by TimelineId; entries may be null after Unregister
 
-    // Shared free pool — populated by Reclaim() when retired buffers complete.
+    // Shared free pool - populated by Reclaim() when retired buffers complete.
     std::vector<Canvas::GfxResourceAllocation> m_Available[kNumBuckets];
 
     std::mutex m_Mutex;
 };
+

--- a/src/CanvasGfx12/Lib/SwapChain12.cpp
+++ b/src/CanvasGfx12/Lib/SwapChain12.cpp
@@ -40,7 +40,7 @@ CSwapChain12::CSwapChain12(Canvas::XCanvas* pCanvas, HWND hWnd, bool Windowed, c
     swapChainDesc.Scaling = DXGI_SCALING_NONE;
     swapChainDesc.Width = 0;
     swapChainDesc.Height = 0;
-    swapChainDesc.Format = Format; // BUGBUG: Need to use GfxFormat
+    swapChainDesc.Format = Format;
     DXGI_SWAP_CHAIN_FULLSCREEN_DESC swapChainDescFS = {};
     swapChainDescFS.RefreshRate.Denominator = 1;
     swapChainDescFS.Windowed = Windowed;

--- a/src/CanvasGfx12/Lib/UploadRing.cpp
+++ b/src/CanvasGfx12/Lib/UploadRing.cpp
@@ -17,7 +17,7 @@ void CUploadRing::Initialize(CDevice12* pDevice, uint64_t initialSize)
     m_BytesAllocatedThisFrame = 0;
     m_LastCompletedFenceValue = 0;
     m_FrameMarkers.clear();
-    // Resource creation is lazy — EnsureResource() on first allocate.
+    // Resource creation is lazy - EnsureResource() on first allocate.
 }
 
 //------------------------------------------------------------------------------------------------
@@ -237,3 +237,4 @@ void CUploadRing::GrowTo(uint64_t newSize)
     m_FrameMarkers.clear();
     EnsureResource();
 }
+

--- a/src/CanvasGfx12/Lib/pch.h
+++ b/src/CanvasGfx12/Lib/pch.h
@@ -12,8 +12,6 @@
 #include <assert.h>
 
 
-// TODO: reference additional headers your program requires here
-
 // D3D
 #include <d3d12.h>
 #include <d3dx12.h>

--- a/src/CanvasGfx12/README.md
+++ b/src/CanvasGfx12/README.md
@@ -365,18 +365,18 @@ The shared heap is split into two regions managed by different allocators:
 
 | Region | Slots | Allocator | Lifetime |
 |---|---|---|---|
-| Persistent | `[0, 32768)` | `CDescriptorHeapAllocator` (free-list) | Per-resource — freed when the resource is destroyed |
-| Transient | `[32768, 65536)` | `CDescriptorRing` (per queue) | Per-frame — recycled once the GPU retires the frame |
+| Persistent | `[0, 32768)` | `CDescriptorHeapAllocator` (free-list) | Per-resource - freed when the resource is destroyed |
+| Transient | `[32768, 65536)` | `CDescriptorRing` (per queue) | Per-frame - recycled once the GPU retires the frame |
 
 The split is a tunable constant (`CDevice12::kNumPersistentSrvDescriptors`).
 
-**Persistent region** (`CDescriptorHeapAllocator`): size-segregated free lists (one per block size) plus a bump pointer, giving O(1) allocate/free with exact-fit reuse and no rounding waste. It hands out contiguous slot runs which live until explicitly freed, and is the home for descriptors that are created once and bound by GPU handle every draw — vertex-stream and material-texture SRVs that scale with the number of *live resources*, not draw calls.
+**Persistent region** (`CDescriptorHeapAllocator`): size-segregated free lists (one per block size) plus a bump pointer, giving O(1) allocate/free with exact-fit reuse and no rounding waste. It hands out contiguous slot runs which live until explicitly freed, and is the home for descriptors that are created once and bound by GPU handle every draw - vertex-stream and material-texture SRVs that scale with the number of *live resources*, not draw calls.
 
 **Transient region** (`CDescriptorRing`): a fence-protected ring for dynamic per-draw / per-frame descriptors. Slots are handed out as contiguous runs and advance through the region as a ring; a slot is not reused until the GPU work that referenced it has retired. The ring records a per-submission `{fenceValue, slotCount}` marker each frame (`MarkSubmissionEnd` in `Flush`) and releases completed submissions in `ProcessCompletedWork` (`Reclaim`), mirroring `CUploadRing`. The RTV and DSV heaps are each managed by their own `CDescriptorRing` over the whole per-queue heap (base slot 0); the SRV ring is given a base offset so it manages only the transient partition of the shared heap.
 
 When wrap-around would overwrite a slot still referenced by in-flight GPU work, the ring blocks on this queue's fence and reclaims completed submissions before reusing those slots, so a descriptor in flight can never be overwritten. Because a descriptor heap cannot be resized, a single frame that demands more transient slots than the partition holds cannot be satisfied and raises `OutOfMemory` rather than silently corrupting in-flight descriptors.
 
-The transient partition is owned by a **single render queue**, claimed via `CDevice12::AcquireTransientSrvRange` when the queue is created and released at teardown. A GPU has one rendering engine, so there is never a second render queue in practice; creating one on the same device fails fast (`Gem::Result::Unavailable`) rather than letting two rings hand out overlapping slots. Future compute queues (physics, work graphs) are expected to address resources through the persistent region or root descriptors, not this transient ring — sharing it could let a long-running compute submission stall rendering or create a render/compute fence lock inversion.
+The transient partition is owned by a **single render queue**, claimed via `CDevice12::AcquireTransientSrvRange` when the queue is created and released at teardown. A GPU has one rendering engine, so there is never a second render queue in practice; creating one on the same device fails fast (`Gem::Result::Unavailable`) rather than letting two rings hand out overlapping slots. Future compute queues (physics, work graphs) are expected to address resources through the persistent region or root descriptors, not this transient ring - sharing it could let a long-running compute submission stall rendering or create a render/compute fence lock inversion.
 
 > Migration in progress: per-resource residency (moving mesh vertex-stream and material-texture SRVs into the persistent region, and the per-object constant buffer to a root CBV) is being wired up. Until it lands, the geometry path still allocates its per-draw descriptor table from the transient ring, so the transient `OutOfMemory` ceiling above still bounds draws per frame. Persistent residency removes that ceiling because geometry stops consuming transient slots entirely.
 
@@ -397,8 +397,8 @@ All PSOs are created lazily on first use and cached for the lifetime of the rend
 - Slot 0: root CBV at b0 for per-frame constants (camera, light count, tile-grid dimensions, shadow atlas parameters, sky/background parameters).
 - Slot 1: descriptor table with SRV[8] at t0-t7: G-buffer (normals t0, diffuse t1, world position t2), optional skybox cube A (t3), optional skybox cube B (t4), optional stars cube (t5), optional moon billboard texture (t6), optional shadow atlas (t7). Unbound slots hold null SRVs; shader flags select active branches.
 - Slot 2: root SRV at t8 for `StructuredBuffer<HlslLight>` (the per-frame light table, sized to `PerFrame.LightCount`). Always bound; a one-element dummy is uploaded when no lights are visible so the slot is never null.
-- Slot 3: root SRV at t9 for `StructuredBuffer<uint>` — per-tile active light count (one uint per screen tile in row-major order).
-- Slot 4: root SRV at t10 for `StructuredBuffer<uint>` — packed per-tile light indices, `MAX_LIGHTS_PER_TILE` uints per tile (fixed stride). Indexed as `tile * MAX_LIGHTS_PER_TILE + i` for `i < TileLightCounts[tile]`. Both tile buffers are rebuilt by `BuildTileLightLists` each frame and uploaded into the ring; a one-element dummy is bound when the framebuffer has no tiles.
+- Slot 3: root SRV at t9 for `StructuredBuffer<uint>` - per-tile active light count (one uint per screen tile in row-major order).
+- Slot 4: root SRV at t10 for `StructuredBuffer<uint>` - packed per-tile light indices, `MAX_LIGHTS_PER_TILE` uints per tile (fixed stride). Indexed as `tile * MAX_LIGHTS_PER_TILE + i` for `i < TileLightCounts[tile]`. Both tile buffers are rebuilt by `BuildTileLightLists` each frame and uploaded into the ring; a one-element dummy is bound when the framebuffer has no tiles.
 - Static samplers: s0 = point/clamp (G-buffer texel fetch), s1 = linear/wrap (cubemap / stars sampling), s2 = linear/clamp (moon billboard), s3 = hardware PCF comparison sampler (GREATER_EQUAL reverse-Z, OPAQUE_WHITE border for shadow atlas).
 - Single render target at back-buffer format. No depth.
 
@@ -412,7 +412,7 @@ All PSOs are created lazily on first use and cached for the lifetime of the rend
 
 **Rect pass**:
 - Slot 0: root CBV at b0 for `HlslRectConstants` (screen size, element offset, rect size, fill color).
-- No vertex buffer — the vertex shader derives the quad from `SV_VertexID` and the constants.
+- No vertex buffer - the vertex shader derives the quad from `SV_VertexID` and the constants.
 - Alpha blending: `SRC_ALPHA / INV_SRC_ALPHA`.
 
 ### G-Buffer
@@ -444,7 +444,7 @@ Positions are bound as a root SRV at t0 by GPU virtual address. Remaining vertex
 
 ### Displaced Mesh Drawing (Tessellation Path)
 
-When a mesh instance has a material with a `GfxDisplacementDesc` attached (`XGfxMaterial::SetDisplacement`) and the mesh uses `PatchList4CP` topology, the render queue routes it through the displaced-mesh pipeline instead of the standard geometry PSO. This path uses a VS+HS+DS+PS quad-patch pipeline; the VS reads per-CP positions, UVs, and base normals from `StructuredBuffer<float4>`/`StructuredBuffer<float2>`/`StructuredBuffer<float4>` SRVs (t4 / t5 / t6) backed by the mesh's own vertex buffers — no IA bindings.
+When a mesh instance has a material with a `GfxDisplacementDesc` attached (`XGfxMaterial::SetDisplacement`) and the mesh uses `PatchList4CP` topology, the render queue routes it through the displaced-mesh pipeline instead of the standard geometry PSO. This path uses a VS+HS+DS+PS quad-patch pipeline; the VS reads per-CP positions, UVs, and base normals from `StructuredBuffer<float4>`/`StructuredBuffer<float2>`/`StructuredBuffer<float4>` SRVs (t4 / t5 / t6) backed by the mesh's own vertex buffers - no IA bindings.
 
 The displaced PSO root signature:
 - Slot 0: root CBV at b0 for per-frame constants.
@@ -456,27 +456,27 @@ The displaced PSO root signature:
 
 `HlslDisplacedConstants` is uploaded to the upload ring once per displaced draw. The displacement-map surface must be in `LAYOUT_SHADER_RESOURCE` before the draw (use `XGfxRenderQueue::FinalizeUploadAsShaderResource` after the initial texture upload).
 
-The per-draw world tile rect for shadow / cull aggregation is derived by the engine from the mesh's `XGfxMeshData::GetLocalBounds` plus the owning node's world translation — `GfxDisplacementDesc` carries no world or geometry fields. The CP positions in the mesh's vertex buffer are interpreted in mesh-local space; the per-tile CB's `World` matrix transforms positions (and rotates normals) to world space in the VS. CP UVs are pre-baked in D3D texture-UV space pointing into whatever sub-rect of the bound displacement map the mesh samples (meshes sharing a single displacement map carry per-mesh UV sub-rects this way). CP normals are the world-space directions along which the displacement offsets each CP; supply `(0, 0, 1, 0)` for a classic flat XY-plane heightfield.
+The per-draw world tile rect for shadow / cull aggregation is derived by the engine from the mesh's `XGfxMeshData::GetLocalBounds` plus the owning node's world translation - `GfxDisplacementDesc` carries no world or geometry fields. The CP positions in the mesh's vertex buffer are interpreted in mesh-local space; the per-tile CB's `World` matrix transforms positions (and rotates normals) to world space in the VS. CP UVs are pre-baked in D3D texture-UV space pointing into whatever sub-rect of the bound displacement map the mesh samples (meshes sharing a single displacement map carry per-mesh UV sub-rects this way). CP normals are the world-space directions along which the displacement offsets each CP; supply `(0, 0, 1, 0)` for a classic flat XY-plane heightfield.
 
-The HS computes per-edge tessellation factors using a distance × curvature LOD scheme: the distance term is proportional to `edgeWorldLength / distToMidpoint`, and the curvature term samples a coarse mip of the displacement map for the Laplacian second derivative. The DS bilerps the patch CPs' base positions, UVs, and normals at the output vertex, samples the displacement map for a world-unit scalar, and emits `basePos + sample * baseNormal` as the displaced world position. Per-vertex normals come from the patch's tangent basis (CP0→CP1 spans U, CP0→CP3 spans V) and the displacement-map gradient — the formulation collapses to the classic Z-only "heightfield" result when all CP normals point +Z and the patch sits in the XY plane. The PS samples the material atlases and writes the standard G-buffer layout, so the deferred lighting and composition passes are unchanged.
+The HS computes per-edge tessellation factors using a distance * curvature LOD scheme: the distance term is proportional to `edgeWorldLength / distToMidpoint`, and the curvature term samples a coarse mip of the displacement map for the Laplacian second derivative. The DS bilerps the patch CPs' base positions, UVs, and normals at the output vertex, samples the displacement map for a world-unit scalar, and emits `basePos + sample * baseNormal` as the displaced world position. Per-vertex normals come from the patch's tangent basis (CP0->CP1 spans U, CP0->CP3 spans V) and the displacement-map gradient - the formulation collapses to the classic Z-only "heightfield" result when all CP normals point +Z and the patch sits in the XY plane. The PS samples the material atlases and writes the standard G-buffer layout, so the deferred lighting and composition passes are unchanged.
 
 The displaced shadow PSO shares the VS and HS bytecode (ensuring shadow tessellation matches the scene LOD to prevent Peter Panning) and pairs them with `DSDisplacedShadow`, which writes only `SV_Position` from a `HlslShadowConstants` matrix with no pixel shader.
 
 ### Light Submission
 
-Lights are accumulated during scene graph traversal (gated by the LightBVH-driven visibility filter that `XScene::SubmitRenderables` installs via `XGfxRenderQueue::SetVisibleLights`). Each light's attenuation and cull distance are pre-computed on the CPU and packed into an `HlslLight` struct. The packed lights are uploaded each frame as a `StructuredBuffer<HlslLight>` (bound at root slot 2 / shader register `t8`), sized to the actual visible-light count — no fixed cap; the count scales with scene complexity the same way mesh-instance count does.
+Lights are accumulated during scene graph traversal (gated by the LightBVH-driven visibility filter that `XScene::SubmitRenderables` installs via `XGfxRenderQueue::SetVisibleLights`). Each light's attenuation and cull distance are pre-computed on the CPU and packed into an `HlslLight` struct. The packed lights are uploaded each frame as a `StructuredBuffer<HlslLight>` (bound at root slot 2 / shader register `t8`), sized to the actual visible-light count - no fixed cap; the count scales with scene complexity the same way mesh-instance count does.
 
-After SubmitLight aggregation and `ResolveShadowCasters`, `BuildTileLightLists` divides the framebuffer into `LIGHT_TILE_SIZE_PIXELS` × `LIGHT_TILE_SIZE_PIXELS` (32×32) screen tiles, constructs each tile's sub-frustum by remapping the camera view-projection to the tile's NDC sub-rect, and bins each spatial light's influence AABB against it. Always-on lights (ambient / directional) are pre-baked into every tile's list. The resulting per-tile counts and packed indices are uploaded as two `StructuredBuffer<uint>`s (root slots 3 / 4 at `t9` / `t10`) capped at `MAX_LIGHTS_PER_TILE` (32) per tile. The composite shader picks the owning tile from `SV_Position`, reads its count, and iterates only those light indices — turning the per-pixel cost from O(visible lights) into O(tile lights).
+After SubmitLight aggregation and `ResolveShadowCasters`, `BuildTileLightLists` divides the framebuffer into `LIGHT_TILE_SIZE_PIXELS` * `LIGHT_TILE_SIZE_PIXELS` (32x32) screen tiles, constructs each tile's sub-frustum by remapping the camera view-projection to the tile's NDC sub-rect, and bins each spatial light's influence AABB against it. Always-on lights (ambient / directional) are pre-baked into every tile's list. The resulting per-tile counts and packed indices are uploaded as two `StructuredBuffer<uint>`s (root slots 3 / 4 at `t9` / `t10`) capped at `MAX_LIGHTS_PER_TILE` (32) per tile. The composite shader picks the owning tile from `SV_Position`, reads its count, and iterates only those light indices - turning the per-pixel cost from O(visible lights) into O(tile lights).
 
 For directional lights with `LightFlags::CastsShadows`, `SubmitLight` additionally:
 
-1. Lazily allocates the shadow atlas (one `D32_Float` surface with both `DepthStencil` and `ShaderResource` usage, 4096 px per side, divided into a fixed 2×2 grid of 2048² tiles — up to four shadow casters per frame).
+1. Lazily allocates the shadow atlas (one `D32_Float` surface with both `DepthStencil` and `ShaderResource` usage, 4096 px per side, divided into a fixed 2x2 grid of 2048^2 tiles - up to four shadow casters per frame).
 2. Picks the next free atlas tile.
 3. Builds a texel-snapped, reverse-Z orthographic `world -> shadow-clip` matrix via `BuildDirectionalShadowMatrix`, centring the frustum on the active camera so receivers near the viewer fall into the high-resolution slab. Snapping the focus point to the atlas texel grid removes shimmer when the camera moves.
 4. Writes `ShadowAtlasRectUV`, `ShadowViewProj`, `ShadowFlags`, `ShadowDepthBias`, and `ShadowNormalOffsetTexels` into the light's `HlslLight` entry so the composite can sample without additional CPU plumbing.
 5. Queues a `PendingShadowCaster` record for `EndFrame` to drain.
 
-`EndFrame` then inserts one `ShadowPass_Displaced` `GpuTask` per (shadow caster × ready displaced tile), each declaring DSV-write usage on the atlas and SRV-read usage on the displacement map. The first task into a tile clears it with a scissor-restricted `ClearDepthStencilView(0.0f)` (reverse-Z far plane); subsequent tasks accumulate depth. The composite task downstream declares SRV usage on the atlas, so the `DEPTH_STENCIL_WRITE -> SHADER_RESOURCE` transition is emitted automatically by the task graph.
+`EndFrame` then inserts one `ShadowPass_Displaced` `GpuTask` per (shadow caster * ready displaced tile), each declaring DSV-write usage on the atlas and SRV-read usage on the displacement map. The first task into a tile clears it with a scissor-restricted `ClearDepthStencilView(0.0f)` (reverse-Z far plane); subsequent tasks accumulate depth. The composite task downstream declares SRV usage on the atlas, so the `DEPTH_STENCIL_WRITE -> SHADER_RESOURCE` transition is emitted automatically by the task graph.
 
 The shadow pass uses a dedicated depth-only PSO (`m_pDisplacedShadowPSO`) that reuses the existing `VSDisplaced` + `HSDisplaced` bytecode (so shadow tessellation tracks the camera and matches receiver LOD, preventing Peter Panning) and pairs them with `DSDisplacedShadow` (writes only `SV_Position` from a `b2` `HlslShadowConstants` matrix) with no pixel shader. Conservative caster-side `DepthBias` + `SlopeScaledDepthBias` are baked into the PSO; per-light caster bias values from `XLight::SetShadowDepthBias` are not honoured in v1 (only the receiver-side constant + normal-offset terms vary per light).
 
@@ -502,7 +502,7 @@ For pixels with no geometry, the composition shader falls back to the scene back
 
 - **Solid color fallback**: when no skybox is bound, the scene fills empty pixels with `SolidColor`. This is the default for newly created scenes (opaque black).
 - **Skybox cubemap**: when `pSkyboxCubemapA` is set, empty pixels are filled by sampling the cubemap in the world-space view direction, rotated by the inverse of `Orientation`. `Intensity` is a linear multiplier on the sample.
-- **Cubemap crossfade**: when both `pSkyboxCubemapA` and `pSkyboxCubemapB` are set, the result is `lerp(A, B, BlendFactor)`, enabling smooth transitions between authored sky presets (day → dusk → night) without per-frame CPU rebaking.
+- **Cubemap crossfade**: when both `pSkyboxCubemapA` and `pSkyboxCubemapB` are set, the result is `lerp(A, B, BlendFactor)`, enabling smooth transitions between authored sky presets (day -> dusk -> night) without per-frame CPU rebaking.
 - **Stars cubemap**: an optional RGBA cubemap (`pStarsCubemap`) is additively blended over the skybox, rotated independently by `StarsOrientation`. The lower hemisphere (view direction z < 0) is clipped so stars never appear below the ground. Apps drive sidereal motion by updating `StarsOrientation` each frame.
 - **Procedural sun disc**: rendered as a soft-edged disc in the composite shader, driven by `SunDirection` (the same unit vector the app uses for the sun's directional light, keeping a single source of truth for the sun's position). Enabled when `SunColor.a > 0`.
 - **Moon billboard**: an optional 2D texture (`pMoonTexture`) rendered as a billboard centred on `MoonDirection` within an angular disc of radius `MoonAngularRadius`. Both celestial bodies are naturally clipped below the horizon.
@@ -511,10 +511,10 @@ All background parameters are packed into `HlslPerFrameConstants` and uploaded o
 
 Shadow sampling lives in this same loop. The directional-light branch calls `SampleDirectionalShadow(light, P, N)` whenever `light.ShadowFlags & SHADOW_FLAG_HAS_SHADOW` is set. The helper:
 
-1. Pushes `P` along `N` by `ShadowNormalOffsetTexels` (in shadow-atlas texels, converted to world meters via `ShadowPcfTexelStep / tileUvWidth`) — combats grazing-angle acne that pure depth bias cannot remove.
+1. Pushes `P` along `N` by `ShadowNormalOffsetTexels` (in shadow-atlas texels, converted to world meters via `ShadowPcfTexelStep / tileUvWidth`) - combats grazing-angle acne that pure depth bias cannot remove.
 2. Projects the biased position through `light.ShadowViewProj` and remaps NDC.xy into atlas UV via `light.ShadowAtlasRectUV`.
 3. Adds `ShadowDepthBias` to the projected NDC z (receiver-side bias in reverse-Z space).
-4. Does a 2×2 hardware PCF lookup with a `SamplerComparisonState` (s3) configured `GREATER_EQUAL` (reverse-Z) and `D3D12_STATIC_BORDER_COLOR_OPAQUE_WHITE` so receivers outside the shadow frustum read as fully lit.
+4. Does a 2x2 hardware PCF lookup with a `SamplerComparisonState` (s3) configured `GREATER_EQUAL` (reverse-Z) and `D3D12_STATIC_BORDER_COLOR_OPAQUE_WHITE` so receivers outside the shadow frustum read as fully lit.
 
 The shadow atlas itself is bound at `t7`. When no shadow casters exist in a frame, a null SRV is bound there and every light's `ShadowFlags == 0`, so the PCF path is short-circuited.
 
@@ -703,7 +703,7 @@ Text rendering spans CanvasText, CanvasCore, and CanvasGfx12.
 
 **CanvasCore** provides `CTextLayout` for standalone text measurement and layout, and `CFont` which wraps the CanvasText `CTrueTypeFont` behind the `XFont` GEM interface.
 
-**CanvasGfx12** owns the glyph cache instance (`CGlyphCache` is a member of `CDevice12`) and the concrete UI element implementations. `CUITextElement12` generates a compact `HlslGlyphInstance` array (32 bytes per glyph) during `Update()`, which the render queue uploads to a structured buffer and the vertex shader expands to quads on the GPU. `CUIRectElement12` carries only size and color — geometry is derived entirely on the GPU from per-draw constants.
+**CanvasGfx12** owns the glyph cache instance (`CGlyphCache` is a member of `CDevice12`) and the concrete UI element implementations. `CUITextElement12` generates a compact `HlslGlyphInstance` array (32 bytes per glyph) during `Update()`, which the render queue uploads to a structured buffer and the vertex shader expands to quads on the GPU. `CUIRectElement12` carries only size and color - geometry is derived entirely on the GPU from per-draw constants.
 
 UI elements are created exclusively via `XGfxDevice::CreateTextElement` and `XGfxDevice::CreateRectElement`. Each element has a local 2D offset relative to its parent `XUIGraphNode`. The glyph atlas surface is lazily created by `CDevice12::GetGlyphAtlasSurface`. Pending glyph uploads are flushed during `EndFrame` before UI drawing begins.
 
@@ -719,7 +719,7 @@ During `Update`, the scene graph marks dirty transforms and propagates them down
 
 ### UI Graph
 
-`XUIGraph` is a 2D overlay graph with position inheritance and dirty-tracked update. Each `XUIGraphNode` can have one or more bound `XUIElement` instances — text elements, rect elements, or a mix. Each element carries a signed 2D offset relative to its parent node.
+`XUIGraph` is a 2D overlay graph with position inheritance and dirty-tracked update. Each `XUIGraphNode` can have one or more bound `XUIElement` instances - text elements, rect elements, or a mix. Each element carries a signed 2D offset relative to its parent node.
 
 Text elements (`CUITextElement12`) regenerate glyph instance buffers via `Update()` when dirty. The render queue allocates a structured buffer and uploads the glyph data at draw time. Rect elements (`CUIRectElement12`) carry size and color properties that are passed directly to the GPU as per-draw constants, requiring no buffer. Both element types are created via `XGfxDevice::CreateTextElement` and `XGfxDevice::CreateRectElement`.
 
@@ -802,3 +802,4 @@ CanvasGfx12 is under active development. The architecture is intended to support
 - Alternative graphics backends leveraging the same CanvasCore interfaces.
 
 None of these are committed plans. They represent directions the current design leaves room for.
+

--- a/src/CanvasPlatformWin32/README.md
+++ b/src/CanvasPlatformWin32/README.md
@@ -100,11 +100,11 @@ Changing the window size - whether via `SetWindowSize`, entering or leaving full
 | Query                       | Meaning                                                          |
 |-----------------------------|------------------------------------------------------------------|
 | `IsKeyDown(vk)`             | Key is currently held.                                           |
-| `IsKeyPressed(vk)`          | Key transitioned up → down since the previous `Update`.          |
-| `IsKeyReleased(vk)`         | Key transitioned down → up since the previous `Update`.          |
+| `IsKeyPressed(vk)`          | Key transitioned up -> down since the previous `Update`.         |
+| `IsKeyReleased(vk)`         | Key transitioned down -> up since the previous `Update`.         |
 | `IsMouseButtonDown(b)`      | Button is currently held (`b` is 0=L, 1=R, 2=M, 3=X1, 4=X2).     |
-| `IsMouseButtonPressed(b)`   | Button transitioned up → down since the previous `Update`.       |
-| `IsMouseButtonReleased(b)`  | Button transitioned down → up since the previous `Update`.       |
+| `IsMouseButtonPressed(b)`   | Button transitioned up -> down since the previous `Update`.      |
+| `IsMouseButtonReleased(b)`  | Button transitioned down -> up since the previous `Update`.      |
 | `GetMouseDelta(dx, dy)`     | Accumulated mouse motion in pixels since the previous `Update`.  |
 | `ConsumeScrollDelta()`      | Accumulated wheel ticks; reads and zeroes in one call.           |
 
@@ -228,3 +228,4 @@ if (Gem::Succeeded(LoadImageData(L"assets/diffuse.png",
 ```
 
 Consumers in this repository include [`CanvasModelViewer`](../CanvasModelViewer) and [`CanvasTerrainViewer`](../CanvasTerrainViewer).
+

--- a/src/CanvasPlatformWin32/RawInput.h
+++ b/src/CanvasPlatformWin32/RawInput.h
@@ -26,17 +26,17 @@ public:
     GEMMETHOD_(bool, IsMouseButtonReleased)(int button) final;
     GEMMETHOD_(int, ConsumeScrollDelta)() final;
 
-    // Internal — called by CImpl::WindowProc when WM_INPUT arrives.  hwnd is the
+    // Internal - called by CImpl::WindowProc when WM_INPUT arrives.  hwnd is the
     // window that owns the capture; needed as the recentre target under RDP.
     void ProcessRawInput(HWND hwnd, WPARAM wParam, LPARAM lParam);
 
-    // Internal — true when running inside a Remote Desktop session.  Sampled by
+    // Internal - true when running inside a Remote Desktop session.  Sampled by
     // Update() each frame so it tracks RDP connect/disconnect transitions.  When
     // true, CAppWindow::PumpMessages must NOT issue its own per-frame warp; the
     // recentre is driven from ProcessRawInput's safe-area logic instead.
     bool IsRemoteSession() const { return m_IsRemoteSession; }
 
-    // Internal — drop the persistent RDP baseline so the next absolute sample
+    // Internal - drop the persistent RDP baseline so the next absolute sample
     // re-seeds without emitting a spurious delta.  Called on capture changes.
     void ResetRemoteBaseline() { m_HasRawPos = false; }
 
@@ -64,3 +64,4 @@ private:
 };
 
 } // namespace Canvas::Platform::Win32
+

--- a/src/CanvasTerrainViewer/README.md
+++ b/src/CanvasTerrainViewer/README.md
@@ -320,7 +320,7 @@ Shipped (v1):
   `SetDirectionalShadowExtent(256 m, 1024 m)`, and the default bias
   triple (`SetShadowDepthBias(1e-4, 2.0, 0.5 texels)`).
 - The backend's shadow atlas is a single `D32_Float` surface (DSV +
-  SRV) divided into a fixed 2×2 grid of 2048² tiles -- room for up
+  SRV) divided into a fixed 2x2 grid of 2048^2 tiles -- room for up
   to four directional shadow casters per frame.  See
   `src/CanvasGfx12/README.md` "Light Submission" + "Composition" for
   the engine-side flow (atlas allocation, depth-only displaced PSO,
@@ -331,7 +331,7 @@ Shipped (v1):
   receiver-side constant bias + world-space normal-offset apply at
   composite sample time and are tunable per light via
   `XLight::SetShadowDepthBias`.
-- 2×2 hardware PCF via a `SamplerComparisonState` (s3) configured
+- 2x2 hardware PCF via a `SamplerComparisonState` (s3) configured
   `GREATER_EQUAL` (reverse-Z) and `OPAQUE_WHITE` border so receivers
   outside the shadow frustum read as fully lit rather than fully
   shadowed.
@@ -344,7 +344,7 @@ Future work:
   near dawn/dusk.
 - Skip the moon's shadow pass when its intensity gate is near zero,
   saving the cost during full daylight.  The frame cost is already
-  small (one 2048² depth fill of the terrain) but the saving is
+  small (one 2048^2 depth fill of the terrain) but the saving is
   free with one branch.
 - Per-light caster-side rasterizer bias (currently baked into the
   shared shadow PSO).  Either via `RSSetDepthBias` or one PSO
@@ -358,7 +358,7 @@ The terrain needs something behind it.
 
 The sky is integrated into `PSComposite` (not a separate sky shader) via the engine's `GfxBackgroundDesc` / `XScene::SetBackground` API. The viewer configures:
 
-- **Up to two cubemaps** (`pSkyboxCubemapA`, `pSkyboxCubemapB`) with a CPU-driven `BlendFactor` for crossfading between presets (e.g. day → dusk → night). Both cubemaps can be bound simultaneously; the composite lerps between them in the shader so transitions are smooth without per-frame texture authoring.
+- **Up to two cubemaps** (`pSkyboxCubemapA`, `pSkyboxCubemapB`) with a CPU-driven `BlendFactor` for crossfading between presets (e.g. day -> dusk -> night). Both cubemaps can be bound simultaneously; the composite lerps between them in the shader so transitions are smooth without per-frame texture authoring.
 - **Stars cubemap** (`pStarsCubemap`): additively blended over the sky, lower hemisphere clipped, driven by `StarsOrientation` for sidereal-motion animation.
 - **Procedural sun disc** (`SunDirection`, `SunColor`): a soft-edged disc rendered analytically in the composite shader, driven by the same unit vector used for the sun's directional light.
 - **Moon billboard** (`pMoonTexture`, `MoonDirection`): a 2D RGBA texture blended as a billboard at the angular position of the moon's directional light.
@@ -409,7 +409,7 @@ src/CanvasTerrainViewer/
     assets/
         default_heightmap.png      (sample fbm heightfield)
         scene.json                 (default scene configuration)
-        terrain_atlas_albedo.png   (2048×2048, four 1024×1024 slots: grass/rock/sand/snow)
+        terrain_atlas_albedo.png   (2048x2048, four 1024x1024 slots: grass/rock/sand/snow)
         terrain_atlas_orm.png      (matching ORM atlas)
         sky/                       (per-preset PNG face images and moon sprite)
 
@@ -486,7 +486,7 @@ Flags: `--seed`, `--tile-size 1024`, `--materials grass,rock,sand,snow`,
 ### `gen_skycube.py`
 
 Placeholder sky cubemaps. Per `--preset` (`day`, `night`, `dusk`):
-fills each face with a per-preset vertical gradient (zenith → horizon)
+fills each face with a per-preset vertical gradient (zenith -> horizon)
 and saves as 6 PNG faces. Pass `--moon` to also emit a soft-edged
 disc moon sprite (`moon.png`).
 
@@ -509,3 +509,4 @@ driven by `StarsOrientation` for sidereal-motion animation.
   policy - to be designed when the viewer can render multiple tiles.
 - Water surface (animated, with reflections) is captured as a future
   todo and will likely warrant its own README.
+

--- a/src/CanvasText/Font.cpp
+++ b/src/CanvasText/Font.cpp
@@ -658,7 +658,7 @@ bool CTrueTypeFont::ParseCompositeGlyph(uint32_t offset, uint32_t endOffset, Gly
         else
         {
             // Arguments are point indices (match points between parent/child);
-            // skip them — uncommon for basic Latin glyphs.
+            // skip them - uncommon for basic Latin glyphs.
             if (flags & ARG_1_AND_2_ARE_WORDS)
                 offset += 4;
             else
@@ -712,3 +712,4 @@ bool CTrueTypeFont::ParseCompositeGlyph(uint32_t offset, uint32_t endOffset, Gly
 }
 
 } // namespace Canvas
+

--- a/src/CanvasText/Font.h
+++ b/src/CanvasText/Font.h
@@ -11,7 +11,7 @@
 #include <unordered_map>
 #include <cstring>
 
-// Windows.h pollutes the global namespace with GetGlyphOutline → GetGlyphOutlineA/W.
+// Windows.h pollutes the global namespace with GetGlyphOutline -> GetGlyphOutlineA/W.
 // Undo it so our method name is not mangled.
 #ifdef GetGlyphOutline
 #undef GetGlyphOutline
@@ -239,3 +239,4 @@ inline float Canvas::CTrueTypeFont::NormalizeY(float fontUnits) const
 {
     return fontUnits / m_UnitsPerEm;
 }
+

--- a/src/CanvasText/SDFGenerator.cpp
+++ b/src/CanvasText/SDFGenerator.cpp
@@ -84,7 +84,7 @@ float CSDFGenerator::SignedDistanceToCurve(float px, float py,
 }
 
 //------------------------------------------------------------------------------------------------
-// Winding-number contribution from a straight line segment (x0,y0)→(x2,y2).
+// Winding-number contribution from a straight line segment (x0,y0)->(x2,y2).
 // Uses a half-open y-interval to avoid double-counting shared endpoints.
 //------------------------------------------------------------------------------------------------
 static int LineWindingCrossing(float px, float py,
@@ -101,7 +101,7 @@ static int LineWindingCrossing(float px, float py,
 }
 
 //------------------------------------------------------------------------------------------------
-// Winding-number contribution from a quadratic Bezier P0→Pctrl→P2.
+// Winding-number contribution from a quadratic Bezier P0->Pctrl->P2.
 // Solves B_y(t) = py analytically (at most 2 roots), accumulates sign(B_y'(t)) at each
 // crossing where px < B_x(t).  Uses t ∈ [0,1) to avoid double-counting shared vertices.
 //------------------------------------------------------------------------------------------------
@@ -121,7 +121,7 @@ static int QuadBezierWindingCrossing(float px, float py,
 
     if (std::abs(a) < 1e-8f)
     {
-        // Degenerate (linear) — single root
+        // Degenerate (linear) - single root
         if (std::abs(b) > 1e-8f)
         {
             float t = -c0 / b;
@@ -158,8 +158,8 @@ static int QuadBezierWindingCrossing(float px, float py,
 
 //------------------------------------------------------------------------------------------------
 // Compute winding number for point-in-polygon test.
-// Decodes TrueType quadratic outlines the same way ContourMinDist does — same on-curve /
-// off-curve logic, same implicit midpoint handling — so inside/outside is correct for
+// Decodes TrueType quadratic outlines the same way ContourMinDist does - same on-curve /
+// off-curve logic, same implicit midpoint handling - so inside/outside is correct for
 // every glyph, including those with curved strokes whose control points fall outside the ink.
 //------------------------------------------------------------------------------------------------
 
@@ -253,7 +253,7 @@ void CSDFGenerator::TransformPoint(float &x, float &y,
 }
 
 //------------------------------------------------------------------------------------------------
-// Analytic minimum distance from point (px, py) to a quadratic Bezier P0→Pctrl→P2.
+// Analytic minimum distance from point (px, py) to a quadratic Bezier P0->Pctrl->P2.
 //
 // Minimises |B(t) - P|² where B(t) = (1-t)²P0 + 2t(1-t)C + t²P2.
 // Setting the derivative to zero yields a cubic in t:
@@ -315,8 +315,8 @@ static float QuadBezierMinDist(float px, float py,
 //------------------------------------------------------------------------------------------------
 // Compute minimum distance from (px, py) to all edges in one contour.
 // Handles TrueType quadratic outlines:
-//   on → on          : straight line segment
-//   on → off → on    : quadratic Bezier
+//   on -> on          : straight line segment
+//   on -> off -> on    : quadratic Bezier
 //   consecutive offs  : implicit on-curve at their midpoint splits them into two Beziers
 //------------------------------------------------------------------------------------------------
 static float ContourMinDist(float px, float py, const Canvas::GlyphContour &contour)
@@ -353,7 +353,7 @@ static float ContourMinDist(float px, float py, const Canvas::GlyphContour &cont
 
             if (offCount == 0)
             {
-                // Straight segment — inline point-to-segment distance
+                // Straight segment - inline point-to-segment distance
                 float edgeDx = ex - sx, edgeDy = ey - sy;
                 float lenSq  = edgeDx*edgeDx + edgeDy*edgeDy;
                 float d;
@@ -432,7 +432,7 @@ bool CSDFGenerator::Generate(const GlyphOutline &outline, const CTrueTypeFont &f
     outBitmap.MaxX = font.NormalizeX(outline.XMax);
     outBitmap.MaxY = font.NormalizeY(outline.YMax);
     
-    // Glyph bounds in font units (same space as contour points — do NOT normalize here)
+    // Glyph bounds in font units (same space as contour points - do NOT normalize here)
     float fXMin = outline.XMin;
     float fYMax = outline.YMax;
     float fWidth  = outline.XMax - outline.XMin;
@@ -520,3 +520,4 @@ bool CSDFGenerator::Generate(const GlyphOutline &outline, const CTrueTypeFont &f
 }
 
 } // namespace Canvas
+

--- a/src/CanvasUnitTest/CanvasTextTest.cpp
+++ b/src/CanvasUnitTest/CanvasTextTest.cpp
@@ -79,7 +79,7 @@ TEST(TextUTF8DecodeTest, PlainASCII)
 
 TEST(TextUTF8DecodeTest, SpacePreserved)
 {
-    // Space (0x20) must survive decoding – it was the root cause of the blank-screen bug
+    // Space (0x20) must survive decoding - it was the root cause of the blank-screen bug
     std::vector<uint32_t> codepoints;
     EXPECT_TRUE(Succeeded(CTextLayout::DecodeUtf8("A B", codepoints)));
     EXPECT_EQ((size_t)3, codepoints.size());
@@ -116,7 +116,7 @@ TEST(TextUTF8DecodeTest, ThreeByteUTF8)
 
 TEST(TextUTF8DecodeTest, MixedASCIIAndMultibyte)
 {
-    // "Hi" + U+00E9 + "!" → 4 codepoints
+    // "Hi" + U+00E9 + "!" -> 4 codepoints
     const char utf8[] = { 'H', 'i', '\xC3', '\xA9', '!', '\0' };
     std::vector<uint32_t> codepoints;
     EXPECT_TRUE(Succeeded(CTextLayout::DecodeUtf8(utf8, codepoints)));
@@ -159,7 +159,7 @@ TEST(TextLayoutGlyphTest, NormalGlyphProduces6Vertices)
 
 TEST(TextLayoutGlyphTest, ZeroSizeGlyphProducesNoVertices)
 {
-    // BitmapWidth/Height == 0 → whitespace glyph, no quad should be emitted
+    // BitmapWidth/Height == 0 -> whitespace glyph, no quad should be emitted
     GlyphAtlasEntry entry = MakeEntry(0.0f, 0.0f);
     Math::FloatVector3 pos(0.0f, 0.0f, 0.0f);
     std::vector<TextVertex> verts;
@@ -282,7 +282,7 @@ TEST(TextRectanglePackerTest, OverflowReturnsFalse)
     CRectanglePacker packer(64, 64);
     CRectanglePacker::Rect r;
     EXPECT_TRUE(packer.Allocate(64, 64, r));
-    // Atlas is full — next allocation must fail
+    // Atlas is full - next allocation must fail
     EXPECT_FALSE(packer.Allocate(1, 1, r)) << "Allocation must fail when atlas is full";
 }
 
@@ -469,3 +469,4 @@ TEST(TextFontLoadTest, NormalizeXDividesUnitsPerEm)
 }
 
 } // namespace CanvasUnitTest
+

--- a/src/CanvasUnitTest/D3D12ResourceUtilsTest.cpp
+++ b/src/CanvasUnitTest/D3D12ResourceUtilsTest.cpp
@@ -92,7 +92,7 @@ TEST(D3D12ResourceUtilsTest, SubresourceLayout_TryCollapse_AllMatch)
     layout.ExpandToPerSubresource(4);
     EXPECT_FALSE(layout.m_AllSame);
 
-    // All subresources are COMMON — should collapse
+    // All subresources are COMMON - should collapse
     layout.TryCollapse();
     EXPECT_TRUE(layout.m_AllSame);
     EXPECT_TRUE(layout.m_UniformLayout == D3D12_BARRIER_LAYOUT_COMMON);
@@ -105,7 +105,7 @@ TEST(D3D12ResourceUtilsTest, SubresourceLayout_TryCollapse_Mismatch)
     layout.SetLayout(2, D3D12_BARRIER_LAYOUT_COPY_SOURCE, 4);
     EXPECT_FALSE(layout.m_AllSame);
 
-    // Subresources differ — should NOT collapse
+    // Subresources differ - should NOT collapse
     layout.TryCollapse();
     EXPECT_FALSE(layout.m_AllSame);
 }
@@ -130,7 +130,7 @@ TEST(D3D12ResourceUtilsTest, CTextureResource_InitLayout)
     HRESULT hr = D3D12CreateDevice(nullptr, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&pDevice));
     if (FAILED(hr))
     {
-        FAIL() << "No D3D12 device available — skipping hardware test";
+        FAIL() << "No D3D12 device available - skipping hardware test";
         return;
     }
 
@@ -161,3 +161,4 @@ TEST(D3D12ResourceUtilsTest, CTextureResource_InitLayout)
 }
 
 }
+

--- a/src/HLSL/HlslTypes.h
+++ b/src/HLSL/HlslTypes.h
@@ -1,4 +1,4 @@
-// HlslTypes.h — Shared between C++ and HLSL
+// HlslTypes.h - Shared between C++ and HLSL
 // Defines GPU-visible struct layouts and constants used by both shader and CPU code.
 #pragma once
 
@@ -199,7 +199,7 @@ struct ALIGN16 HlslDisplacedConstants
 #endif
 
 //------------------------------------------------------------------------------------------------
-// UI rendering types — shared between UI shaders and the graphics backend.
+// UI rendering types - shared between UI shaders and the graphics backend.
 // These live outside the HlslTypes namespace in HLSL but inside it in C++.
 //------------------------------------------------------------------------------------------------
 
@@ -256,3 +256,4 @@ static_assert(sizeof(HlslTypes::HlslLight) == 160, "HlslLight must be 160 bytes"
 #pragma warning(pop)
 #endif
 #endif
+

--- a/src/Inc/CanvasCore.h
+++ b/src/Inc/CanvasCore.h
@@ -222,7 +222,7 @@ XCanvasElement : public XNamedElement
 };
 
 //------------------------------------------------------------------------------------------------
-// Animation clip descriptors — ABI-safe POD; no STL types.
+// Animation clip descriptors - ABI-safe POD; no STL types.
 // All pointer fields must remain valid for the duration of the AddAnimationClip call.
 // CModel copies the data into its internal storage immediately.
 //------------------------------------------------------------------------------------------------
@@ -261,7 +261,7 @@ struct AnimationClipDesc
 static constexpr uint32_t InvalidClipIndex = UINT32_MAX;
 
 //------------------------------------------------------------------------------------------------
-// XAnimationController — a behavior that drives the transforms of a subtree of scene-graph
+// XAnimationController - a behavior that drives the transforms of a subtree of scene-graph
 // nodes from baked animation clips.  It is NOT a spatial element: it does not describe a
 // node's presence in space (no bounds, no attachment).  Instead a scene-graph node holds
 // a typed reference to one via XSceneGraphNode::SetAnimationController, and the node's
@@ -270,7 +270,7 @@ static constexpr uint32_t InvalidClipIndex = UINT32_MAX;
 //
 // One controller is created per XModel::Instantiate call and holds its own playback state
 // (time, active clip, blend), while the heavy keyframe data is shared on the XModel.  This
-// makes it cheap to have many instances of one model animating independently — e.g. a
+// makes it cheap to have many instances of one model animating independently - e.g. a
 // hillside of windmills or a hallway of zombies each at a different point in the same clip.
 //
 // Supports immediate clip switching and cross-fade blending.  ResetToBindPose restores the
@@ -619,7 +619,7 @@ XMeshInstance : public XSceneGraphElement
 };
 
 //------------------------------------------------------------------------------------------------
-// Result of model instantiation — returned by XModel::Instantiate()
+// Result of model instantiation - returned by XModel::Instantiate()
 struct ModelInstantiateResult
 {
     XSceneGraphNode      *pInstanceRoot        = nullptr;   // Synthetic root of the cloned subtree
@@ -636,12 +636,12 @@ XModel : public XCanvasElement
     // Device that owns this model's GPU resources
     GEMMETHOD_(XGfxDevice *, GetDevice)() = 0;
 
-    // Node hierarchy authoring — the model's internal root node.
+    // Node hierarchy authoring - the model's internal root node.
     // Build the model by creating nodes/elements via XCanvas and
     // adding them as children of this root.
     GEMMETHOD_(XSceneGraphNode *, GetRootNode)() = 0;
 
-    // Shared GPU resource library — resources added here are kept
+    // Shared GPU resource library - resources added here are kept
     // alive by the model and shared across all instances.
     GEMMETHOD_(uint32_t, GetMeshDataCount)() = 0;
     GEMMETHOD_(XGfxMeshData *, GetMeshData)(uint32_t index) = 0;
@@ -655,17 +655,17 @@ XModel : public XCanvasElement
     GEMMETHOD_(XGfxSurface *, GetTexture)(uint32_t index) = 0;
     GEMMETHOD(AddTexture)(XGfxSurface *pTexture) = 0;
 
-    // Active camera designation — set to the node in the model's
+    // Active camera designation - set to the node in the model's
     // hierarchy that carries the "default" camera.  Instantiate()
     // will map it to the cloned counterpart in the result.
     GEMMETHOD_(void, SetActiveCameraNode)(XSceneGraphNode *pNode) = 0;
     GEMMETHOD_(XSceneGraphNode *, GetActiveCameraNode)() = 0;
 
-    // Animation clip library — clips added here are shared across all instances.
+    // Animation clip library - clips added here are shared across all instances.
     // Each clip corresponds to one FBX AnimationStack (Blender Action).
     GEMMETHOD(AddAnimationClip)(const AnimationClipDesc* pClip) = 0;
 
-    // Skin binding registration — called by BuildModel for each skinned mesh.
+    // Skin binding registration - called by BuildModel for each skinned mesh.
     // pMeshNode is the model-template node carrying the skinned XMeshInstance.
     // ppBoneNodes / pInvBindPoses are BoneCount entries (copied internally).
     // On Instantiate(), bone nodes are resolved via the clone map and
@@ -891,5 +891,6 @@ public:
 }
 
 using FnCreateCanvasPlugin = Gem::Result (*)(Canvas::XCanvasPlugin**);
+
 
 

--- a/src/Inc/CanvasPlatformWin32.h
+++ b/src/Inc/CanvasPlatformWin32.h
@@ -66,7 +66,7 @@ struct AppWindowDesc
 };
 
 //------------------------------------------------------------------------------------------------
-// Raw input interface — keyboard, mouse delta, buttons, and scroll.
+// Raw input interface - keyboard, mouse delta, buttons, and scroll.
 // Neither interface holds a public reference to the other; the impl-level wiring
 // is established atomically by CreatePlatformWindow.
 //------------------------------------------------------------------------------------------------
@@ -82,7 +82,7 @@ struct XRawInput : public Gem::XGeneric
     // Clears all key and button state (e.g. after an unexpected focus loss).
     GEMMETHOD_(void, ClearState)() = 0;
 
-    // Keyboard — level query (held) and edge queries (valid for one frame after Update).
+    // Keyboard - level query (held) and edge queries (valid for one frame after Update).
     GEMMETHOD_(bool, IsKeyDown)(int vk) = 0;
     GEMMETHOD_(bool, IsKeyPressed)(int vk) = 0;   // went down this frame
     GEMMETHOD_(bool, IsKeyReleased)(int vk) = 0;  // went up this frame
@@ -95,12 +95,12 @@ struct XRawInput : public Gem::XGeneric
     GEMMETHOD_(bool, IsMouseButtonPressed)(int button) = 0;
     GEMMETHOD_(bool, IsMouseButtonReleased)(int button) = 0;
 
-    // Scroll wheel — returns accumulated ticks and zeroes the counter.
+    // Scroll wheel - returns accumulated ticks and zeroes the counter.
     GEMMETHOD_(int, ConsumeScrollDelta)() = 0;
 };
 
 //------------------------------------------------------------------------------------------------
-// Platform window — Win32 window lifecycle and exclusive (relative) mouse capture.
+// Platform window - Win32 window lifecycle and exclusive (relative) mouse capture.
 //------------------------------------------------------------------------------------------------
 struct XAppWindow : public Gem::XGeneric
 {
@@ -122,7 +122,7 @@ struct XAppWindow : public Gem::XGeneric
     // Exclusive (relative) mouse capture: hides the cursor, clips it to the client
     // rect, and registers raw mouse input.  Suitable for any interaction that wants
     // unbounded mouse motion (first-person cameras, orbit/pan cameras, modal drag,
-    // painting tools, etc.) — the mechanism itself is policy-free.
+    // painting tools, etc.) - the mechanism itself is policy-free.
     GEMMETHOD_(void, SetMouseCaptured)(bool captured) = 0;
     GEMMETHOD_(bool, IsMouseCaptured)() = 0;
 
@@ -141,13 +141,14 @@ struct XAppWindow : public Gem::XGeneric
 };
 
 //------------------------------------------------------------------------------------------------
-// CreatePlatformWindow — atomically creates a window and a bound raw-input object.
+// CreatePlatformWindow - atomically creates a window and a bound raw-input object.
 // The impl classes are privately wired; neither public interface exposes the other.
 // Both objects must remain alive simultaneously.
 //
-// CreateAppWindow — creates a window with no raw-input binding (e.g. UI-only tools).
+// CreateAppWindow - creates a window with no raw-input binding (e.g. UI-only tools).
 //------------------------------------------------------------------------------------------------
 Gem::Result CreatePlatformWindow(const AppWindowDesc& desc, XAppWindow** ppWindow, XRawInput** ppInput);
 Gem::Result CreateAppWindow(const AppWindowDesc& desc, XAppWindow** ppWindow);
 
 } // namespace Canvas::Platform::Win32
+


### PR DESCRIPTION
* Replaced Unicode arrows (`→`) with ASCII arrows (`->`) and em dashes (`—`) with hyphens (`-`) in comments and documentation.
* Ensured consistent use of ASCII symbols in key explanatory comments, such as function descriptions, data structure notes, and inline explanations. (All references above)
*  Defensively release GPU task functions in CanvasGfx12