### PR TITLE
CanvasGfx12: Fix fullscreen deadlock on Alt+Enter

### DIFF
--- a/src/CanvasGfx12/Lib/SwapChain12.cpp
+++ b/src/CanvasGfx12/Lib/SwapChain12.cpp
@@ -46,6 +46,11 @@ CSwapChain12::CSwapChain12(Canvas::XCanvas* pCanvas, HWND hWnd, bool Windowed, c
     swapChainDescFS.Windowed = Windowed;
     ThrowFailedHResult(pFactory->CreateSwapChainForHwnd(pRenderQueue->GetD3DCommandQueue(), hWnd, &swapChainDesc, &swapChainDescFS, nullptr, &pSwapChain1));
 
+    // Disable DXGI's built-in Alt+Enter handler: without this it calls SetFullscreenState(TRUE),
+    // entering exclusive fullscreen, where DXGI_PRESENT_ALLOW_TEARING and the frame-latency
+    // waitable object are both illegal -- causing Present errors and an infinite wait lockup.
+    ThrowFailedHResult(pFactory->MakeWindowAssociation(hWnd, DXGI_MWA_NO_ALT_ENTER));
+
     CComPtr<IDXGISwapChain4> pSwapChain4;
     ThrowFailedHResult(pSwapChain1->QueryInterface(&pSwapChain4));
 


### PR DESCRIPTION
This pull request addresses a potential issue with fullscreen handling in the swap chain creation process. The main change is the explicit disabling of DXGI's default Alt+Enter fullscreen toggle to prevent errors and lockups related to exclusive fullscreen mode.

Improvements to swap chain initialization and fullscreen handling:

* Disabled DXGI's built-in Alt+Enter handler by calling `MakeWindowAssociation` with the `DXGI_MWA_NO_ALT_ENTER` flag. This prevents the application from entering exclusive fullscreen mode, which is incompatible with `DXGI_PRESENT_ALLOW_TEARING` and the frame-latency waitable object, avoiding present errors and potential infinite wait lockups. (`src/CanvasGfx12/Lib/SwapChain12.cpp`)