### PR TITLE
Canvas element fixes

### DIFF
--- a/src/CanvasCore/CanvasCore.cpp
+++ b/src/CanvasCore/CanvasCore.cpp
@@ -222,12 +222,7 @@ GEMMETHODIMP CCanvas::CreateUIGraph(XGfxDevice* pDevice, XUIGraph** ppGraph)
     if (!pDevice || !ppGraph)
         return Gem::Result::BadPointer;
 
-    Gem::TGemPtr<CUIGraph> pGraph = new Gem::TGenericImpl<CUIGraph>();
-    pGraph->SetName("UIGraph");
-    pGraph->Register(this);
-    pGraph->SetDevice(pDevice);
-    *ppGraph = pGraph.Detach();
-    return Gem::Result::Success;
+    return CreateElement<CUIGraph>(ppGraph, "UIGraph", pDevice);
 }
 
 //------------------------------------------------------------------------------------------------

--- a/src/CanvasCore/UIGraph.cpp
+++ b/src/CanvasCore/UIGraph.cpp
@@ -13,9 +13,7 @@ GEMMETHODIMP_(XUIGraphNode*) CUIGraph::GetRootNode()
 {
     if (!m_pRootNode)
     {
-        m_pRootNode = new Gem::TGenericImpl<CUIGraphNodeImpl>();
-        m_pRootNode->SetName("UIRoot");
-        if (m_pCanvas) m_pRootNode->Register(m_pCanvas);
+        Gem::ThrowGemError(CreateAndRegister(&m_pRootNode, m_pCanvas, "UIRoot"));
     }
     return m_pRootNode.Get();
 }
@@ -28,10 +26,11 @@ Gem::Result CUIGraph::CreateNode(XUIGraphNode* pParent, XUIGraphNode** ppNode)
 
     XUIGraphNode* pParentNode = pParent ? pParent : GetRootNode();
 
-    Gem::TGemPtr<CUIGraphNodeImpl> pNode = new Gem::TGenericImpl<CUIGraphNodeImpl>();
-    pNode->SetName("UINode");
-    if (m_pCanvas) pNode->Register(m_pCanvas);
-    pParentNode->AddChild(pNode);
+    Gem::TGemPtr<CUIGraphNodeImpl> pNode;
+    Gem::Result result = CreateAndRegister(&pNode, m_pCanvas, "UINode");
+    if (Gem::Failed(result))
+        return result;
+    pParentNode->AddChild(pNode.Get());
 
     *ppNode = pNode.Detach();
     return Gem::Result::Success;

--- a/src/CanvasCore/UIGraph.h
+++ b/src/CanvasCore/UIGraph.h
@@ -21,12 +21,10 @@ public:
     END_GEM_INTERFACE_MAP()
 
     CUIGraph() = default;
-    CUIGraph(XCanvas* pCanvas) : TCanvasElement(pCanvas) {}
+    CUIGraph(XCanvas* pCanvas, XGfxDevice* pDevice) : TCanvasElement(pCanvas), m_pDevice(pDevice) {}
 
     void Initialize() {}
     void Uninitialize() {}
-
-    void SetDevice(XGfxDevice* pDevice) { m_pDevice = pDevice; }
 
     GEMMETHOD_(XGfxDevice*, GetDevice)() override { return m_pDevice.Get(); }
     GEMMETHOD(RemoveElement)(XUIElement* pElement) override;

--- a/src/CanvasGfx12/Lib/Device12.cpp
+++ b/src/CanvasGfx12/Lib/Device12.cpp
@@ -949,10 +949,8 @@ GEMMETHODIMP CDevice12::CreateTextElement(Canvas::XUITextElement **ppElement)
     if (!pCanvas)
         return Gem::Result::NotFound;
 
-    Gem::TGemPtr<CUITextElement12> pElement =
-        new Gem::TGenericImpl<CUITextElement12>(pCanvas, &m_GlyphCache);
-    pElement->SetName("UITextElement");
-    Gem::Result result = pCanvas->RegisterElement(pElement.Get());
+    Gem::TGemPtr<CUITextElement12> pElement;
+    Gem::Result result = CreateAndRegister<CUITextElement12>(&pElement, pCanvas, &m_GlyphCache, "UITextElement");
     if (Gem::Failed(result))
         return result;
     *ppElement = pElement.Detach();
@@ -969,10 +967,8 @@ GEMMETHODIMP CDevice12::CreateRectElement(Canvas::XUIRectElement **ppElement)
     if (!pCanvas)
         return Gem::Result::NotFound;
 
-    Gem::TGemPtr<CUIRectElement12> pElement =
-        new Gem::TGenericImpl<CUIRectElement12>(pCanvas);
-    pElement->SetName("UIRectElement");
-    Gem::Result result = pCanvas->RegisterElement(pElement.Get());
+    Gem::TGemPtr<CUIRectElement12> pElement;
+    Gem::Result result = CreateAndRegister<CUIRectElement12>(&pElement, pCanvas, "UIRectElement");
     if (Gem::Failed(result))
         return result;
     *ppElement = pElement.Detach();

--- a/src/CanvasGfx12/Lib/UIRectElement12.h
+++ b/src/CanvasGfx12/Lib/UIRectElement12.h
@@ -31,7 +31,11 @@ public:
     END_GEM_INTERFACE_MAP()
 
     CUIRectElement12() = default;
-    CUIRectElement12(Canvas::XCanvas* pCanvas) : TGfxElement(pCanvas) {}
+    CUIRectElement12(Canvas::XCanvas* pCanvas, PCSTR name = nullptr)
+        : TGfxElement(pCanvas)
+    {
+        if (name) SetName(name);
+    }
     void Initialize() {}
     void Uninitialize() {}
 

--- a/src/CanvasGfx12/Lib/UITextElement12.h
+++ b/src/CanvasGfx12/Lib/UITextElement12.h
@@ -53,10 +53,12 @@ public:
     END_GEM_INTERFACE_MAP()
 
     CUITextElement12() = default;
-    CUITextElement12(Canvas::XCanvas* pCanvas, Canvas::CGlyphCache* pGlyphCache)
+    CUITextElement12(Canvas::XCanvas* pCanvas, Canvas::CGlyphCache* pGlyphCache, PCSTR name = nullptr)
         : TGfxElement(pCanvas)
         , m_pGlyphCache(pGlyphCache)
-    {}
+    {
+        if (name) SetName(name);
+    }
 
     void Initialize() {}
     void Uninitialize() {}


### PR DESCRIPTION
Some XCanvasElement interface objects were being manually created using the `new` instead of the `CCanvas::CreateElement` helper - which automatically registers and names elements". This is cleaner and more maintainable.